### PR TITLE
Add RocksDB environment setting descprtions

### DIFF
--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -10,7 +10,7 @@ Before you begin, check the [supported platforms](./requirements.md#supported-pl
 
 You must follow [rust-rocksdb](https://github.com/pingcap/rust-rocksdb/blob/master/librocksdb_sys/build.sh#L127) to see which version TiKV needs. You can install the RocksDB shared library manually according to [INSTALL.md](https://github.com/facebook/rocksdb/blob/master/INSTALL.md).
 
-Once installed, please add the RocksDB include path to your `CPATH` environment variable and the RocksDB lib path to `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
+Once installed, please mkae sure that RocksDB include path is in your `CPATH` environment variable and the RocksDB lib path is in `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
 
 ## Build TiKV
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -9,6 +9,7 @@ Before you begin, check the [supported platforms](./requirements.md#supported-pl
 ## Install RocksDB
 
 You must follow [rust-rocksdb](https://github.com/pingcap/rust-rocksdb/blob/master/librocksdb_sys/build.sh#L127) to see which version TiKV needs. You can install the RocksDB shared library manually according to [INSTALL.md](https://github.com/facebook/rocksdb/blob/master/INSTALL.md).
+Once installed, please add the include path for RocksDB to your `CPATH` environment variable and the lib path to `LIBRARY_PATH`, `LD_LIBRARY_PATH`.
 
 ## Build TiKV
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -10,7 +10,7 @@ Before you begin, check the [supported platforms](./requirements.md#supported-pl
 
 You must follow [rust-rocksdb](https://github.com/pingcap/rust-rocksdb/blob/master/librocksdb_sys/build.sh#L127) to see which version TiKV needs. You can install the RocksDB shared library manually according to [INSTALL.md](https://github.com/facebook/rocksdb/blob/master/INSTALL.md).
 
-Once installed, please mkae sure that RocksDB include path is in your `CPATH` environment variable and the RocksDB lib path is in `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
+Once installed, please make sure that RocksDB include path is in your `CPATH` environment variable and the RocksDB lib path is in `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
 
 ## Build TiKV
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -10,7 +10,7 @@ Before you begin, check the [supported platforms](./requirements.md#supported-pl
 
 You must follow [rust-rocksdb](https://github.com/pingcap/rust-rocksdb/blob/master/librocksdb_sys/build.sh#L127) to see which version TiKV needs. You can install the RocksDB shared library manually according to [INSTALL.md](https://github.com/facebook/rocksdb/blob/master/INSTALL.md).
 
-Once installed, please make sure that RocksDB include path is in your `CPATH` environment variable and the RocksDB lib path is in `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
+After you install RocksDB, make sure that the RocksDB include path is in the `CPATH` environment variable and the RocksDB lib path is in the `LIBRARY_PATH` and `LD_LIBRARY_PATH` environment variables.  
 
 ## Build TiKV
 

--- a/dev-guide/development.md
+++ b/dev-guide/development.md
@@ -9,7 +9,8 @@ Before you begin, check the [supported platforms](./requirements.md#supported-pl
 ## Install RocksDB
 
 You must follow [rust-rocksdb](https://github.com/pingcap/rust-rocksdb/blob/master/librocksdb_sys/build.sh#L127) to see which version TiKV needs. You can install the RocksDB shared library manually according to [INSTALL.md](https://github.com/facebook/rocksdb/blob/master/INSTALL.md).
-Once installed, please add the include path for RocksDB to your `CPATH` environment variable and the lib path to `LIBRARY_PATH`, `LD_LIBRARY_PATH`.
+
+Once installed, please add the RocksDB include path to your `CPATH` environment variable and the RocksDB lib path to `LIBRARY_PATH`, `LD_LIBRARY_PATH` environment variables.
 
 ## Build TiKV
 


### PR DESCRIPTION
After install RocksDB, some environment variables should be modified in order to build TiKV.

To make command `make` for TiKV success, RocksDB include path should be added into `CPATH` and  RocksDB lib path should be added into `LIBRARY_PATH`.
To make command `make test` success, RocksDB lib path should be added into `LD_LIBRARY_PATH`.