### PR TITLE
tools: added a checklist for debugging speed problem

### DIFF
--- a/tools/lightning-errors.md
+++ b/tools/lightning-errors.md
@@ -20,7 +20,7 @@ There are several reasons why Lightning becomes slow:
 
 1. The setting can be found from the start of the log by searching `region-concurrency`.
 2. If Lightning shares the same machine with other services (e.g. Importer), `region-concurrency` must be **manually** set to 75% of the total number of CPU cores
-3. If there is a quota on CPU (e.g. limited by K8s settings), Lightning may not be able to read this out. In this case, the `region-concurrency` must also be **manually** reduced.
+3. If there is a quota on CPU (e.g. limited by K8s settings), Lightning may not be able to read this out. In this case, `region-concurrency` must also be **manually** reduced.
 
 **Cause 2**: The table is too complex.
 

--- a/tools/lightning-errors.md
+++ b/tools/lightning-errors.md
@@ -19,7 +19,7 @@ There are several reasons why Lightning becomes slow:
 **Cause 1**: `region-concurrency` is too high, which causes thread contention and reduces performance.
 
 1. The setting can be found from the start of the log by searching `region-concurrency`.
-2. If Lightning shares the same machine with other services (e.g. Importer), the `region-concurrency` must be **manually** set to 75% of total CPU number
+2. If Lightning shares the same machine with other services (e.g. Importer), `region-concurrency` must be **manually** set to 75% of the total number of CPU cores
 3. If there is a quota on CPU (e.g. limited by K8s settings), Lightning may not be able to read this out. In this case, the `region-concurrency` must also be **manually** reduced.
 
 **Cause 2**: The table is too complex.

--- a/tools/lightning-errors.md
+++ b/tools/lightning-errors.md
@@ -10,6 +10,26 @@ When Lightning encounters an unrecoverable error, it exits with nonzero exit cod
 
 This document summarizes some commonly encountered errors in the `tidb-lightning` log file and their solutions.
 
+## Import speed is too slow
+
+Normally it takes Lightning 5 minutes per thread to import a 256 MB Chunk. It is an error if the speed is much slower than this. The time taken for each chunk can be checked from the log mentioning `restore chunk … takes`. This can also be observed from metrics on Grafana.
+
+There are several reasons why Lightning becomes slow:
+
+**Cause 1**: `region-concurrency` is too high, causing thread contention and reduces performance on the contrary
+
+1. The setting can be found from the start of the log by searching `region-concurrency`.
+2. If Lightning shares the same machine with other services (e.g. Importer), the `region-concurrency` must be **manually** set to 75% of total CPU number
+3. If there is a quota on CPU (e.g. limited by K8s settings), Lightning may not be able to read this out. In this case, the `region-concurrency` must also be **manually** reduced.
+
+**Cause 2**: The table is too complex.
+
+Every additional index will introduce a new KV pair for each row. If there are N indices, the actual size to be imported would be approximately (N+1) times the size of the mydumper output. If the indices are negligible, you may first remove them from the schema, and add them back via `CREATE INDEX` after import is complete.
+
+**Cause 3**: Lightning is too old.
+
+Try the latest version! Maybe there is new speed improvement.
+
 ## checksum failed: checksum mismatched remote vs local
 
 **Cause**: The checksum of a table in the local data source and the remote imported database differ. This error has several deeper reasons:

--- a/tools/lightning-errors.md
+++ b/tools/lightning-errors.md
@@ -16,7 +16,7 @@ Normally it takes Lightning 5 minutes per thread to import a 256 MB Chunk. It is
 
 There are several reasons why Lightning becomes slow:
 
-**Cause 1**: `region-concurrency` is too high, causing thread contention and reduces performance on the contrary
+**Cause 1**: `region-concurrency` is too high, which causes thread contention and reduces performance.
 
 1. The setting can be found from the start of the log by searching `region-concurrency`.
 2. If Lightning shares the same machine with other services (e.g. Importer), the `region-concurrency` must be **manually** set to 75% of total CPU number


### PR DESCRIPTION
This adds a list of common causes and fixes about why Lightning is slower than expected.

Chinese version: pingcap/docs-cn#998
