### PR TITLE
update rocksdb version to the latest version

### DIFF
--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -10,7 +10,7 @@ echo "building RocksDB in $DEPS_PATH"
 mkdir -p ${DEPS_PATH}
 cd $DEPS_PATH
 
-ROCKSDB_VER=5.2.1
+ROCKSDB_VER=5.4.6
 
 SUDO=
 if which sudo; then 
@@ -19,8 +19,12 @@ fi
 
 function get_linux_platform {
     if [ -f /etc/redhat-release ]; then 
-        # For CentOS or redhat, we treat all as CentOS.
-        echo "CentOS"
+	    if [[ `cat /etc/redhat-release` == Fedora* ]]; then
+	        echo "Fedora"
+	    else 
+            # For CentOS or redhat, we treat all as CentOS.
+            echo "CentOS"
+	    fi
     elif [ -f /etc/lsb-release ]; then
         DIST=`cat /etc/lsb-release | grep '^DISTRIB_ID' | awk -F=  '{ print $2 }'`
         echo "$DIST"
@@ -50,6 +54,21 @@ function install_in_centos {
     if [ ! -d rocksdb-${ROCKSDB_VER} ]; then
         ${SUDO} yum install -y epel-release
         ${SUDO} yum install -y snappy-devel zlib-devel bzip2-devel lz4-devel
+        curl -L https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
+        tar xf rocksdb.tar.gz 
+    fi
+    
+    cd rocksdb-${ROCKSDB_VER} 
+    make shared_lib 
+    ${SUDO} make install-shared 
+    # guarantee tikv can find rocksdb.
+    ${SUDO} ldconfig
+}
+
+function install_in_fedora {
+    echo "building RocksDB in Fedora..."
+    if [ ! -d rocksdb-${ROCKSDB_VER} ]; then
+        ${SUDO} dnf install -y snappy-devel zlib-devel bzip2-devel lz4-devel
         curl -L https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VER}.tar.gz -o rocksdb.tar.gz 
         tar xf rocksdb.tar.gz 
     fi
@@ -96,6 +115,9 @@ case "$OSTYPE" in
             ;;
             CentOS)
                 install_in_centos
+            ;;
+            Fedora)
+                install_in_fedora
             ;;
             *)
                 echo "unsupported platform $dist, you may install RocksDB manually"

--- a/scripts/build_rocksdb.sh
+++ b/scripts/build_rocksdb.sh
@@ -19,12 +19,12 @@ fi
 
 function get_linux_platform {
     if [ -f /etc/redhat-release ]; then 
-	    if [[ `cat /etc/redhat-release` == Fedora* ]]; then
-	        echo "Fedora"
-	    else 
+        if [[ `cat /etc/redhat-release` == Fedora* ]]; then
+	    echo "Fedora"
+        else 
             # For CentOS or redhat, we treat all as CentOS.
             echo "CentOS"
-	    fi
+	fi
     elif [ -f /etc/lsb-release ]; then
         DIST=`cat /etc/lsb-release | grep '^DISTRIB_ID' | awk -F=  '{ print $2 }'`
         echo "$DIST"


### PR DESCRIPTION
Try to compile tikv with rocksdb 5.1 or 5.2 will cause compile error:
```
cargo build --release --features "default"
   Compiling cfg-if v0.1.0
   Compiling log v0.3.6
   Compiling strsim v0.6.0
   Compiling winapi-build v0.1.1
   Compiling unicode-normalization v0.1.2
   Compiling kernel32-sys v0.2.2
   Compiling httparse v1.1.2
   Compiling unicode-width v0.1.4
   Compiling futures v0.1.13
   Compiling bitflags v0.4.0
   Compiling threadpool v1.3.0
   Compiling vec_map v0.7.0
   Compiling fnv v1.0.5
   Compiling lazy_static v0.1.16
   Compiling kernel32-sys v0.1.4
   Compiling backtrace v0.2.3
   Compiling semver v0.1.20
   Compiling toml v0.2.1
   Compiling slab v0.3.0
   Compiling ws2_32-sys v0.2.1
   Compiling mime v0.2.2
   Compiling scoped-tls v0.1.0
   Compiling dbghelp-sys v0.2.0
   Compiling traitobject v0.0.1
   Compiling bitflags v0.8.2
   Compiling byteorder v1.0.0
   Compiling gcc v0.3.35
   Compiling num-traits v0.1.32
   Compiling hpack v0.3.0
   Compiling num-integer v0.1.32
   Compiling bytes v0.3.0
   Compiling libc v0.1.12
   Compiling tokio-timer v0.1.1
   Compiling winapi v0.2.8
   Compiling sys-info v0.4.1
   Compiling backtrace-sys v0.1.4
   Compiling pkg-config v0.3.8
   Compiling openssl v0.9.6
   Compiling lazycell v0.4.0
   Compiling slab v0.1.3
   Compiling flat_map v0.0.4
   Compiling rustc-demangle v0.1.2
   Compiling num-iter v0.1.32
   Compiling protobuf v1.2.1
   Compiling error-chain v0.7.2
   Compiling unicode-segmentation v1.1.0
   Compiling utf8-ranges v0.1.3
   Compiling metadeps v1.1.1
   Compiling crc v1.2.0
   Compiling void v1.0.2
   Compiling typeable v0.1.2
   Compiling quick-error v0.2.2
   Compiling nom v1.2.4
   Compiling ordermap v0.2.9
   Compiling bitflags v0.7.0
   Compiling libc v0.2.21
   Compiling iovec v0.1.0
   Compiling thread-id v2.0.0
   Compiling thread_local v0.2.7
   Compiling time v0.1.35
   Compiling term_size v0.3.0
   Compiling atty v0.2.2
   Compiling memchr v0.1.11
   Compiling bytes v0.4.1
   Compiling aho-corasick v0.5.3
   Compiling num_cpus v1.2.1
   Compiling tokio-io v0.1.1
   Compiling openssl-sys v0.9.6
   Compiling tikv v0.0.1 (file:///home/cholerae/rustcode/tikv)
   Compiling rustc-serialize v0.3.19
   Compiling librocksdb_sys v0.1.0 (https://github.com/pingcap/rust-rocksdb.git#328fa017)
error: failed to run custom build command for `librocksdb_sys v0.1.0 (https://github.com/pingcap/rust-rocksdb.git#328fa017)`
process didn't exit successfully: `/home/cholerae/rustcode/tikv/target/release/build/librocksdb_sys-01678a0dde3477ed/build-script-build` (exit code: 101)
--- stdout
TARGET = Some("x86_64-unknown-linux-gnu")
OPT_LEVEL = Some("3")
PROFILE = Some("release")
TARGET = Some("x86_64-unknown-linux-gnu")
debug=false opt-level=3
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CXX_x86_64-unknown-linux-gnu = None
CXX_x86_64_unknown_linux_gnu = None
HOST_CXX = None
CXX = None
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CXXFLAGS_x86_64-unknown-linux-gnu = None
CXXFLAGS_x86_64_unknown_linux_gnu = None
HOST_CXXFLAGS = None
CXXFLAGS = None
running: "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-m64" "-fPIC" "-std=c++11" "-fPIC" "-O2" "-o" "/home/cholerae/rustcode/tikv/target/release/build/librocksdb_sys-a40eeeb2edcbb581/out/crocksdb/c.o" "-c" "crocksdb/c.cc"
cargo:warning=crocksdb/c.cc: In function ‘void crocksdb_options_set_use_direct_io_for_flush_and_compaction(crocksdb_options_t*, unsigned char)’:
cargo:warning=crocksdb/c.cc:1780:12: error: ‘struct rocksdb::Options’ has no member named ‘use_direct_io_for_flush_and_compaction’
cargo:warning=   opt->rep.use_direct_io_for_flush_and_compaction = v;
cargo:warning=            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ExitStatus(ExitStatus(256))


command did not execute successfully, got: exit code: 1



--- stderr
thread 'main' panicked at 'explicit panic', /home/cholerae/.cargo/registry/src/github.com-1ecc6299db9ec823/gcc-0.3.35/src/lib.rs:897
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
Because this feature is released in rocksdb 5.4.0:

> Replace Options::use_direct_writes with Options::use_direct_io_for_flush_and_compaction. Read Direct IO wiki for details.
https://github.com/facebook/rocksdb/blob/master/HISTORY.md

By the way, let build_rocksdb.sh support fedora, which is also a widely used linux distribution.

@siddontang PTAL