### PR TITLE
Fix broken manual page

### DIFF
--- a/sql/mysql-compatibility.md
+++ b/sql/mysql-compatibility.md
@@ -40,9 +40,7 @@ The auto-increment ID feature in TiDB is only guaranteed to be automatically inc
 > 
 > Assume that you have a table with the auto-increment ID:
 > 
-> ```
-> create table t(id int unique key auto_increment, c int);
-> ```
+> `create table t(id int unique key auto_increment, c int);`
 > 
 > The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
 >


### PR DESCRIPTION
The manual page is currently broken:
https://pingcap.com/docs/sql/mysql-compatibility/

It broke after push of https://github.com/pingcap/docs/pull/604 although it looks like it was a change in the markdown parser, since this line was not modified.

I investigated it, and think this might fix it - but it's difficult to tell since GitHub's markdown parser works fine.