### PR TITLE
Fix relative links in op-guide

### DIFF
--- a/op-guide/ansible-deployment.md
+++ b/op-guide/ansible-deployment.md
@@ -310,7 +310,7 @@ To deploy TiDB using a normal user account, take the following steps:
     ansible-playbook start.yml
     ```
 
-> **Note:** If you want to deploy TiDB using the root user account, see [Ansible Deployment Using the Root User Account](op-guide/root-ansible-deployment.md).
+> **Note:** If you want to deploy TiDB using the root user account, see [Ansible Deployment Using the Root User Account](root-ansible-deployment.md).
 
 ## Test the cluster
 

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -9,7 +9,7 @@ category: operations
 
 A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
 
-Before you start, see [TiDB architecture](../overview.md#tidb-architecture) and [Software and Hardware Requirements](op-guide/recommendation.md).
+Before you start, see [TiDB architecture](../overview.md#tidb-architecture) and [Software and Hardware Requirements](recommendation.md).
 
 This document describes the binary deployment of three scenarios:
 

--- a/op-guide/offline-ansible-deployment.md
+++ b/op-guide/offline-ansible-deployment.md
@@ -87,13 +87,13 @@ Before you start, make sure that you have:
 
 ## Orchestrate the TiDB cluster
 
-See [Orchestrate the TiDB cluster](op-guide/ansible-deployment.md#orchestrate-the-tidb-cluster).
+See [Orchestrate the TiDB cluster](ansible-deployment.md#orchestrate-the-tidb-cluster).
 
 ## Deploy the TiDB cluster
 
-1. See [Deploy the TiDB cluster](op-guide/ansible-deployment.md#deploy-the-tidb-cluster).
+1. See [Deploy the TiDB cluster](ansible-deployment.md#deploy-the-tidb-cluster).
 2. You do not need to run the `ansible-playbook local_prepare.yml` playbook again.
 
 ## Test the cluster
 
-See [Test the cluster](op-guide/ansible-deployment.md#test-the-cluster).
+See [Test the cluster](ansible-deployment.md#test-the-cluster).


### PR DESCRIPTION
I think the migration in https://github.com/pingcap/docs/pull/347 broke a few links. On master they currently 404.