### PR TITLE
*: Reorganize quick start to promote other platforms

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,18 +11,18 @@ Installation instructions for platforms officially supported by PingCAP.
 - [Ansible (recommended)](op-guide/ansible-deployment.md)
 - [Ansible (offline deployment)](op-guide/offline-ansible-deployment.md)
 - [Docker](op-guide/docker-deployment.md)
-- [Docker Compose (for development environments)](op-guide/docker-compose.md)
+- [Docker Compose (development environments)](op-guide/docker-compose.md)
 - [Kubernetes (beta)](op-guide/kubernetes.md)
 
 ## Community Provided Blog Posts & Tutorials
 
-A collection of blog posts demonstrating how to install TiDB.  The content is maintained by 
-third parties and not guaranteed to be up to date. 
+A collection of installation guides for TiDB authored by the community. The content is maintained by 
+third parties and not guaranteed to be up to date.
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
 
-_Please open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to have your tutorial added here._
+_Please open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links._
 
 ## Source Code
 
@@ -32,3 +32,4 @@ Source Code for [all PingCAP projects](https://github.com/pingcap) is available 
 - [TiKV](https://github.com/tikv/tikv)
 - [PD](https://github.com/pingcap/pd)
 - [TiSpark](https://github.com/pingcap/tispark)
+- [TiDB Operator](https://github.com/pingcap/tidb-operator)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,57 +6,17 @@ category: quick start
 
 # TiDB Quick Start Guide
 
-This guide introduces how to deploy and monitor a TiDB cluster on your local drive using Docker Compose for experimenting and testing.
+- Docker Compose
+- Ansible
+- Ansible
+- Docker
+- GKE
+- DinD
 
-> **Warning:** Deploying TiDB using Docker Compose can only be used for experimental purposes. For production usage, [use Ansible to deploy the TiDB cluster](op-guide/ansible-deployment.md).
+## Community Provided Blog Posts & Tutorials
 
-## Prerequisites
+A collection of blog posts demonstrating how to install TiDB.  The content is maintained by 
+third parties and not guaranteed to be up to date. 
 
-Before you begin, make sure to install the following tools:
-
-- [Git](https://git-scm.com/downloads)
-- [Docker Compose](https://docs.docker.com/compose/install/)
-- [MySQL Client](https://dev.mysql.com/downloads/mysql/)
-
-## Deploy a TiDB cluster
-
-1. Download `tidb-docker-compose`:
-
-    ```bash
-    git clone https://github.com/pingcap/tidb-docker-compose.git
-    ```
-
-2. Change the directory to tidb-docker-compose and get the latest TiDB Docker Images:
-
-    ```bash
-    cd tidb-docker-compose && docker-compose pull
-    ```
-
-3. Start the TiDB cluster:
-
-    ```bash
-    docker-compose up -d
-    ```
-
-Congratulations! You have deployed a TiDB cluster! You can see messages in your terminal of the default components of a TiDB cluster: 
-
-- 1 TiDB instance
-- 3 TiKV instances
-- 3 Placement Driver (PD) instances
-- Prometheus
-- Grafana
-- 2 TiSpark instances (one master, one slave)
-- 1 TiDB-Vision instance
-
-You can now test your TiDB server using one of the following methods:
-
-- Use the MySQL client to connect to TiDB:
-
-    ```
-    mysql -h 127.0.0.1 -P 4000 -u root
-    ```
-    
-    You can [try TiDB](try-tidb.md) to explore the SQL statements.
-    
-- Use Grafana to view the status of the cluster via [http://localhost:3000](http://localhost:3000) with the default account name and password:  `admin` and `admin`.
-- Use [TiDB-Vision](https://github.com/pingcap/tidb-vision), a cluster visualization tool, to see data transfer and load-balancing inside your cluster via [http://localhost:8010](http://localhost:8010).
+- [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
+- [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,12 +6,11 @@ category: quick start
 
 # TiDB Quick Start Guide
 
-- Docker Compose
-- Ansible
-- Ansible
-- Docker
-- GKE
-- DinD
+- [Docker Compose](op-guide/docker-compose.md)
+- [Ansible (recommended)](op-guide/ansible-deployment.md)
+- [Ansible (offline deployment)](op-guide/offline-ansible-deployment.md)
+- [Docker](op-guide/docker-deployment.md)
+- [Kubernetes](op-guide/kubernetes.md)
 
 ## Community Provided Blog Posts & Tutorials
 
@@ -20,6 +19,8 @@ third parties and not guaranteed to be up to date.
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
+
+_Please open a [pull request](https://github.com/pingcap/docs/pulls) to have your tutorial added here._
 
 ## Source Code
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,22 +6,22 @@ category: quick start
 
 # TiDB Quick Start Guide
 
-Installation instructions for platforms officially supported by PingCAP.
+As an open source distributed scalable HTAP database, TiDB can be deployed on-premise or in-cloud. The following deployment options are officially supported by PingCAP.
 
-- [Ansible (recommended)](op-guide/ansible-deployment.md)
-- [Ansible (offline deployment)](op-guide/offline-ansible-deployment.md)
-- [Docker](op-guide/docker-deployment.md)
-- [Docker Compose (development environments)](op-guide/docker-compose.md)
-- [Kubernetes (beta)](op-guide/kubernetes.md)
+- [Ansible Deployment](op-guide/ansible-deployment.md): This guide describes how to deploy TiDB using Ansible. It is strongly recommended for production deployment.
+- [Ansible Offline Deployment](op-guide/offline-ansible-deployment.md): If your environment has no access to the internet, you can follow this guide to see how to deploy a TiDB cluster offline using Ansible.
+- [Docker Deployment](op-guide/docker-deployment.md): This guide describes how to deploy TiDB using Docker.
+- [Docker Compose Deployment](op-guide/docker-compose.md): This guide describes how to deploy TiDB using Docker compose. You can follow this guide to quickly deploy a TiDB cluster for testing and development on your local drive.
+- [Kubernetes Deployment (beta)](op-guide/kubernetes.md): This guide describes how to deploy TiDB on Kubernetes using [TiDB Operator](https://github.com/pingcap/tidb-operator). You can follow this guide to see how to deploy TiDB on Google Kubernetes Engine or deploy TiDB locally using Docker in Docker.
 
 ## Community Provided Blog Posts & Tutorials
 
-A collection of unofficial installation guides for TiDB authored by the community. The content is not guaranteed to be up to date.
+The following list collects deployment guides and tutorials from the community. The content is subject to change by the contributors.
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
 
-_Please open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links._
+_Your contribution is also welcome! Feel free to open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links.
 
 ## Source Code
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,11 +6,13 @@ category: quick start
 
 # TiDB Quick Start Guide
 
+Installation instructions for platforms officially supported by PingCAP.
+
 - [Ansible (recommended)](op-guide/ansible-deployment.md)
 - [Ansible (offline deployment)](op-guide/offline-ansible-deployment.md)
 - [Docker](op-guide/docker-deployment.md)
-- [Docker Compose](op-guide/docker-compose.md)
-- [Kubernetes](op-guide/kubernetes.md)
+- [Docker Compose (for development environments)](op-guide/docker-compose.md)
+- [Kubernetes (beta)](op-guide/kubernetes.md)
 
 ## Community Provided Blog Posts & Tutorials
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,10 +6,10 @@ category: quick start
 
 # TiDB Quick Start Guide
 
-- [Docker Compose](op-guide/docker-compose.md)
 - [Ansible (recommended)](op-guide/ansible-deployment.md)
 - [Ansible (offline deployment)](op-guide/offline-ansible-deployment.md)
 - [Docker](op-guide/docker-deployment.md)
+- [Docker Compose](op-guide/docker-compose.md)
 - [Kubernetes](op-guide/kubernetes.md)
 
 ## Community Provided Blog Posts & Tutorials

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,8 +16,7 @@ Installation instructions for platforms officially supported by PingCAP.
 
 ## Community Provided Blog Posts & Tutorials
 
-A collection of installation guides for TiDB authored by the community. The content is maintained by 
-third parties and not guaranteed to be up to date.
+A collection of unofficial installation guides for TiDB authored by the community. The content is not guaranteed to be up to date.
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,7 +21,7 @@ The following list collects deployment guides and tutorials from the community. 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
 
-_Your contribution is also welcome! Feel free to open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links.
+_Your contribution is also welcome! Feel free to open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links._
 
 ## Source Code
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -22,7 +22,7 @@ third parties and not guaranteed to be up to date.
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
 
-_Please open a [pull request](https://github.com/pingcap/docs/pulls) to have your tutorial added here._
+_Please open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to have your tutorial added here._
 
 ## Source Code
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -26,7 +26,7 @@ _Please open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKS
 
 ## Source Code
 
-Source Code for [all PingCAP projects](https://github.com/pingcap) is available on GitHub.
+Source code for [all components of the TiDB platform](https://github.com/pingcap) is available on GitHub.
 
 - [TiDB](https://github.com/pingcap/tidb)
 - [TiKV](https://github.com/tikv/tikv)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,3 +20,12 @@ third parties and not guaranteed to be up to date.
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
+
+## Source Code
+
+Source Code for [all PingCAP projects](https://github.com/pingcap) is available on GitHub.
+
+- [TiDB](https://github.com/pingcap/tidb)
+- [TiKV](https://github.com/tikv/tikv)
+- [PD](https://github.com/pingcap/pd)
+- [TiSpark](https://github.com/pingcap/tispark)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 + Quick Start
   - [TiDB Quick Start Guide](QUICKSTART.md)
   - [Basic SQL Statements](try-tidb.md)
-- [TiDB Tutorial](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 + TiDB User Guide
   + TiDB Server Administration
     - [The TiDB Server](sql/tidb-server.md)


### PR DESCRIPTION
I think that over time Kubernetes-based quickstart will become more popular than Docker Compose.  Currently, our recommended production deployment is also ansible -- but it is buried a few levels deep in navigation.

I would like to propose a reorganization so that the Quickstart links to all op-guide deployments.  This also reduces duplication since the Docker Compose tutorial is in Quickstart and in op-guide.

Minor/unofficial platforms can also have a link under "community provided blog posts".  I've included the 5-minute quick start and a link to one of my blog posts (which should be removed as newer and better guides are written).