### PR TITLE
sql: Add example to QEP manual page

### DIFF
--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -64,7 +64,6 @@ mmysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 
 |     └─IndexScan_24     | 8166.73 | cop  | table:trips, index:start_date, range:[2017-07-01 00:00:00,2017-07-01 23:59:59], keep order:false |
 +------------------------+---------+------+--------------------------------------------------------------------------------------------------+
 4 rows in set (0.01 sec)
-
 ```
 
 In the revisted `EXPLAIN` we can see the count of rows scanned has reduced via the use of an index.  On a reference system, this reduced query execution time reduced from 50.41 seconds to 0.00 seconds!

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -47,7 +47,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 5 rows in set (0.00 sec)
 ```
 
-Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). Each of the TiKV nodes return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return `1.00` row to the client.
+Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). The `count` column shows an approximate number of rows that will be processed, which is estimated with the help of table statistics. In this query it is estimated that each of the TiKV nodes will return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return an estimated `1.00` row to the client.
 
 The good news with this query is that most of the work is pushed down to the coprocessor. This means that minimal data transfer way required for query execution. However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
 

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -29,7 +29,7 @@ Currently, the `EXPLAIN` statement returns the following four columns: id, count
 | task | the task that the current operator belongs to. The current execution plan contains two types of tasks: 1) the **root** task that runs on the TiDB server; 2) the **cop** task that runs concurrently on the TiKV server. The topological relations of the current execution plan in the task level is that a root task can be followed by many cop tasks. The root task uses the output of cop task as the input. The cop task executes the tasks that TiDB pushes to TiKV. Each cop task scatters in the TiKV cluster and is executed by multiple processes. |
 | operator info | The details about each operator. The information of each operator differs from others, see [Operator Info](#operator-info).|
 
-### Example Usage
+### Example usage
 
 Using the [bikeshare example database](../bikeshare-example-database.md):
 
@@ -49,7 +49,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 
 Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). The `count` column shows an approximate number of rows that will be processed, which is estimated with the help of table statistics. In this query it is estimated that each of the TiKV nodes will return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return an estimated `1.00` row to the client.
 
-The good news with this query is that most of the work is pushed down to the coprocessor. This means that minimal data transfer way required for query execution. However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
+The good news with this query is that most of the work is pushed down to the coprocessor. This means that minimal data transfer is required for query execution. However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
 
 ```
 mysql> ALTER TABLE trips ADD INDEX (start_date);
@@ -66,7 +66,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 4 rows in set (0.01 sec)
 ```
 
-In the revisted `EXPLAIN` we can see the count of rows scanned has reduced via the use of an index. On a reference system, this reduced query execution time reduced from 50.41 seconds to 0.00 seconds!
+In the revisited `EXPLAIN` you can see the count of rows scanned has reduced via the use of an index. On a reference system, the query execution time reduced from 50.41 seconds to 0.00 seconds!
 
 ## Overview
 

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -47,7 +47,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 5 rows in set (0.00 sec)
 ```
 
-Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). The `count` column shows an approximate number of rows that will be processed, which is estimated with the help of table statistics. In this query it is estimated that each of the TiKV nodes will return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return an estimated `1.00` row to the client.
+Here you can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). The `count` column shows an approximate number of rows that will be processed, which is estimated with the help of table statistics. In this query it is estimated that each of the TiKV nodes will return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return an estimated `1.00` row to the client.
 
 The good news with this query is that most of the work is pushed down to the coprocessor. This means that minimal data transfer is required for query execution. However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
 

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -47,7 +47,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 5 rows in set (0.00 sec)
 ```
 
-Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`.  Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV).  Each of the TiKV nodes return `1.00` rows to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return `1.00` rows to the client.
+Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`.  Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV).  Each of the TiKV nodes return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return `1.00` row to the client.
 
 The good news with this query is that most of the work is pushed down to the coprocessor.  This means that minimal data transfer way required for query execution.  However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
 

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -54,7 +54,7 @@ The good news with this query is that most of the work is pushed down to the cop
 ```
 mysql> ALTER TABLE trips ADD INDEX (start_date);
 ..
-mmysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 00:00:00' AND '2017-07-01 23:59:59';
+mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 00:00:00' AND '2017-07-01 23:59:59';
 +------------------------+---------+------+--------------------------------------------------------------------------------------------------+
 | id                     | count   | task | operator info                                                                                    |
 +------------------------+---------+------+--------------------------------------------------------------------------------------------------+

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -29,6 +29,14 @@ Currently, the `EXPLAIN` statement returns the following four columns: id, count
 | task | the task that the current operator belongs to. The current execution plan contains two types of tasks: 1) the **root** task that runs on the TiDB server; 2) the **cop** task that runs concurrently on the TiKV server. The topological relations of the current execution plan in the task level is that a root task can be followed by many cop tasks. The root task uses the output of cop task as the input. The cop task executes the tasks that TiDB pushes to TiKV. Each cop task scatters in the TiKV cluster and is executed by multiple processes. |
 | operator info | The details about each operator. The information of each operator differs from others, see [Operator Info](#operator-info).|
 
+### Example Usage
+
+Using the [bikeshare example database](bikeshare-example-database.md):
+
+```
+SELECT 1 FROM DUAL;
+```
+
 ## Overview
 
 ### Introduction to task

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -47,9 +47,9 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 5 rows in set (0.00 sec)
 ```
 
-Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`.  Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV).  Each of the TiKV nodes return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return `1.00` row to the client.
+Here we can see that the coprocesor (cop) needs to scan the table `trips` to find rows that match the criteria of `start_date`. Rows that meet this criteria are determined in `Selection_19` and passed to `StreamAgg_9`, all still within the coprocessor (i.e. inside of TiKV). Each of the TiKV nodes return `1.00` row to TiDB (as `TableReader_21`), which are then aggregated as `StreamAgg_20` to return `1.00` row to the client.
 
-The good news with this query is that most of the work is pushed down to the coprocessor.  This means that minimal data transfer way required for query execution.  However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
+The good news with this query is that most of the work is pushed down to the coprocessor. This means that minimal data transfer way required for query execution. However, the `TableScan_18` can be eliminated by adding an index to speed up queries on `start_date`:
 
 ```
 mysql> ALTER TABLE trips ADD INDEX (start_date);
@@ -66,7 +66,7 @@ mysql> EXPLAIN SELECT count(*) FROM trips WHERE start_date BETWEEN '2017-07-01 0
 4 rows in set (0.01 sec)
 ```
 
-In the revisted `EXPLAIN` we can see the count of rows scanned has reduced via the use of an index.  On a reference system, this reduced query execution time reduced from 50.41 seconds to 0.00 seconds!
+In the revisted `EXPLAIN` we can see the count of rows scanned has reduced via the use of an index. On a reference system, this reduced query execution time reduced from 50.41 seconds to 0.00 seconds!
 
 ## Overview
 


### PR DESCRIPTION
This adds an example to the Query Execution Plan page.

It depends on https://github.com/pingcap/docs/pull/596 which is also ready to merge.