### PR TITLE
Change the document structure

### DIFF
--- a/sql/README.md
+++ b/sql/README.md
@@ -1,15 +1,26 @@
 ---
-title: SQL Statement Syntax of TiDB
-category: compatibility
+title: TiDB User Guide
+category: user guide
 ---
 
-# SQL Statement Syntax of TiDB
 
-TiDB supports the SQL-92 standard and is compatible with MySQL grammar. Currently, TiDB supports the majority of frequently used MySQL syntax.
+# TiDB User Guide
+
+TiDB supports the SQL-92 standard and is compatible with MySQL. To help you easily get started with TiDB, TiDB user guide mainly inherits the MySQL document structure with some TiDB specific changes.
 
 ## Table of Contents
 
-+ [TiDB SQL Syntax Diagram](https://pingcap.github.io/sqlgram/)
++ TiDB Server Administration
+	- The TiDB Server
+	- The TiDB Data Directory
+	- The TiDB System Database
+	- [The Proprietary System Variables and Syntax in TiDB](tidb-specific.md)
+	- TiDB Server Logs
++ Security
+	- [The TiDB Access Privilege System](privilege.md)
+	- TiDB User Account Management
+	- Using Secure Connections
++ Optimization
 + Language Structure
     - Literal Values
     - Schema Object Names
@@ -17,22 +28,47 @@ TiDB supports the SQL-92 standard and is compatible with MySQL grammar. Currentl
     - User-Defined Variables
     - Expression Syntax
     - Comment Syntax
++ Globalization
+	- Character Set Support
+	- Character Set Configuration
+	- MySQL Server Time Zone Support
 + Data Types
-    - Numeric Types
-    - String Types
-    - Date and Time Type
-    - Others
+	- Numeric Types
+	- Date and Time Types
+	- String Types
+	- Extensions for Spatial Data
+	- The JSON Data Type
+	- Data Type Default Values
+	- Data Type Storage Requirements
+	- Choosing the Right Type for a Column
+	- Using Data Types from Other Database Engines
 + Functions and Operators
-    - Operators
-    - Built-in Functions
+	- Function and Operator Reference
+	- Type Conversion in Expression Evaluation
+	- Operators
+	- Control Flow Functions
+	- String Functions
+	- Numeric Functions and Operators
+	- Date and Time Functions
+	- Cast Functions and Operators
+	- Bit Functions and Operators
+	- Encryption and Compression Functions
+	- Information Functions
+	- JSON Functions
+	- Functions Used with Global Transaction IDs
+	- Aggregate (GROUP BY) Functions
+	- Miscellaneous Functions
+	- Precision Math
 + SQL Statement Syntax
-    - Data Definition Statements
-    - Data Manipulation Statements
-    - Transactional Statements
-    - Prepared SQL Statement Syntax
-    - Database Administration Statements
-    - Utility Statements
-+ [Privilege Management](privilege.md)
-+ [The Proprietary System Variables and Syntax in TiDB](tidb-specific.md)
-+ Others
-    - SQL Modes
+	- Data Definition Statements
+	- Data Manipulation Statements
+	- Transactions
+	- Replication Statements
+	- Prepared SQL Statement Syntax
+	- Compound-Statement Syntax
+	- Database Administration Statements
+	- Utility Statements
+	- [TiDB SQL Syntax Diagram](https://pingcap.github.io/sqlgram/)
++ Document Store
++ Connectors and APIs
++ Troubleshooting


### PR DESCRIPTION
Change the original SQL syntax doc to be the landing page of TiDB user guide.