### PR TITLE
scripts: fix tikv static portable build hung

### DIFF
--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -40,9 +40,8 @@ function install_in_ubuntu {
     
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
-    ${SUDO} make install-shared 
     make static_lib
-    ${SUDO} make install-static
+    ${SUDO} make install
     # guarantee tikv can find rocksdb.
     ${SUDO} ldconfig
 }
@@ -58,9 +57,8 @@ function install_in_centos {
     
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
-    ${SUDO} make install-shared 
     make static_lib
-    ${SUDO} make install-static
+    ${SUDO} make install
     # guarantee tikv can find rocksdb.
     ${SUDO} ldconfig
 }
@@ -77,9 +75,8 @@ function install_in_macosx {
     
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
-    ${SUDO} make install-shared
     make static_lib
-    ${SUDO} make install-static
+    ${SUDO} make install
 }
 
 case "$OSTYPE" in 

--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -41,6 +41,8 @@ function install_in_ubuntu {
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
     ${SUDO} make install-shared 
+    make static_lib
+    ${SUDO} make install-static
     # guarantee tikv can find rocksdb.
     ${SUDO} ldconfig
 }
@@ -57,6 +59,8 @@ function install_in_centos {
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
     ${SUDO} make install-shared 
+    make static_lib
+    ${SUDO} make install-static
     # guarantee tikv can find rocksdb.
     ${SUDO} ldconfig
 }
@@ -74,6 +78,8 @@ function install_in_macosx {
     cd rocksdb-rocksdb-${ROCKSDB_VER} 
     make shared_lib 
     ${SUDO} make install-shared
+    make static_lib
+    ${SUDO} make install-static
 }
 
 case "$OSTYPE" in 


### PR DESCRIPTION
```
ROCKSDB_SYS_STATIC=1 ROCSDB_SYS_PORTABLE=1 cargo build --release --bin tikv-server -v
```

TiKV build hungs in librocksdb_sys, if we only install shared rocksdb.