### PR TITLE
op-guide: add tabs for TiDB deployment tutorials on gcp and local

### DIFF
--- a/op-guide/kubernetes.md
+++ b/op-guide/kubernetes.md
@@ -11,14 +11,20 @@ and automates tasks related to operating a TiDB cluster. It makes TiDB a truly c
 
 > **Warning:** Currently, TiDB Operator is work in progress [WIP] and is NOT ready for production. Use at your own risk.
 
-## Google Kubernetes Engine (GKE)
+<main class="tabs">
+  <input id="tabGoogle" type="radio" name="tabs" checked>
+  <label for="tabGoogle" class="label__png">GCP</label>
+  <input id="tabLocal" type="radio" name="tabs">
+  <label for="tabLocal" class="label__png">Local</label>
+  <section id="GoogleContent">
+    <h3>Google Kubernetes Engine (GKE)</h3>
+    <p>The TiDB Operator tutorial for GKE runs directly in the Google Cloud Shell.</p>
+    <a href="https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md"><img src="https://gstatic.com/cloudssh/images/open-btn.png"/></a>
+  </section>
+  <section id="LocalContent">
+  <h3>Local installation using Docker in Docker</h3>
+  <p>Docker in Docker (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. <code>kubeadm-dind-cluster</code> uses this technology to run the Kubernetes cluster in Docker containers. TiDB Operator uses a modified DinD script to manage the DinD Kubernetes cluster.</p>
 
-The TiDB Operator tutorial for GKE runs directly in the Google Cloud Shell.
-
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md)
-
-## Local installation using Docker in Docker
-
-Docker in Docker (DinD) runs Docker containers as virtual machines and runs another layer of Docker containers inside the first layer of Docker containers. `kubeadm-dind-cluster` uses this technology to run the Kubernetes cluster in Docker containers. TiDB Operator uses a modified DinD script to manage the DinD Kubernetes cluster.
-
-[Continue reading tutorial on GitHub &rarr;](https://github.com/pingcap/tidb-operator/blob/master/docs/local-dind-tutorial.md)
+  <a href="https://github.com/pingcap/tidb-operator/blob/master/docs/local-dind-tutorial.md">Continue reading tutorial on GitHub<span class="continue__arrow"></span></a>
+  </section>
+</main>


### PR DESCRIPTION
PTAL