### PR TITLE
*: Include bikeshare example database in manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 + Quick Start
   - [TiDB Quick Start Guide](QUICKSTART.md)
   - [Basic SQL Statements](try-tidb.md)
-  - [Bikeshare Example Database](bikeshare-example-database.md]
+  - [Bikeshare Example Database](bikeshare-example-database.md)
 - [TiDB Tutorial](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 + TiDB User Guide
   + TiDB Server Administration

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 + Quick Start
   - [TiDB Quick Start Guide](QUICKSTART.md)
   - [Basic SQL Statements](try-tidb.md)
+  - [Bikeshare Example Database](bikeshare-example-database.md]
 - [TiDB Tutorial](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 + TiDB User Guide
   + TiDB Server Administration

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -23,7 +23,7 @@ done;
 
 ```
 
-## Create table in TiDB
+## Load data into MySQL
 
 The system data can be imported to MySQL using the following schema:
 

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -55,4 +55,4 @@ for FILE in `ls *.csv`; do
   LINES TERMINATED BY '\r\n'
 (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
 done;
-``
+```

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -1,6 +1,7 @@
 ---
 title: Bikeshare Example Database
-summary: Install the Bikeshare Example Database
+summary: Install the Bikeshare example database.
+category: user guide
 ---
 
 # Bikeshare Example Database
@@ -8,9 +9,9 @@ summary: Install the Bikeshare Example Database
 Examples used in the TiDB manual use [System Data](https://www.capitalbikeshare.com/system-data) from 
 Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement](https://www.capitalbikeshare.com/data-license-agreement).
 
-## Downloading all data files
+## Download all data files
 
-The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year. Downloading and extracting all files requires approximately 3GB of disk space.  To download all files for years 2010-2017 using a bash script:
+The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year. Downloading and extracting all files requires approximately 3GB of disk space. To download all files for years 2010-2017 using a bash script:
 
 ```bash
 mkdir -p bikeshare-data && cd bikeshare-data
@@ -42,6 +43,7 @@ CREATE TABLE trips (
  member_type varchar(255)
 );
 ```
+
 You can import files individually using the example `LOAD DATA` command here, or import all files using the bash loop below:
 
 ```sql

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,7 +10,7 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once using a bash script:
+The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files for years 2010-2017 using a bash script:
 
 ```
 

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -23,9 +23,9 @@ done;
 
 ```
 
-## Load data into MySQL
+## Load data into TiDB
 
-The system data can be imported to MySQL using the following schema:
+The system data can be imported into TiDB using the following schema:
 
 ```
 CREATE DATABASE bikeshare;

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -8,13 +8,38 @@ summary: Install the Bikeshare Example Database
 Examples used in the TiDB manual use [System Data](https://www.capitalbikeshare.com/system-data) from 
 Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement](https://www.capitalbikeshare.com/data-license-agreement).
 
-Installation of the sample database can be automated as follows:
+## Downloading all data files
+
+To download and extract all previous years in one step (using a bash script):
 
 ```
 
-for YEAR in "2010 2011 2012 2013 2014 2015 2016 2017"; do
- wget https://s3.amazonaws.com/capitalbikeshare-data/$YEAR-capitalbikeshare-tripdata.zip
- unzip $YEAR-capitalbikeshare-tripdata.zip
+mkdir -p bikeshare-data && cd bikeshare-data
+
+for YEAR in 2010 2011 2012 2013 2014 2015 2016 2017; do
+ wget https://s3.amazonaws.com/capitalbikeshare-data/${YEAR}-capitalbikeshare-tripdata.zip
+ unzip ${YEAR}-capitalbikeshare-tripdata.zip
 done;
 
 ```
+
+## Create table in TiDB
+
+```
+CREATE DATABASE bikeshare;
+USE bikeshare;
+
+CREATE TABLE trips (
+
+);
+```
+
+### Import all files
+
+To import all *.csv files into TiDB in a bash loop:
+
+```
+for FILE in `ls *.csv`; do
+
+done;
+``

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,7 +10,7 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-To download and extract all previous years in one step (using a bash script).  This requires approximately 3GB of disk space:
+The system data is available [for download](https://s3.amazonaws.com/capitalbikeshare-data/index.html) in zip files organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once (using a bash script):
 
 ```
 
@@ -24,6 +24,8 @@ done;
 ```
 
 ## Create table in TiDB
+
+The system data can be imported to MySQL using the following schema:
 
 ```
 CREATE DATABASE bikeshare;
@@ -41,6 +43,15 @@ CREATE TABLE trips (
  bike_number varchar(255),
  member_type varchar(255)
 );
+```
+You can import files indivudally using the example `LOAD DATA` command here, or import all files using the bash loop below:
+
+```
+LOAD DATA LOCAL INFILE '2017Q1-capitalbikeshare-tripdata.csv' INTO TABLE trips
+  FIELDS TERMINATED BY ',' ENCLOSED BY '"'
+  LINES TERMINATED BY '\r\n'
+(duration, start_date, end_date, start_station_number, start_station, 
+end_station_number, end_station, bike_number, member_type);
 ```
 
 ### Import all files

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,7 +10,7 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-The system data is available [for download](https://s3.amazonaws.com/capitalbikeshare-data/index.html) in zip files organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once (using a bash script):
+The system data is available [for download](https://s3.amazonaws.com/capitalbikeshare-data/index.html) in zip files organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once using a bash script:
 
 ```
 
@@ -50,6 +50,7 @@ You can import files indivudally using the example `LOAD DATA` command here, or 
 LOAD DATA LOCAL INFILE '2017Q1-capitalbikeshare-tripdata.csv' INTO TABLE trips
   FIELDS TERMINATED BY ',' ENCLOSED BY '"'
   LINES TERMINATED BY '\r\n'
+  IGNORE 1 LINES
 (duration, start_date, end_date, start_station_number, start_station, 
 end_station_number, end_station, bike_number, member_type);
 ```
@@ -61,6 +62,6 @@ To import all `*.csv` files into TiDB in a bash loop:
 ```
 for FILE in `ls *.csv`; do
  echo "== $FILE =="
- mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
+ mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
 done;
 ```

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,7 +10,7 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-The system data is available [for download](https://s3.amazonaws.com/capitalbikeshare-data/index.html) in zip files organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once using a bash script:
+The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files at once using a bash script:
 
 ```
 

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,7 +10,7 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-To download and extract all previous years in one step (using a bash script):
+To download and extract all previous years in one step (using a bash script).  This requires approximately 3GB of disk space:
 
 ```
 
@@ -30,16 +30,29 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
-
+ trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+ duration integer not null,
+ start_date datetime,
+ end_date datetime,
+ start_station_number integer,
+ start_station varchar(255),
+ end_station_number integer,
+ end_station varchar(255),
+ bike_number varchar(255),
+ member_type varchar(255)
 );
 ```
 
 ### Import all files
 
-To import all *.csv files into TiDB in a bash loop:
+To import all `*.csv` files into TiDB in a bash loop:
 
 ```
 for FILE in `ls *.csv`; do
-
+ echo "== $FILE =="
+ mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips
+  FIELDS TERMINATED BY ',' ENCLOSED BY '"'
+  LINES TERMINATED BY '\r\n'
+(duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
 done;
 ``

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -50,9 +50,6 @@ To import all `*.csv` files into TiDB in a bash loop:
 ```
 for FILE in `ls *.csv`; do
  echo "== $FILE =="
- mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips
-  FIELDS TERMINATED BY ',' ENCLOSED BY '"'
-  LINES TERMINATED BY '\r\n'
-(duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
+ mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"
 done;
 ```

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -1,0 +1,20 @@
+---
+title: Bikeshare Example Database
+summary: Install the Bikeshare Example Database
+---
+
+# Bikeshare Example Database
+
+Examples used in the TiDB manual use [System Data](https://www.capitalbikeshare.com/system-data) from 
+Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement](https://www.capitalbikeshare.com/data-license-agreement).
+
+Installation of the sample database can be automated as follows:
+
+```
+
+for YEAR in "2010 2011 2012 2013 2014 2015 2016 2017"; do
+ wget https://s3.amazonaws.com/capitalbikeshare-data/$YEAR-capitalbikeshare-tripdata.zip
+ unzip $YEAR-capitalbikeshare-tripdata.zip
+done;
+
+```

--- a/bikeshare-example-database.md
+++ b/bikeshare-example-database.md
@@ -10,24 +10,22 @@ Capital Bikeshare, released under the [Capital Bikeshare Data License Agreement]
 
 ## Downloading all data files
 
-The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year.  Downloading and extracting all files requires approximately 3GB of disk space.  To download all files for years 2010-2017 using a bash script:
+The system data is available [for download in .zip files](https://s3.amazonaws.com/capitalbikeshare-data/index.html) organized per year. Downloading and extracting all files requires approximately 3GB of disk space.  To download all files for years 2010-2017 using a bash script:
 
-```
-
+```bash
 mkdir -p bikeshare-data && cd bikeshare-data
 
 for YEAR in 2010 2011 2012 2013 2014 2015 2016 2017; do
  wget https://s3.amazonaws.com/capitalbikeshare-data/${YEAR}-capitalbikeshare-tripdata.zip
  unzip ${YEAR}-capitalbikeshare-tripdata.zip
 done;
-
 ```
 
 ## Load data into TiDB
 
 The system data can be imported into TiDB using the following schema:
 
-```
+```sql
 CREATE DATABASE bikeshare;
 USE bikeshare;
 
@@ -44,9 +42,9 @@ CREATE TABLE trips (
  member_type varchar(255)
 );
 ```
-You can import files indivudally using the example `LOAD DATA` command here, or import all files using the bash loop below:
+You can import files individually using the example `LOAD DATA` command here, or import all files using the bash loop below:
 
-```
+```sql
 LOAD DATA LOCAL INFILE '2017Q1-capitalbikeshare-tripdata.csv' INTO TABLE trips
   FIELDS TERMINATED BY ',' ENCLOSED BY '"'
   LINES TERMINATED BY '\r\n'
@@ -59,7 +57,7 @@ end_station_number, end_station, bike_number, member_type);
 
 To import all `*.csv` files into TiDB in a bash loop:
 
-```
+```bash
 for FILE in `ls *.csv`; do
  echo "== $FILE =="
  mysql bikeshare -e "LOAD DATA LOCAL INFILE '${FILE}' INTO TABLE trips FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);"


### PR DESCRIPTION
The MySQL manual makes use of sample databases which are available for [download here](https://dev.mysql.com/doc/index-other.html).  i.e. sakila, world, employees, menagerie.

The problem with re-using these databases is they are too small for TiDB to demonstrate HTAP.  This pull request includes a sample data set from Capital Bikeshare.  It takes 18m43s to import on my desktop.

https://github.com/pingcap/docs/pull/599 covers adding examples in the manual (`sql/understanding-the-query-execution-plan.md`).

This PR depends on https://github.com/pingcap/tidb/pull/7576 (recently merged).