### PR TITLE
scripts: use PORTABLE rocksdb default

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,7 +54,7 @@ rm -rf $TIDB_PATH/deps/tikv
 git clone --depth=1 https://github.com/pingcap/tikv.git $TIDB_PATH/deps/tikv
 cd $TIDB_PATH/deps/tikv
 
-ROCKSDB_SYS_STATIC=1 make
+ROCKSDB_SYS_STATIC=1 ROCSDB_SYS_PORTABLE=1 make
 
 cp -f ./bin/tikv-server $TIDB_PATH/bin
 cd $TIDB_PATH


### PR DESCRIPTION
seem that user will compile tikv in one platform like ubuntu and then copy to other, so PORTABLE is necessary. 

@shenli @queenypingcap @iamxy 