### PR TITLE
sql: Fix broken links

### DIFF
--- a/sql/datatype.md
+++ b/sql/datatype.md
@@ -253,7 +253,7 @@ INSERT INTO city VALUES (1, '{"name": "Beijing", "population": 100}');
 SELECT id FROM city WHERE population >= 100;
 ```
 
-For more information, see [JSON Functions and Generated Column](../sql/json-functions-generated-column.md).
+For more information, see [JSON Functions](../sql/json-functions.md) and [Generated Columns](../sql/generated-columns.md).
 
 ## The ENUM data type
 

--- a/sql/user-manual.md
+++ b/sql/user-manual.md
@@ -81,9 +81,9 @@ TiDB supports the SQL-92 standard and is compatible with MySQL. To help you easi
 - [Utility Statements](util.md)
 - [TiDB SQL Syntax Diagram](https://pingcap.github.io/sqlgram/)
 
-## JSON functions and generated column
+## Generated columns
 
-- [JSON Functions and Generated Column](json-functions-generated-column.md)
+- [Generated Columns](generated-columns.md)
 
 ## Connectors and APIs
 


### PR DESCRIPTION
I don't believe anything links to sql/user-manual.md, but I've updated it anyway.

Found the links via a grep search.