### PR TITLE
*: update build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ TiDB is a distributed SQL database. Inspired by the design of Google F1, TiDB su
 ## Getting started
  - [Quick Start for TiDB](https://github.com/pingcap/tidb/blob/master/docs/QUICKSTART.md)
 
+## Building TiDB
+
+ - [Supported platform](dev-guide/requirements.md#supported-platforms)
+ - [Prerequisites](dev-guide/requirements.md#prerequisites)
+ - [For Deployment](dev-guide/deployment.md)
+ - [For Development](dev-guide/development.md)
 
 ## Operating TiDB clusters
  - [Deployment overview](op-guide/overview.md)
- - [Supported platform](dev-guide/requirements.md#supported-platforms)
  - [Configuration](op-guide/configuration.md)
  - [Setting up clusters](op-guide/clustering.md)
  - [Running the TiDB clusters inside containers](op-guide/docker.md)
  - [Getting the TiDB clusters status from the Placement Driver (PD)](https://cdn.rawgit.com/pingcap/docs/master/op-guide/pd-api-v1.html)
-
-## Developing with TiDB
- - [Build Requirements](dev-guide/requirements.md)
- - [Building TiDB](dev-guide/build.md)

--- a/dev-guide/deployment.md
+++ b/dev-guide/deployment.md
@@ -1,0 +1,13 @@
+# Build for deployment 
+
+## Overview
+
+If you want to build the TiDB project, deploy the binaries to other machines and run them, you can follow this guide.
+
+Before your begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
+
+## Building and installing TiDB components
+
+You can use the [build script](../scripts/build.sh) to build and install TiDB components in the `bin` directory.
+
+You can use the [update script](../scripts/update.sh) to update all the TiDB components to the latest version.

--- a/dev-guide/deployment.md
+++ b/dev-guide/deployment.md
@@ -4,7 +4,7 @@
 
 If you want to build the TiDB project, deploy the binaries to other machines and run them, you can follow this guide.
 
-Before your begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
+Before you begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
 
 ## Building and installing TiDB components
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -4,7 +4,7 @@
 
 If you want to develop the TiDB project, you can follow this guide.
 
-Before your begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
+Before you begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
 
 ## Install RocksDB
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -1,10 +1,10 @@
-# Build
+# Build For Development
 
 ## Overview
 
-You can follow this guide to build the TiDB project.
+If you want to develop the TiDB project, you can follow this guide.
 
-Before your begin, check the [supported platforms](../op-guide/build.md#supported-platforms) and [prerequisites](../op-guide/build.md#prerequisites) first.
+Before your begin, check the [supported platforms](./requirements.md#supported-platforms) and [prerequisites](./requirements.md#prerequisites) first.
 
 ## Install RocksDB
 

--- a/dev-guide/requirements.md
+++ b/dev-guide/requirements.md
@@ -19,8 +19,3 @@ The following table lists TiDB support for common architectures and operating sy
 The [check requirement script](../scripts/check_requirement.sh) can help you check prerequisites and 
 install the missing ones automatically.
 
-## Building and installing TiDB components
-
-You can use the [build script](../scripts/build.sh) to build and install TiDB components in the `bin` directory.
-
-You can use the [update script](../scripts/update.sh) to update all the TiDB components to the latest version.


### PR DESCRIPTION
Previous build instruction is not clear and has some link failed bug. 
I divide the build instruction into two parts: deployment and development.
+ For Deployment: we use static link RocksDB for TiKV and can deploy the binaries to other machines.
+ For Development: we use dynamic link RocksDB for TiKV and can only run tikv-server in local machine, this is convenient for developer because they don't need to re-compile RocksDB after we `cargo clean` the TiKV. 

@shenli @queenypingcap @c4pt0r 