### PR TITLE
tools, readme: adjust Lightning docs for the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
     - [Overview](tools/lightning/overview-architecture.md)
     - [Deployment](tools/lightning/deployment.md)
     - [Checkpoints](tools/lightning/checkpoints.md)
+    - [Table Filter](tools/lightning/filter.md)
     - [Monitor](tools/lightning/monitor.md)
     - [Troubleshooting](tools/lightning/errors.md)
     - [FAQs](tools/lightning/faq.md)

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -30,7 +30,7 @@ driver = "file"
 
 # The data source name (DSN) indicating the location of the checkpoint storage.
 #
-# For "file" driver, the DSN is a path. If not specified, Lightning would
+# For the "file" driver, the DSN is a path. If the path is not specified, Lightning would
 # default to "/tmp/CHECKPOINT_SCHEMA.pb".
 #
 # For the "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -33,7 +33,7 @@ driver = "file"
 # For "file" driver, the DSN is a path. If not specified, Lightning would
 # default to "/tmp/CHECKPOINT_SCHEMA.pb".
 #
-# For "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
+# For the "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
 # If not specified, the TiDB server from the [tidb] section will be used to
 # store the checkpoints. You should specify a different MySQL-compatible
 # database server to reduce the load of the target TiDB cluster.

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -49,9 +49,9 @@ driver = "file"
 
 Lightning supports two kinds of checkpoint storage: a local file or a remote MySQL-compatible database.
 
-With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, so we highly recommend placing the checkpoint file on a drive with very high write endurance, such as a RAM disk.
+* With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, so we highly recommend placing the checkpoint file on a drive with very high write endurance, such as a RAM disk.
 
-With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or later, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
+* With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or later, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
 
 While using the target database as the checkpoints storage, Lightning is importing large amounts of data at the same time. This puts extra stress on the target database and sometimes leads to communication timeout. Therefore, **it is strongly recommended to install a temporary MySQL server to store these checkpoints**. This server can be installed on the same host as `tidb-lightning` and can be uninstalled after the importer progress is completed.
 

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -23,11 +23,21 @@ enable = true
 # The schema name (database name) to store the checkpoints
 schema = "tidb_lightning_checkpoint"
 
-# The data source name (DSN) in the form of "USER:PASS@tcp(HOST:PORT)/".
-# If not specified, the TiDB server from the [tidb] section is used to
-# store the checkpoints. You could also specify a different MySQL-compatible
+# Where to store the checkpoints.
+#  - file:  store as a local file.
+#  - mysql: store into a remote MySQL-compatible database
+driver = "file"
+
+# The data source name (DSN) indicating the location of the checkpoint storage.
+#
+# For "file" driver, the DSN is a path. If not specified, Lightning would
+# default to "/tmp/CHECKPOINT_SCHEMA.pb".
+#
+# For "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
+# If not specified, the TiDB server from the [tidb] section will be used to
+# store the checkpoints. You should specify a different MySQL-compatible
 # database server to reduce the load of the target TiDB cluster.
-#dsn = "root@tcp(127.0.0.1:4000)/"
+#dsn = "/tmp/tidb_lightning_checkpoint.pb"
 
 # Whether to keep the checkpoints after all data are imported. If false, the
 # checkpoints are deleted. Keeping the checkpoints can aid debugging but
@@ -37,7 +47,11 @@ schema = "tidb_lightning_checkpoint"
 
 ## Checkpoints storage
 
-Checkpoints can be saved in any databases compatible with MySQL 5.7 or above, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
+Lightning supports two kinds of checkpoint storage: a local file or a remote MySQL-compatible database.
+
+With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, and we highly recommend to place the checkpoint file on a drive with very high write endurance e.g. a RAM disk.
+
+With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or above, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
 
 While using the target database as the checkpoints storage, Lightning is importing large amounts of data at the same time. This puts extra stress on the target database and sometimes leads to communication timeout. Therefore, **it is strongly recommended to install a temporary MySQL server to store these checkpoints**. This server can be installed on the same host as `tidb-lightning` and can be uninstalled after the importer progress is completed.
 
@@ -92,4 +106,4 @@ This option simply removes all checkpoint information about one table or all tab
 tidb-lightning-ctl --checkpoint-dump=output/directory
 ```
 
-This option dumps the content of the checkpoint into the given directory, which is mainly used for debugging by the technical staff.
+This option dumps the content of the checkpoint into the given directory, which is mainly used for debugging by the technical staff. This option is only enabled when `driver = "mysql"`.

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -24,7 +24,7 @@ enable = true
 schema = "tidb_lightning_checkpoint"
 
 # Where to store the checkpoints.
-#  - file:  store as a local file (requires v2.1.1 or above)
+#  - file:  store as a local file (requires v2.1.1 or later)
 #  - mysql: store into a remote MySQL-compatible database
 driver = "file"
 

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -34,7 +34,7 @@ driver = "file"
 # default to "/tmp/CHECKPOINT_SCHEMA.pb".
 #
 # For the "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
-# If not specified, the TiDB server from the [tidb] section will be used to
+# If the URL is not specified, the TiDB server from the [tidb] section is used to
 # store the checkpoints. You should specify a different MySQL-compatible
 # database server to reduce the load of the target TiDB cluster.
 #dsn = "/tmp/tidb_lightning_checkpoint.pb"

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -51,7 +51,7 @@ Lightning supports two kinds of checkpoint storage: a local file or a remote MyS
 
 With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, so we highly recommend placing the checkpoint file on a drive with very high write endurance, such as a RAM disk.
 
-With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or above, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
+With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or later, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
 
 While using the target database as the checkpoints storage, Lightning is importing large amounts of data at the same time. This puts extra stress on the target database and sometimes leads to communication timeout. Therefore, **it is strongly recommended to install a temporary MySQL server to store these checkpoints**. This server can be installed on the same host as `tidb-lightning` and can be uninstalled after the importer progress is completed.
 

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -24,7 +24,7 @@ enable = true
 schema = "tidb_lightning_checkpoint"
 
 # Where to store the checkpoints.
-#  - file:  store as a local file.
+#  - file:  store as a local file (requires v2.1.1 or above)
 #  - mysql: store into a remote MySQL-compatible database
 driver = "file"
 

--- a/tools/lightning/checkpoints.md
+++ b/tools/lightning/checkpoints.md
@@ -49,7 +49,7 @@ driver = "file"
 
 Lightning supports two kinds of checkpoint storage: a local file or a remote MySQL-compatible database.
 
-With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, and we highly recommend to place the checkpoint file on a drive with very high write endurance e.g. a RAM disk.
+With `driver = "file"`, checkpoints are stored in a local file at the path given by the `dsn` setting. Checkpoints are updated rapidly, so we highly recommend placing the checkpoint file on a drive with very high write endurance, such as a RAM disk.
 
 With `driver = "mysql"`, checkpoints can be saved in any databases compatible with MySQL 5.7 or above, including MariaDB and TiDB. By default, the checkpoints are saved in the target database.
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -322,7 +322,8 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # already exist on the target TiDB cluster, and will not execute the `CREATE
     # TABLE` statements
     no-schema = false
-    # the character set of the schema files; only supports one of:
+    # the character set of the schema files, containing CREATE TABLE statements;
+    # only supports one of:
     #  - utf8mb4: the schema files must be encoded as UTF-8, otherwise Lightning
     #             will emit errors
     #  - gb18030: the schema files must be encoded as GB-18030, otherwise
@@ -378,7 +379,7 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     log-progress = "5m"
 
     # Table filter options. See the corresponding section for details.
-    [black-white-list]
+    #[black-white-list]
     # ...
     ```
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -64,6 +64,22 @@ It is recommended to use the following configuration of the single machine:
 
 > **Notes:** `tidb-lightning` is a CPU intensive program. In an environment with mixed components, the resources allocated to `tidb-lightning` must be limited. Otherwise, other components might not be able to run. It is recommended to set the `region-concurrency` to 75% of CPU logical cores. For instance, if the CPU has 32 logical cores, you can set the `region-concurrency` to 24.
 
+## Export data
+
+Use the [`mydumper` tool](../../tools/mydumper.md) to export data from MySQL by using the following command:
+
+```sh
+./bin/mydumper -h 127.0.0.1 -P 3306 -u root -t 16 -F 256 -B test -T t1,t2 --skip-tz-utc -o /data/my_database/
+```
+
+In this command,
+
+- `-B test`: means the data is exported from the `test` database.
+- `-T t1,t2`: means only the `t1` and `t2` tables are exported.
+- `-t 16`: means 16 threads are used to export the data.
+- `-F 256`: means a table is partitioned into chunks and one chunk is 256 MB.
+- `--skip-tz-utc`: the purpose of adding this parameter is to ignore the inconsistency of time zone setting between MySQL and the data exporting machine and to disable automatic conversion.
+
 ## Deploy TiDB-Lightning
 
 This section describes two deployment methods of TiDB-Lightning:
@@ -158,8 +174,9 @@ You can find deployment instructions in [TiDB Quick Start Guide](https://pingcap
 
 Download the TiDB-Lightning package (choose the same version as that of the TiDB cluster):
 
-- **v2.1**: https://download.pingcap.org/tidb-lightning-release-2.1-linux-amd64.tar.gz
-- **v2.0**: https://download.pingcap.org/tidb-lightning-release-2.0-linux-amd64.tar.gz
+- **v2.1.0**: https://download.pingcap.org/tidb-lightning-v2.1.0-linux-amd64.tar.gz
+- **v2.0.9**: https://download.pingcap.org/tidb-lightning-release-2.0-linux-amd64.tar.gz
+- Latest unstable version: https://download.pingcap.org/tidb-lightning-latest-linux-amd64.tar.gz
 
 #### Step 3: Start `tikv-importer`
 
@@ -271,11 +288,18 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     enable = true
     # The schema name (database name) to store the checkpoints
     schema = "tidb_lightning_checkpoint"
-    # The data source name (DSN) in the form of "USER:PASS@tcp(HOST:PORT)/".
+    # Where to store the checkpoints.
+    #  - file:  store as a local file.
+    #  - mysql: store into a remote MySQL-compatible database
+    driver = "file"
+    # The data source name (DSN) indicating the location of the checkpoint storage.
+    # For "file" driver, the DSN is a path. If not specified, Lightning would
+    # default to "/tmp/CHECKPOINT_SCHEMA.pb".
+    # For "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
     # If not specified, the TiDB server from the [tidb] section will be used to
-    # store the checkpoints. You could also specify a different MySQL-compatible
+    # store the checkpoints. You should specify a different MySQL-compatible
     # database server to reduce the load of the target TiDB cluster.
-    #dsn = "root@tcp(127.0.0.1:4000)/"
+    #dsn = "/tmp/tidb_lightning_checkpoint.pb"
     # Whether to keep the checkpoints after all data are imported. If false, the
     # checkpoints will be deleted. Keeping the checkpoints can aid debugging but
     # will leak metadata about the data source.
@@ -288,7 +312,7 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     [mydumper]
     # Block size for file reading. Keep it longer than the longest string of
     # the data source.
-    read-block-size = 4096 # Byte (default = 4 KB)
+    read-block-size = 65536 # Byte (default = 64 KB)
     # Each data file is split into multiple chunks of this size. Each chunk
     # is processed in parallel.
     region-min-size = 268435456 # Byte (default = 256 MB)
@@ -298,6 +322,17 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # already exist on the target TiDB cluster, and will not execute the `CREATE
     # TABLE` statements
     no-schema = false
+    # the character set of the schema files; only supports one of:
+    #  - utf8mb4: the schema files must be encoded as UTF-8, otherwise will emit
+    #             errors
+    #  - gb18030: the schema files must be encoded as GB-18030, otherwise will
+    #             emit errors
+    #  - auto:    (default) automatically detect if the schema is UTF-8 or
+    #             GB-18030, error if the encoding is neither
+    #  - binary:  do not try to decode the schema files
+    # note that the *data* files are always parsed as binary regardless of
+    # schema encoding.
+    character-set = "auto"
 
     [tidb]
     # Configuration of any TiDB server from the cluster
@@ -312,13 +347,19 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # tidb-lightning imports TiDB as a library and generates some logs itself.
     # This setting controls the log level of the TiDB library.
     log-level = "error"
+
     # Sets the TiDB session variable to speed up the Checksum and Analyze operations.
-    distsql-scan-concurrency = 16
+    # See https://pingcap.com/docs/sql/statistics/#control-analyze-concurrency
+    # for the meaning of each setting
+    build-stats-concurrency = 20
+    distsql-scan-concurrency = 100
+    index-serial-scan-concurrency = 20
+    checksum-table-concurrency = 16
 
     # When data importing is complete, tidb-lightning can automatically perform
     # the Checksum, Compact and Analyze operations. It is recommended to leave
     # these as true in the production environment.
-    # The execution order: Checksum -> Compact -> Analyze
+    # The execution order: Checksum -> Analyze
     [post-restore]
     # Performs `ADMIN CHECKSUM TABLE <table>` for each table to verify data integrity.
     checksum = true
@@ -326,6 +367,19 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     compact = true
     # Performs `ANALYZE TABLE <table>` for each table.
     analyze = true
+
+    # Configures the background periodic actions
+    # Supported units: h (hour), m (minute), s (second).
+    [cron]
+    # Duration between which Lightning will automatically refresh the import mode
+    # status. Should be shorter than the corresponding TiKV setting.
+    switch-mode = "5m"
+    # Duration which the an import progress will be printed to the log.
+    log-progress = "5m"
+
+    # Table filter options. See the corresponding section for details.
+    [black-white-list]
+    # ...
     ```
 
 4. Run `tidb-lightning`.

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -175,7 +175,7 @@ You can find deployment instructions in [TiDB Quick Start Guide](https://pingcap
 Download the TiDB-Lightning package (choose the same version as that of the TiDB cluster):
 
 - **v2.1.0**: https://download.pingcap.org/tidb-lightning-v2.1.0-linux-amd64.tar.gz
-- **v2.0.9**: https://download.pingcap.org/tidb-lightning-release-2.0-linux-amd64.tar.gz
+- **v2.0.9**: https://download.pingcap.org/tidb-lightning-v2.0.9-linux-amd64.tar.gz
 - Latest unstable version: https://download.pingcap.org/tidb-lightning-latest-linux-amd64.tar.gz
 
 #### Step 3: Start `tikv-importer`
@@ -293,10 +293,10 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     #  - mysql: store into a remote MySQL-compatible database
     driver = "file"
     # The data source name (DSN) indicating the location of the checkpoint storage.
-    # For "file" driver, the DSN is a path. If not specified, Lightning would
+    # For the "file" driver, the DSN is a path. If the path is not specified, Lightning would
     # default to "/tmp/CHECKPOINT_SCHEMA.pb".
-    # For "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
-    # If not specified, the TiDB server from the [tidb] section will be used to
+    # For the "mysql" driver, the DSN is a URL in the form of "USER:PASS@tcp(HOST:PORT)/".
+    # If the URL is not specified, the TiDB server from the [tidb] section is used to
     # store the checkpoints. You should specify a different MySQL-compatible
     # database server to reduce the load of the target TiDB cluster.
     #dsn = "/tmp/tidb_lightning_checkpoint.pb"
@@ -323,10 +323,10 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # TABLE` statements
     no-schema = false
     # the character set of the schema files; only supports one of:
-    #  - utf8mb4: the schema files must be encoded as UTF-8, otherwise will emit
-    #             errors
-    #  - gb18030: the schema files must be encoded as GB-18030, otherwise will
-    #             emit errors
+    #  - utf8mb4: the schema files must be encoded as UTF-8, otherwise Lightning
+    #             will emit errors
+    #  - gb18030: the schema files must be encoded as GB-18030, otherwise
+    #             Lightning will emit errors
     #  - auto:    (default) automatically detects whether the schema is UTF-8 or
     #             GB-18030. An error is reported if the encoding is neither.
     #  - binary:  do not try to decode the schema files

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -328,7 +328,7 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     #  - gb18030: the schema files must be encoded as GB-18030, otherwise will
     #             emit errors
     #  - auto:    (default) automatically detects whether the schema is UTF-8 or
-    #             GB-18030, error if the encoding is neither
+    #             GB-18030. An error is reported if the encoding is neither.
     #  - binary:  do not try to decode the schema files
     # note that the *data* files are always parsed as binary regardless of
     # schema encoding.
@@ -371,10 +371,10 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # Configures the background periodic actions
     # Supported units: h (hour), m (minute), s (second).
     [cron]
-    # Duration between which Lightning will automatically refresh the import mode
+    # Duration between which Lightning automatically refreshes the import mode
     # status. Should be shorter than the corresponding TiKV setting.
     switch-mode = "5m"
-    # Duration which the an import progress will be printed to the log.
+    # Duration between which an import progress is printed to the log.
     log-progress = "5m"
 
     # Table filter options. See the corresponding section for details.

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -78,7 +78,7 @@ In this command,
 - `-T t1,t2`: means only the `t1` and `t2` tables are exported.
 - `-t 16`: means 16 threads are used to export the data.
 - `-F 256`: means a table is partitioned into chunks and one chunk is 256 MB.
-- `--skip-tz-utc`: the purpose of adding this parameter is to ignore the inconsistency of time zone setting between MySQL and the data exporting machine and to disable automatic conversion.
+- `--skip-tz-utc`: the purpose of adding this parameter is to ignore the inconsistency of time zone setting between MySQL and the data exporting machine, and to disable automatic conversion.
 
 ## Deploy TiDB-Lightning
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -174,7 +174,7 @@ You can find deployment instructions in [TiDB Quick Start Guide](https://pingcap
 
 Download the TiDB-Lightning package (choose the same version as that of the TiDB cluster):
 
-- **v2.1.0**: https://download.pingcap.org/tidb-lightning-v2.1.0-linux-amd64.tar.gz
+- **v2.1.2**: https://download.pingcap.org/tidb-lightning-v2.1.2-linux-amd64.tar.gz
 - **v2.0.9**: https://download.pingcap.org/tidb-lightning-v2.0.9-linux-amd64.tar.gz
 - Latest unstable version: https://download.pingcap.org/tidb-lightning-latest-linux-amd64.tar.gz
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -327,7 +327,7 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     #             errors
     #  - gb18030: the schema files must be encoded as GB-18030, otherwise will
     #             emit errors
-    #  - auto:    (default) automatically detect if the schema is UTF-8 or
+    #  - auto:    (default) automatically detects whether the schema is UTF-8 or
     #             GB-18030, error if the encoding is neither
     #  - binary:  do not try to decode the schema files
     # note that the *data* files are always parsed as binary regardless of

--- a/tools/lightning/errors.md
+++ b/tools/lightning/errors.md
@@ -79,7 +79,7 @@ Try the latest version! Maybe there is new speed improvement.
 
 ## [sql2kv] sql encode error = [types:1292]invalid time format: '{1970 1 1 0 45 0 0}'
 
-**Cause**: A table contains a column with type `timestamp`, and the time value itself does not exist, either due to DST changes or has exceeded the supported range (1970 Jan 1st to 2038 Jan 19th).
+**Cause**: A table contains a column with the `timestamp` type, but the time value itself does not exist. This is either because of DST changes or the time value has exceeded the supported range (1970 Jan 1st to 2038 Jan 19th).
 
 **Solutions**:
 

--- a/tools/lightning/errors.md
+++ b/tools/lightning/errors.md
@@ -75,7 +75,7 @@ Try the latest version! Maybe there is new speed improvement.
 
 2. Manually `CREATE` the affected tables in the target database, and then set `[mydumper] no-schema = true` to skip automatic table creation.
 
-3. Set `[mydumper] character-set = "binary"` to skip the check. Note that this may introduce mojibake into the target database.
+3. Set `[mydumper] character-set = "binary"` to skip the check. Note that this might introduce mojibake into the target database.
 
 ## [sql2kv] sql encode error = [types:1292]invalid time format: '{1970 1 1 0 45 0 0}'
 

--- a/tools/lightning/filter.md
+++ b/tools/lightning/filter.md
@@ -6,7 +6,7 @@ category: tools
 
 # TiDB-Lightning Table Filter
 
-TiDB-Lightning supports setting up black and white lists to ignore certain databases and tables. This can be used to skip cache tables, or manually partitions the data source on a shared storage to allow multiple Lightning instances work together without interfering each other.
+TiDB-Lightning supports setting up black and white lists to ignore certain databases and tables. This can be used to skip cache tables, or manually partition the data source on a shared storage to allow multiple Lightning instances work together without interfering each other.
 
 The filtering rule is similar to MySQL `replication-rules-db`/`replication-rules-table`.
 
@@ -60,7 +60,7 @@ Note that the database filtering rules are applied before considering the table 
 
 ## Example
 
-To illustrate how these rules work, let’s suppose the data source contains the following tables:
+To illustrate how these rules work, suppose the data source contains the following tables:
 
 ```
 `logs`.`messages_2016`
@@ -98,7 +98,7 @@ db-name = "~^forum.*"
 table-name = "messages"
 ```
 
-First we apply the database rules:
+First apply the database rules:
 
 | Database                  | Outcome                                    |
 |---------------------------|--------------------------------------------|
@@ -108,7 +108,7 @@ First we apply the database rules:
 | `` `forum_backup_2017` `` | Skipped by rule C                          |
 | `` `forum_backup_2018` `` | Included by rule A (rule C will not apply) |
 
-Then we apply the table rules:
+Then apply the table rules:
 
 | Table                                | Outcome                                    |
 |--------------------------------------|--------------------------------------------|

--- a/tools/lightning/filter.md
+++ b/tools/lightning/filter.md
@@ -19,10 +19,10 @@ ignore-dbs = ["pattern4", "pattern5"]
 ```
 
 * If the `do-dbs` array in the `[black-white-list]` section is not empty,
-    * If the name of a database matched *any* pattern in the `do-dbs` array, the database is included,
+    * If the name of a database matches *any* pattern in the `do-dbs` array, the database is included.
     * Otherwise, the database is skipped.
-* Otherwise, if the name matched *any* pattern in the `ignore-dbs` array, the database is skipped.
-* If a database’s name matched *both* the `do-dbs` and `ignore-dbs` arrays, the database is included.
+* Otherwise, if the name matches *any* pattern in the `ignore-dbs` array, the database is skipped.
+* If a database’s name matches *both* the `do-dbs` and `ignore-dbs` arrays, the database is included.
 
 The pattern can either be a simple name, or a regular expression in [Go dialect](https://golang.org/pkg/regexp/syntax/#hdr-Syntax) if it starts with a `~` character.
 

--- a/tools/lightning/filter.md
+++ b/tools/lightning/filter.md
@@ -18,11 +18,9 @@ do-dbs = ["pattern1", "pattern2", "pattern3"]
 ignore-dbs = ["pattern4", "pattern5"]
 ```
 
-If the name of a database matched *any* pattern in the `do-dbs` array in the `[black-white-list]` section, the database will be included.
-
-Otherwise, if the name matched *any* pattern in the `ignore-dbs` array, the database will be skipped.
-
-If a database’s name matched *both* the `do-dbs` and `ignore-dbs` arrays, the database will be included.
+* If the name of a database matched *any* pattern in the `do-dbs` array in the `[black-white-list]` section, the database is included.
+* Otherwise, if the name matched *any* pattern in the `ignore-dbs` array, the database is skipped.
+* If a database’s name matched *both* the `do-dbs` and `ignore-dbs` arrays, the database is included.
 
 The pattern can either be a simple name, or a regular expression in [Go dialect](https://golang.org/pkg/regexp/syntax/#hdr-Syntax) if it starts with a `~` character.
 
@@ -50,13 +48,11 @@ db-name = "db-pattern-5"
 table-name = "table-pattern-5"
 ```
 
-If the qualified name of a table matched *any* pair of patterns in the `do-tables` array, the table will be included.
+* If the qualified name of a table matched *any* pair of patterns in the `do-tables` array, the table is included.
+* Otherwise, if the qualified name matched *any* pair of patterns in the `ignore-tables` array, the table is skipped.
+* If a table’s qualified name matched *both* the `do-tables` and `ignore-tables` arrays, the table is included.
 
-Otherwise, if the qualified name matched *any* pair of patterns in the `ignore-tables` array, the table will be skipped.
-
-If a table’s qualified name matched *both* the `do-tables` and `ignore-tables` arrays, the table will be included.
-
-Note that the database filtering rules are applied before considering the table filtering rules. This means if a database is ignored by `ignore-dbs`, all tables inside this database will not be considered even if they matched any `do-tables` array.
+Note that the database filtering rules are applied before Lightning considers the table filtering rules. This means if a database is ignored by `ignore-dbs`, all tables inside this database are not considered even if they matches any `do-tables` array.
 
 ## Example
 

--- a/tools/lightning/filter.md
+++ b/tools/lightning/filter.md
@@ -1,0 +1,122 @@
+---
+title: TiDB-Lightning Table Filter
+summary: Use black and white lists to filter out tables, ignoring them during import.
+category: tools
+---
+
+# TiDB-Lightning Table Filter
+
+TiDB-Lightning supports setting up black and white lists to ignore certain databases and tables. This can be used to skip cache tables, or manually partitions the data source on a shared storage to allow multiple Lightning instances work together without interfering each other.
+
+The filtering rule is similar to MySQL `replication-rules-db`/`replication-rules-table`.
+
+## Filtering databases
+
+```toml
+[black-white-list]
+do-dbs = ["pattern1", "pattern2", "pattern3"]
+ignore-dbs = ["pattern4", "pattern5"]
+```
+
+If the name of a database matched *any* pattern in the `do-dbs` array in the `[black-white-list]` section, the database will be included.
+
+Otherwise, if the name matched *any* pattern in the `ignore-dbs` array, the database will be skipped.
+
+If a database’s name matched *both* the `do-dbs` and `ignore-dbs` arrays, the database will be included.
+
+The pattern can either be a simple name, or a regular expression in [Go dialect](https://golang.org/pkg/regexp/syntax/#hdr-Syntax) if it starts with a `~` character.
+
+## Filtering tables
+
+```toml
+[[black-white-list.do-tables]]
+db-name = "db-pattern-1"
+table-name = "table-pattern-1"
+
+[[black-white-list.do-tables]]
+db-name = "db-pattern-2"
+table-name = "table-pattern-2"
+
+[[black-white-list.do-tables]]
+db-name = "db-pattern-3"
+table-name = "table-pattern-3"
+
+[[black-white-list.ignore-tables]]
+db-name = "db-pattern-4"
+table-name = "table-pattern-4"
+
+[[black-white-list.ignore-tables]]
+db-name = "db-pattern-5"
+table-name = "table-pattern-5"
+```
+
+If the qualified name of a table matched *any* pair of patterns in the `do-tables` array, the table will be included.
+
+Otherwise, if the qualified name matched *any* pair of patterns in the `ignore-tables` array, the table will be skipped.
+
+If a table’s qualified name matched *both* the `do-tables` and `ignore-tables` arrays, the table will be included.
+
+Note that the database filtering rules are applied before considering the table filtering rules. This means if a database is ignored by `ignore-dbs`, all tables inside this database will not be considered even if they matched any `do-tables` array.
+
+## Example
+
+To illustrate how these rules work, let’s suppose the data source contains the following tables:
+
+```
+`logs`.`messages_2016`
+`logs`.`messages_2017`
+`logs`.`messages_2018`
+`forum`.`users`
+`forum`.`messages`
+`forum_backup_2016`.`messages`
+`forum_backup_2017`.`messages`
+`forum_backup_2018`.`messages`
+```
+
+Using this configuration:
+
+```toml
+[black-white-list]
+do-dbs = [
+    "forum_backup_2018",            # rule A
+    "forum",                        # rule B
+]
+ignore-dbs = [
+    "~^forum_backup_",              # rule C
+]
+
+[[black-white-list.do-tables]]      # rule D
+db-name = "logs"
+table-name = "~_2018$"
+
+[[black-white-list.ignore-tables]]  # rule E
+db-name = "~.*"
+table-name = "~^messages.*"
+
+[[black-white-list.do-tables]]      # rule F
+db-name = "~^forum.*"
+table-name = "messages"
+```
+
+First we apply the database rules:
+
+| Database                  | Outcome                                    |
+|---------------------------|--------------------------------------------|
+| `` `logs` ``              | Included by default                        |
+| `` `forum` ``             | Included by rule B                         |
+| `` `forum_backup_2016` `` | Skipped by rule C                          |
+| `` `forum_backup_2017` `` | Skipped by rule C                          |
+| `` `forum_backup_2018` `` | Included by rule A (rule C will not apply) |
+
+Then we apply the table rules:
+
+| Table                                | Outcome                                    |
+|--------------------------------------|--------------------------------------------|
+| `` `logs`.`messages_2016` ``         | Skipped by rule E                          |
+| `` `logs`.`messages_2017` ``         | Skipped by rule E                          |
+| `` `logs`.`messages_2018` ``         | Included by rule D (rule E will not apply) |
+| `` `forum`.`users` ``                | Included by default                        |
+| `` `forum`.`messages` ``             | Included by rule F (rule E will not apply) |
+| `` `forum_backup_2016`.`messages` `` | Skipped, since is database already skipped |
+| `` `forum_backup_2017`.`messages` `` | Skipped, since is database already skipped |
+| `` `forum_backup_2018`.`messages` `` | Included by rule F (rule E will not apply) |

--- a/tools/lightning/monitor.md
+++ b/tools/lightning/monitor.md
@@ -125,7 +125,7 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
 - **`lightning_block_read_seconds`** (Histogram)
 
-    Bucketed histogram of the time needed to read a block of SQL rows from the data source
+    Bucketed histogram of the time needed to read a block of SQL rows from the data source.
 
 - **`lightning_block_read_bytes`** (Histogram)
 

--- a/tools/lightning/monitor.md
+++ b/tools/lightning/monitor.md
@@ -110,7 +110,7 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
     Counting number of tables processed and their status. Labels:
 
-    - **state**: `pending` / `written` / `closed` / `imported` / `altered_auto_inc` / `checksum` / `completed`
+    - **state**: `pending` / `written` / `closed` / `imported` / `altered_auto_inc` / `checksum` / `analyzed` / `completed`
     - **result**: `success` / `failure`
 
 - **`lightning_chunks`** (Counter)
@@ -118,3 +118,31 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
     Counting number of chunks processed and their status. Labels:
 
     - **state**: `estimated` / `pending` / `running` / `finished` / `failed`
+
+- **`lightning_import_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed to import a table.
+
+- **`lightning_block_read_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed to read a block of SQL rows from the data source
+
+- **`lightning_block_read_bytes`** (Histogram)
+
+    Bucketed histogram of the size of a block of SQL rows.
+
+- **`lightning_block_encode_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed to encode a block of SQL rows into KV pairs.
+
+- **`lightning_block_deliver_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed to deliver a block of KV pairs.
+
+- **`lightning_block_deliver_bytes`** (Histogram)
+
+    Bucketed histogram of the size of a block of KV pairs.
+
+- **`lightning_checksum_seconds`** (Histogram)
+
+    Bucketed histogram of the time taken to compute the checksum of a table.

--- a/tools/lightning/overview-architecture.md
+++ b/tools/lightning/overview-architecture.md
@@ -31,8 +31,8 @@ The complete import process is as follows:
 
 4. Once a full table of KV pairs are received, `tikv-importer` divides and schedules these data and imports them into the target TiKV cluster.
 
-5. `tidb-lightning` then performs a checksum comparison between the local data source and those calculated from the cluster, to ensure there is no data corruption in the process.
+5. `tidb-lightning` then performs a checksum comparison between the local data source and those calculated from the cluster, to ensure there is no data corruption in the process, and tells TiDB to `ANALYZE` all imported tables, to prepare for optimal query planning.
 
-6. After all tables are imported, `tidb-lightning` performs a global compaction on the TiKV cluster, and tells TiDB to `ANALYZE` all imported tables, to prepare for optimal query planning.
+6. After all tables are imported, `tidb-lightning` performs a global compaction on the TiKV cluster.
 
 7. Finally, `tidb-lightning` switches the TiKV cluster back to "normal mode", so the cluster resumes normal services.


### PR DESCRIPTION
* Added description of the table filter (black-white-list)
* Included the new metrics
* Use a permanent download link for ~~v2.1.0~~ ~~v2.1.1~~ v2.1.2; added download link for latest build
* Included a brief description what flags should be passed to mydumper (mostly copied from the Migration Guide, but adjusted for Lightning)
* Included several new config flags
* Included troubleshooting for timezone issues
* Checkpoints can be stored as a local file now; updated descriptions