### PR TITLE
fix build_rocksdb.sh

### DIFF
--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -10,7 +10,7 @@ echo "building RocksDB in $DEPS_PATH"
 mkdir -p ${DEPS_PATH}
 cd $DEPS_PATH
 
-ROCKSDB_VER=5.1.2
+ROCKSDB_VER=5.2.1
 
 SUDO=
 if which sudo; then 

--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -10,7 +10,7 @@ echo "building RocksDB in $DEPS_PATH"
 mkdir -p ${DEPS_PATH}
 cd $DEPS_PATH
 
-ROCKSDB_VER=v5.1.2
+ROCKSDB_VER=5.1.2
 
 SUDO=
 if which sudo; then 
@@ -34,7 +34,7 @@ function install_in_ubuntu {
     if [ ! -d rocksdb-${ROCKSDB_VER} ]; then
         ${SUDO} apt-get update 
         ${SUDO} apt-get install -y --no-install-recommends zlib1g-dev libbz2-dev libsnappy-dev libgflags-dev liblz4-dev 
-        curl -L https://github.com/facebook/rocksdb/archive/${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
+        curl -L https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
         tar xf rocksdb.tar.gz 
     fi
     
@@ -50,7 +50,7 @@ function install_in_centos {
     if [ ! -d rocksdb-${ROCKSDB_VER} ]; then
         ${SUDO} yum install -y epel-release
         ${SUDO} yum install -y snappy-devel zlib-devel bzip2-devel lz4-devel
-        curl -L https://github.com/facebook/rocksdb/archive/${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
+        curl -L https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
         tar xf rocksdb.tar.gz 
     fi
     
@@ -78,7 +78,7 @@ function install_in_macosx {
                 $SUDO port install snappy || true
             fi
         fi
-        curl -L https://github.com/facebook/rocksdb/archive/${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
+        curl -L https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
         tar xf rocksdb.tar.gz 
     fi
     


### PR DESCRIPTION
`tar xf rocksdb.tar.gz` will create `rocksdb-5.1.2` directory not `rocksdb-v5.1.2`.

And, `cd rocksdb-v5.1.2` will show error: 
> ./build_rocksdb.sh: line 88: cd: rocksdb-v5.1.2: No such file or directory

Then this PR fix the issue