### PR TITLE
op-guide, tools: Recommend mydumper from enterprise tools

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -691,7 +691,7 @@ TiDB is not suitable for tables of small size (such as below ten million level),
 
 #### How to back up data in TiDB?
 
-Currently, the preferred way of backing up is using the [TiDB fork of mydumper](tools/mydumper.md).Although the official MySQL tool `mysqldump` is also supported in TiDB to back up and restore data, its performance is poorer than [`mydumper`](tools/mydumper.md)/[`loader`](tools/loader.md) and it needs much more time to back up and restore large volumes of data. Therefore, it is not recommended to use `mysqldump`. 
+Currently, the preferred method for backup is using the [PingCAP fork of mydumper](tools/mydumper.md). Although the official MySQL tool `mysqldump` is also supported in TiDB to back up and restore data, its performance is poorer than [`mydumper`](tools/mydumper.md)/[`loader`](tools/loader.md) and it needs much more time to back up and restore large volumes of data.
 
 Keep the size of the data file exported from `mydumper` as small as possible. It is recommended to keep the size within 64M. You can set value of the `-F` parameter to 64.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -691,23 +691,11 @@ TiDB is not suitable for tables of small size (such as below ten million level),
 
 #### How to back up data in TiDB?
 
-Currently, the major way of backing up data in TiDB is using `mydumper`. For details, see [mydumper repository](https://github.com/maxbube/mydumper). Although the official MySQL tool `mysqldump` is also supported in TiDB to back up and restore data, its performance is poorer than `mydumper`/`loader` and it needs much more time to back up and restore large volumes of data. Therefore, it is not recommended to use `mysqldump`. 
+Currently, the preferred way of backing up is using the [TiDB fork of mydumper](tools/mydumper.md).Although the official MySQL tool `mysqldump` is also supported in TiDB to back up and restore data, its performance is poorer than [`mydumper`](tools/mydumper.md)/[`loader`](tools/loader.md) and it needs much more time to back up and restore large volumes of data. Therefore, it is not recommended to use `mysqldump`. 
 
 Keep the size of the data file exported from `mydumper` as small as possible. It is recommended to keep the size within 64M. You can set value of the `-F` parameter to 64.
 
 You can edit the `t` parameter of `loader` based on the number of TiKV instances and load status. For example, in scenarios of three TiKV instances, you can set its value to `3 * (1 ～ n)`. When the TiKV load is very high and `backoffer.maxSleep 15000ms is exceeded` displays a lot in `loader` and TiDB logs, you can adjust the parameter to a smaller value. When the TiKV load is not very high, you can adjust the parameter to a larger value accordingly.
-
-## Migrate the data and traffic
-
-### Full data export and import
-
-#### Mydumper
-
-See the [mydumper repository](https://github.com/maxbube/mydumper).
-
-#### Loader
-
-See [Loader Instructions](tools/loader.md).
 
 #### How to migrate an application running on MySQL to TiDB?
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
   - [Troubleshoot](trouble-shooting.md)
 + TiDB Enterprise Tools
   - [Syncer](tools/syncer.md)
+  - [mydumper](tools/mydumper.md)
   - [Loader](tools/loader.md)
   - [TiDB-Binlog](tools/tidb-binlog-kafka.md)
   - [PD Control](tools/pd-control.md)

--- a/op-guide/backup-restore.md
+++ b/op-guide/backup-restore.md
@@ -38,7 +38,7 @@ cd tidb-enterprise-tools-latest-linux-amd64
 
 ## Full backup and restoration using `mydumper`/`loader`
 
-You can use `mydumper` to export data from MySQL and `loader` to import the data into TiDB.
+You can use [`mydumper`](../tools/mydumper.md) to export data from MySQL and [`loader`](../tools/loader.md) to import the data into TiDB.
 
 > **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager.  The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
 

--- a/op-guide/backup-restore.md
+++ b/op-guide/backup-restore.md
@@ -40,7 +40,7 @@ cd tidb-enterprise-tools-latest-linux-amd64
 
 You can use [`mydumper`](../tools/mydumper.md) to export data from MySQL and [`loader`](../tools/loader.md) to import the data into TiDB.
 
-> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager.  The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
+> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager. The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
 
 ### Best practices of full backup and restoration using `mydumper`/`loader` 
 

--- a/op-guide/backup-restore.md
+++ b/op-guide/backup-restore.md
@@ -40,7 +40,7 @@ cd tidb-enterprise-tools-latest-linux-amd64
 
 You can use `mydumper` to export data from MySQL and `loader` to import the data into TiDB.
 
-> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager.  The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
+> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager.  The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
 
 ### Best practices of full backup and restoration using `mydumper`/`loader` 
 

--- a/op-guide/backup-restore.md
+++ b/op-guide/backup-restore.md
@@ -40,7 +40,7 @@ cd tidb-enterprise-tools-latest-linux-amd64
 
 You can use [`mydumper`](../tools/mydumper.md) to export data from MySQL and [`loader`](../tools/loader.md) to import the data into TiDB.
 
-> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager. The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
+> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager. The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155)). Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
 
 ### Best practices of full backup and restoration using `mydumper`/`loader` 
 

--- a/op-guide/backup-restore.md
+++ b/op-guide/backup-restore.md
@@ -40,7 +40,7 @@ cd tidb-enterprise-tools-latest-linux-amd64
 
 You can use `mydumper` to export data from MySQL and `loader` to import the data into TiDB.
 
-> **Note**: Although TiDB also supports the official `mysqldump` tool from MySQL for data migration, it is not recommended to use it. Its performance is much lower than `mydumper`/`loader` and it takes much time to migrate large amounts of data. `mydumper`/`loader` is more powerful. For more information, see https://github.com/maxbube/mydumper.
+> **Important**: You must use the `mydumper` from the Enterprise Tools package, and not the `mydumper` provided by your operating system's package manager.  The upstream version of `mydumper` does not yet handle TiDB correctly ([#155](https://github.com/maxbube/mydumper/pull/155).  Using `mysqldump` is also not recommended, as it is much slower for both backup and restoration.
 
 ### Best practices of full backup and restoration using `mydumper`/`loader` 
 

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -1,7 +1,7 @@
 ---
 title: mydumper Instructions 
 summary: Use mydumper to export data from TiDB.
-category: advanced
+category: tools
 ---
 
 # mydumper Instructions

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -8,7 +8,7 @@ category: tools
 
 ## What is mydumper?
 
-`mydumper` is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB.  It is the recommended method to use for logical backups of TiDB.
+`mydumper` is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB. It is the recommended method to use for logical backups of TiDB.
 
 [Download the Binary](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz).
 
@@ -43,4 +43,4 @@ Source code for PingCAP's mydumper is [available on GitHub](https://github.com/p
 
 ### Do you plan to make these changes available to upstream mydumper?
 
-Yes, we intend to make our changes available to upstream mydumper.  See [PR #155](https://github.com/maxbube/mydumper/pull/155).
+Yes, we intend to make our changes available to upstream mydumper. See [PR #155](https://github.com/maxbube/mydumper/pull/155).

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -14,11 +14,11 @@ category: tools
 
 ## What enhancements does this contain over regular mydumper?
 
-+ Use `tidb_snapshot` to provide backup consistency instead of `FLUSH TABLES WITH READ LOCK`
++ Uses `tidb_snapshot` to provide backup consistency instead of `FLUSH TABLES WITH READ LOCK`
 
-+ Include the hidden `_tidb_rowid` column in `INSERT` statements when present
++ Includes the hidden `_tidb_rowid` column in `INSERT` statements when present
 
-+ Allow for `tidb_snapshot` to be [configurable](../op-guide/history-read.md#how-tidb-reads-data-from-history-versions) (i.e. backup data as it appeared at an earlier point in time)
++ Allows `tidb_snapshot` to be [configurable](../op-guide/history-read.md#how-tidb-reads-data-from-history-versions) (i.e. backup data as it appeared at an earlier point in time)
 
 ### New parameter description
 
@@ -35,6 +35,7 @@ Command line parameter:
 ```
 ./bin/mydumper -h 127.0.0.1 -u root -P 4000
 ```
+
 ## FAQ
 
 ### Is the source code for these changes available?

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -8,7 +8,7 @@ category: tools
 
 ## What is mydumper?
 
-Mydumper is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB.  It is the recommended method to use for logical backups of TiDB.
+`mydumper` is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB.  It is the recommended method to use for logical backups of TiDB.
 
 [Download the Binary](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz).
 
@@ -37,7 +37,7 @@ Command line parameter:
 ```
 ## FAQ
 
-### Is this source code for these changes available?
+### Is the source code for these changes available?
 
 Source code for PingCAP's mydumper is [available on GitHub](https://github.com/pingcap/mydumper).
 

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -1,0 +1,46 @@
+---
+title: mydumper Instructions 
+summary: Use mydumper to export data from TiDB.
+category: advanced
+---
+
+# mydumper Instructions
+
+## What is mydumper?
+
+Mydumper is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB.  It is the recommended method to use for logical backups of TiDB.
+
+[Download the Binary](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz).
+
+## What enhancements does this contain over regular mydumper?
+
++ Use `tidb_snapshot` to provide backup consistency instead of `FLUSH TABLES WITH READ LOCK`
+
++ Include the hidden `_tidb_rowid` column in exports when present
+
++ Allow for `tidb_snapshot` to be configurable (i.e. backup data as it appeared at an earlier point in time)
+
+
+### New parameter description
+
+```
+  -z, --tidb-snapshot: Set the tidb_snapshot to be used for the backup.
+                       Default: NOW()-INTERVAL 1 SECOND.
+```
+
+### Usage example
+
+Command line parameter:
+
+```
+./bin/mydumper -h 127.0.0.1 -u root -P 4000
+```
+## FAQ
+
+### Is this source code for these changes available?
+
+Source code for PingCAP's mydumper is [available on GitHub](https://github.com/pingcap/mydumper).
+
+### Do you plan to make these changes available to upstream mydumper?
+
+Yes, we intend to make our changes available to upstream mydumper.  See [PR #155](https://github.com/maxbube/mydumper/pull/155).

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -16,16 +16,16 @@ category: tools
 
 + Use `tidb_snapshot` to provide backup consistency instead of `FLUSH TABLES WITH READ LOCK`
 
-+ Include the hidden `_tidb_rowid` column in exports when present
++ Include the hidden `_tidb_rowid` column in `INSERT` statements when present
 
-+ Allow for `tidb_snapshot` to be configurable (i.e. backup data as it appeared at an earlier point in time)
-
++ Allow for `tidb_snapshot` to be [configurable](../op-guide/history-read.md#how-tidb-reads-data-from-history-versions) (i.e. backup data as it appeared at an earlier point in time)
 
 ### New parameter description
 
 ```
   -z, --tidb-snapshot: Set the tidb_snapshot to be used for the backup.
                        Default: NOW()-INTERVAL 1 SECOND.
+                       Accepts either a TSO or valid datetime.  For example: -z "2016-10-08 16:45:26"
 ```
 
 ### Usage example


### PR DESCRIPTION
The `mydumper` upstream is unsafe, since it relies on `ftwrl` instead of `tidb_snapshot`.  Soon the server will produce an error when attempting this unsafe statement: https://github.com/pingcap/tidb/pull/7712

The `mydumper` currently in enterprise tools is unsafe by default, but can be made safe by setting the `tidb_snapshot` as an option.

In https://github.com/morgo/mydumper/tree/tidb-head I have re-implimented the `tidb_snapshot` option to aut-set, so backups are safe by default.  It is also based on upstream's master branch, so it includes the last couple of years of bug fixes and support for generated columns.

`tidb-head` also includes all features that were in the master branch of `pingcap/mydumper`, so I am hoping we can switch it to be `pingcap/master`.  At which point the docs page in this pull request will be 100% accurate.

Fixes #630