### PR TITLE
lightning: increase the required version from 2.0.4 to 2.0.9

### DIFF
--- a/tools/lightning-deployment.md
+++ b/tools/lightning-deployment.md
@@ -150,7 +150,7 @@ You can deploy TiDB-Lightning using Ansible together with the [deployment of the
 
 #### Step 1: Deploy a TiDB cluster
 
-Before importing data, you need to have a deployed TiDB cluster, with the cluster version 2.0.4 or above. It is highly recommended to use the latest version.
+Before importing data, you need to have a deployed TiDB cluster, with the cluster version 2.0.9 or above. It is highly recommended to use the latest version.
 
 You can find deployment instructions in [TiDB Quick Start Guide](https://pingcap.com/docs/QUICKSTART/).
 

--- a/tools/lightning-faq.md
+++ b/tools/lightning-faq.md
@@ -8,7 +8,7 @@ category: tools
 
 ## What is the minimum TiDB/TiKV/PD cluster version supported by Lightning?
 
-The minimum version is 2.0.4.
+The minimum version is 2.0.9.
 
 ## Does Lightning support importing multiple schemas (databases)?
 


### PR DESCRIPTION
Recently we fixed a bug in RocksDB which would cause loss of data due to race condition (pingcap/rocksdb#59). So we need to increase the TiKV requirement to 2.0.9.

