### PR TITLE
Remove the reason about unsupported features

### DIFF
--- a/op-guide/mysql-compatibility.md
+++ b/op-guide/mysql-compatibility.md
@@ -4,7 +4,7 @@ TiDB supports the majority of the MySQL grammar, including cross-row transaction
 
 TiDB is compatible with most of the MySQL database management & administration tools such as `PHPMyAdmin`, `Navicat`, `MySQL Workbench`, and so on. It also supports the database backup tools, such as `mysqldump` and `mydumper/myloader`.
 
-However, in TiDB, there are some MySQL features that are not supported or are different because they cannot be implemented well in distributed scenario.
+However, in TiDB, the following MySQL features are not supported for the time being or are different:
 
 ## Unsupported features
 


### PR DESCRIPTION
The previous reason is: 
because they cannot be implemented well in distributed scenario.
This is not entirely true. We are planning to support some of these features in the future. Therefore, changing the statement.
@shenli @ngaut PTAL.