### PR TITLE
build_rocksdb.sh: check ldconfig 

### DIFF
--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -31,6 +31,7 @@ function get_linux_platform {
 
 
 function ldconfig_for_rocksdb {
+    ldconfig
     if [ $(${SUDO} ldconfig -p | grep librocksdb | wc -l) -eq 0 ]; then
         ${SUDO} echo "/usr/local/lib" >> /etc/ld.so.conf
         ${SUDO} ldconfig

--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -29,6 +29,14 @@ function get_linux_platform {
     fi 
 }
 
+
+function ldconfig_for_rocksdb {
+    if [ $(${SUDO} ldconfig -p | grep librocksdb | wc -l) -eq 0 ]; then
+        ${SUDO} echo "/usr/local/lib" >> /etc/ld.so.conf
+        ${SUDO} ldconfig
+    fi
+}
+
 function install_in_ubuntu {
     echo "building RocksDB in Ubuntu..."
     if [ ! -d rocksdb-${ROCKSDB_VER} ]; then
@@ -42,7 +50,7 @@ function install_in_ubuntu {
     make shared_lib 
     ${SUDO} make install-shared 
     # guarantee tikv can find rocksdb.
-    ${SUDO} ldconfig
+    ldconfig_for_rocksdb
 }
 
 function install_in_centos {
@@ -58,7 +66,7 @@ function install_in_centos {
     make shared_lib 
     ${SUDO} make install-shared 
     # guarantee tikv can find rocksdb.
-    ${SUDO} ldconfig
+    ldconfig_for_rocksdb
 }
 
 function install_in_macosx {
@@ -113,4 +121,5 @@ case "$OSTYPE" in
 esac
 
 cd ${TIDB_PATH}
+rm -rf deps
 echo "building RocksDB OK"

--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -31,7 +31,7 @@ function get_linux_platform {
 
 
 function ldconfig_for_rocksdb {
-    ldconfig
+    ${SUDO} ldconfig
     if [ $(${SUDO} ldconfig -p | grep librocksdb | wc -l) -eq 0 ]; then
         ${SUDO} echo "/usr/local/lib" >> /etc/ld.so.conf
         ${SUDO} ldconfig


### PR DESCRIPTION
1. Fix  error `./bin/tikv-server: error while loading shared libraries: librocksdb.so.5.2: cannot open shared object file: No such file or directory
`

     Actually,  rocksdb lib path is `/usr/local/lib`  ( it can be found in [rocksdb-readme](https://github.com/facebook/rocksdb/blob/master/INSTALL.md)  ) ,
     but  `/usr/local/lib`  is not default lib path  for command `ldconfig` . reference [ldconfig-manpage](http://man7.org/linux/man-pages/man8/ldconfig.8.html)

   So, we should check first , and then add `/usr/local/lib`  to `/etc/ld.so.conf` if necessary.
   

  2. Directory `deps` is temp directory ,  let's delete it

