### PR TITLE
sql: Add XML functions to incompatible

### DIFF
--- a/sql/mysql-compatibility.md
+++ b/sql/mysql-compatibility.md
@@ -27,6 +27,7 @@ However, in TiDB, the following MySQL features are not supported for the time be
 + Drop primary key
 + SYS schema
 + Optimizer trace
++ XML Functions
 + X-Protocol
 
 ## Features that are different from MySQL


### PR DESCRIPTION
TiDB does not support updatexml or extractvalue:
https://dev.mysql.com/doc/refman/5.7/en/xml-functions.html
