### PR TITLE
sql: Rename TiDB proprietary variables to TiDB specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     - [The TiDB Data Directory](sql/tidb-server.md#tidb-data-directory)
     - [The TiDB System Database](sql/system-database.md)
     - [The TiDB System Variables](sql/variable.md)
-    - [The Proprietary System Variables and Syntax in TiDB](sql/tidb-specific.md)
+    - [The TiDB Specific System Variables](sql/tidb-specific.md)
     - [The TiDB Server Logs](sql/tidb-server.md#tidb-server-logs)
     - [The TiDB Access Privilege System](sql/privilege.md)
     - [TiDB User Account Management](sql/user-account-management.md)

--- a/sql/tidb-specific.md
+++ b/sql/tidb-specific.md
@@ -1,10 +1,10 @@
 ---
-title: The Proprietary System Variables and Syntaxes in TiDB
-summary: Use the proprietary system variables and syntaxes in TiDB to optimize performance.
+title: TiDB Specific System Variables
+summary: Use system variables specific to TiDB to optimize performance.
 category: user guide
 ---
 
-# The Proprietary System Variables and Syntaxes in TiDB
+# TiDB Specific System Variables
 
 On the basis of MySQL variables and syntaxes, TiDB has defined some specific system variables and syntaxes to optimize performance.
 

--- a/sql/tidb-specific.md
+++ b/sql/tidb-specific.md
@@ -6,7 +6,7 @@ category: user guide
 
 # TiDB Specific System Variables
 
-TiDB contains a number of system variables which are specific to its usage, and **do not** apply to MySQL.  These variables start with a `tidb_` prefix, and can be tuned to optimize system performance.
+TiDB contains a number of system variables which are specific to its usage, and **do not** apply to MySQL. These variables start with a `tidb_` prefix, and can be tuned to optimize system performance.
 
 ## System variable
 

--- a/sql/tidb-specific.md
+++ b/sql/tidb-specific.md
@@ -6,7 +6,7 @@ category: user guide
 
 # TiDB Specific System Variables
 
-On the basis of MySQL variables and syntaxes, TiDB has defined some specific system variables and syntaxes to optimize performance.
+TiDB contains a number of system variables which are specific to its usage, and **do not** apply to MySQL.  These variables start with a `tidb_` prefix, and can be tuned to optimize system performance.
 
 ## System variable
 


### PR DESCRIPTION
I had a chat with @gregwebs, and we agreed that while not incorrect - the word "proprietary" has too strong of an association with "not open source" (which is not the case here).

So I've changed the name to TiDB specific to reduce confusion.