### PR TITLE
sql: Clarify default character-set is utf8

### DIFF
--- a/sql/character-set-configuration.md
+++ b/sql/character-set-configuration.md
@@ -6,6 +6,6 @@ category: user guide
 
 # Character Set Configuration
 
-Currently, TiDB does not support configuring the character set. The default character set is `utf8mb4`.
+Currently, TiDB only supports the `utf8` character set, which is the equivalent to `utf8mb4` in MySQL. Since MySQL 5.7 defaults to latin1, this difference is documented under [default differences](mysql-compatibility.md#default-differences) between TiDB and MySQL.
 
 For more information, see [Character Set Configuration in MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-configuration.html).

--- a/sql/character-set-configuration.md
+++ b/sql/character-set-configuration.md
@@ -6,6 +6,6 @@ category: user guide
 
 # Character Set Configuration
 
-Currently, TiDB only supports the `utf8` character set, which is the equivalent to `utf8mb4` in MySQL. Since MySQL 5.7 defaults to latin1, this difference is documented under [default differences](mysql-compatibility.md#default-differences) between TiDB and MySQL.
+Currently, TiDB only supports the `utf8` character set, which is the equivalent to `utf8mb4` in MySQL. Since MySQL 5.7 defaults to `latin1`, this difference is documented under [default differences](mysql-compatibility.md#default-differences) between TiDB and MySQL.
 
 For more information, see [Character Set Configuration in MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-configuration.html).


### PR DESCRIPTION
Improved clarity of changing character set, linked back to mysql compatibility/differences in defaults so users can discover other differences.