### PR TITLE
tools: update mydumper default tidb_snapshot

### DIFF
--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -24,7 +24,7 @@ category: tools
 
 ```
   -z, --tidb-snapshot: Set the tidb_snapshot to be used for the backup.
-                       Default: NOW()-INTERVAL 1 SECOND.
+                       Default: The current TSO (UniqueID from SHOW MASTER STATUS).
                        Accepts either a TSO or valid datetime.  For example: -z "2016-10-08 16:45:26"
 ```
 


### PR DESCRIPTION
In https://github.com/pingcap/mydumper/pull/8 our `mydumper` recently changed it's default from NOW()-1 second to the current TSO from `SHOW MASTER STATUS`.  This PR updates the docs.