### PR TITLE
op-guide: update deployment links and fix typo

### DIFF
--- a/op-guide/ansible-deployment.md
+++ b/op-guide/ansible-deployment.md
@@ -282,7 +282,7 @@ Log in to the Control Machine using the `tidb` user account, and edit the `tidb-
 - Do not deploy TiKV together with TiDB or PD on the same machine.
 - Use the first TiDB machine as the monitoring machine.
 
-> **Note:** It is required to use the internal IP address to deploy. If the SSH port of the target machines are not the default 22 port, you need to add the `ansible_port` variable. For example, `TiDB1 ansible_host=172.16.10.1 ansible_port=5555`.
+> **Note:** It is required to use the internal IP address to deploy. If the SSH port of the target machines is not the default 22 port, you need to add the `ansible_port` variable. For example, `TiDB1 ansible_host=172.16.10.1 ansible_port=5555`.
 
 You can choose one of the following two types of cluster topology according to your scenario:
 

--- a/op-guide/tidb-v2-upgrade-guide.md
+++ b/op-guide/tidb-v2-upgrade-guide.md
@@ -11,11 +11,11 @@ This document describes how to upgrade from TiDB 1.0 or TiDB 2.0 RC versions to 
 
 TiDB-Ansible release-2.0 depends on Ansible 2.4.2 or later, and is compatible with the latest Ansible 2.5. In addition, TiDB-Ansible release-2.0 depends on the Python module: `jinja2>=2.9.6` and `jmespath>=0.9.0`.
 
-To make it easy to manage dependencies, use `pip` to install Ansible and its dependencies. For details, see [Install Ansible and dependencies in the Control Machine](ansible-deployment.md#install-ansible-and-dependencies-in-the-control-machine). For offline environment, see [Install Ansible and dependencies offline in the Control Machine](offline-ansible-deployment.md#install-ansible-and-dependencies-offline-in-the-control-machine).
+To make it easy to manage dependencies, use `pip` to install Ansible and its dependencies. For details, see [Install Ansible and its dependencies on the Control Machine](ansible-deployment.md#step-4-install-ansible-and-its-dependencies-on-the-control-machine). For offline environment, see [Install Ansible and its dependencies offline on the Control Machine](offline-ansible-deployment.md#step-3-install-ansible-and-its-dependencies-offline-on-the-control-machine).
 
 After the installation is finished, you can view the version information using the following command:
 
-```
+```bash
 $ ansible --version
 ansible 2.5.2
 $ pip show jinja2
@@ -56,7 +56,7 @@ Login to the Control Machine using the `tidb` user account and enter the `/home/
 
 Edit the `inventory.ini` file. For IP information, see the `/home/tidb/tidb-ansible-bak/inventory.ini` backup file.
 
-Pay special attention to the following variables configuration. For variable meaning, see [Description of other variables](ansible-deployment.md#description-of-other-variables).
+Pay special attention to the following variables configuration. For variable meaning, see [Description of other variables](ansible-deployment.md#edit-other-variables-optional).
 
 1. Make sure that `ansible_user` is the normal user. For unified privilege management, remote installation using the root user is no longer supported. The default configuration uses the `tidb` user as the SSH remote user and the program running user.
 
@@ -66,7 +66,7 @@ Pay special attention to the following variables configuration. For variable mea
     ansible_user = tidb
     ```
 
-    You can refer to [How to configure SSH mutual trust and sudo without password](ansible-deployment.md#how-to-configure-ssh-mutual-trust-and-sudo-without-password) to automatically configure the mutual trust among hosts.
+    You can refer to [How to configure SSH mutual trust and sudo rules on the Control Machine](ansible-deployment.md#step-5-configure-the-ssh-mutual-trust-and-sudo-rules-on-the-control-machine) to automatically configure the mutual trust among hosts.
 
 2. Keep the `process_supervision` variable consistent with that in the previous version. It is recommended to use `systemd` by default.
 
@@ -75,7 +75,7 @@ Pay special attention to the following variables configuration. For variable mea
     process_supervision = systemd
     ```
 
-    If you need to modify this variable, see [How to adjust the supervision method of a process from supervise to systemd](ansible-deployment.md#how-to-adjust-the-supervision-method-of-a-process-from-supervise-to-systemd). Before you upgrade, first use the `/home/tidb/tidb-ansible-bak/` backup branch to modify the supervision method of a process.
+    If you need to modify this variable, see [How to modify the supervision method of a process from `supervise` to `systemd`](ansible-deployment.md#how-to-modify-the-supervision-method-of-a-process-from-supervise-to-systemd). Before you upgrade, first use the `/home/tidb/tidb-ansible-bak/` backup branch to modify the supervision method of a process.
 
 ### Edit the configuration file of TiDB cluster components
 


### PR DESCRIPTION
@CaitinChen PTAL

op-guide/ansible-deployment.md is updated, so the original links in other files need to be updated.