### PR TITLE
sql: Default changes from TIDB master

### DIFF
--- a/sql/character-set-configuration.md
+++ b/sql/character-set-configuration.md
@@ -6,6 +6,6 @@ category: user guide
 
 # Character Set Configuration
 
-Currently, TiDB only supports the `utf8` character set, which is the equivalent to `utf8mb4` in MySQL. Since MySQL 5.7 defaults to `latin1`, this difference is documented under [default differences](../sql/mysql-compatibility.md#default-differences) between TiDB and MySQL.
+Currently, TiDB only supports the `utf8mb4` character set, and its alias `utf8`. Since MySQL 5.7 defaults to `latin1`, this difference is documented under [default differences](../sql/mysql-compatibility.md#default-differences) between TiDB and MySQL.
 
 For more information, see [Character Set Configuration in MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-configuration.html).

--- a/sql/character-set-configuration.md
+++ b/sql/character-set-configuration.md
@@ -6,6 +6,6 @@ category: user guide
 
 # Character Set Configuration
 
-Currently, TiDB only supports the `utf8mb4` character set, and its alias `utf8`. Since MySQL 5.7 defaults to `latin1`, this difference is documented under [default differences](../sql/mysql-compatibility.md#default-differences) between TiDB and MySQL.
+Currently, TiDB only supports the `utf8mb4` character set. Since MySQL 5.7 defaults to `latin1`, this difference is documented under [default differences](../sql/mysql-compatibility.md#default-differences) between TiDB and MySQL.
 
 For more information, see [Character Set Configuration in MySQL](https://dev.mysql.com/doc/refman/5.7/en/charset-configuration.html).

--- a/sql/character-set-support.md
+++ b/sql/character-set-support.md
@@ -8,7 +8,7 @@ category: user guide
 
 A character set is a set of symbols and encodings. A collation is a set of rules for comparing characters in a character set.
 
-Currently, TiDB supports the following character sets:
+For **compatibility reasons** TiDB lists several character sets as available, but will always store data in the `utf8mb4` character set.
 
 ```sql
 mysql> SHOW CHARACTER SET;
@@ -24,7 +24,7 @@ mysql> SHOW CHARACTER SET;
 5 rows in set (0.00 sec)
 ```
 
-> **Note**: In TiDB, utf8 is treated as utf8mb4.
+> **Note**: All character sets are currently treated as utf8mb4.
 
 Each character set has at least one collation. Most of the character sets have several collations. You can use the following statement to display the available character sets:
 

--- a/sql/character-set-support.md
+++ b/sql/character-set-support.md
@@ -8,7 +8,7 @@ category: user guide
 
 A character set is a set of symbols and encodings. A collation is a set of rules for comparing characters in a character set.
 
-For **compatibility reasons** TiDB lists several character sets as available, but will always store data in the `utf8mb4` character set.
+For **compatibility reasons**, TiDB lists several character sets as available, but will always store data in the `utf8mb4` character set.
 
 ```sql
 mysql> SHOW CHARACTER SET;

--- a/sql/mysql-compatibility.md
+++ b/sql/mysql-compatibility.md
@@ -160,7 +160,7 @@ mysql> SHOW CREATE TABLE t1\G
        Table: t1
 Create Table: CREATE TABLE `t1` (
   `a` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 1 row in set (0.00 sec)
 ```
 
@@ -173,12 +173,9 @@ The output of the query execution plan returned from the `EXPLAIN` command diffe
 ### Default differences
 
 - Default character set:
-    - The default value in TiDB is `utf8` which is equivalent to `utf8mb4` in MySQL.
+    - The default value in TiDB is `utf8mb4`.
     - The default value in MySQL 5.7 is `latin1`, but changes to `utf8mb4` in MySQL 8.0.
 - Default collation: `latin1_swedish_ci` in MySQL 5.7, while `binary` in TiDB.
-- Default SQL mode:
-    - The default value in TiDB is `STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION`.
-    - The default value in MySQL 5.7 is `ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION`.
 - Default value of `lower_case_table_names`:
     - The default value in TiDB is 2 and currently TiDB only supports 2.
     - The default value in MySQL:

--- a/sql/mysql-compatibility.md
+++ b/sql/mysql-compatibility.md
@@ -176,6 +176,9 @@ The output of the query execution plan returned from the `EXPLAIN` command diffe
     - The default value in TiDB is `utf8mb4`.
     - The default value in MySQL 5.7 is `latin1`, but changes to `utf8mb4` in MySQL 8.0.
 - Default collation: `latin1_swedish_ci` in MySQL 5.7, while `binary` in TiDB.
+- Default value of `foreign_key_checks`:
+    - The default value in TiDB is `OFF` and currently TiDB only supports `OFF`.
+    - The default value in MySQL 5.7 is `ON`.
 - Default value of `lower_case_table_names`:
     - The default value in TiDB is 2 and currently TiDB only supports 2.
     - The default value in MySQL:

--- a/sql/mysql-compatibility.md
+++ b/sql/mysql-compatibility.md
@@ -22,7 +22,7 @@ However, in TiDB, the following MySQL features are not supported for the time be
 + `FOREIGN KEY` constraints
 + `FULLTEXT` functions and indexes
 + `SPATIAL` functions and indexes
-+ Character sets other than `utf8`
++ Character sets other than `utf8mb4`
 + Collations other than `BINARY`
 + Add primary key
 + Drop primary key


### PR DESCRIPTION
These changes AFAIK are in master only, and have not been backported to TiDB 2.1:

- The default charset is now utf8mb4 https://github.com/pingcap/tidb/pull/7965  (simplifying explanation, since TiDB utf8 is like MySQL utf8mb4).
- foreign key checks = 0  https://github.com/pingcap/tidb/pull/8358
- the sql mode will be the same as mysql  https://github.com/pingcap/parser/pull/45