### PR TITLE
Add FLUSH PRIVILEGES hint to user-account-management.md and FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -104,6 +104,7 @@ The display content of TiDB `show processlist` is almost the same as that of MyS
 #### How to modify the user password and privilege?
 
 To modify the user password in TiDB, it is recommended to use `set password for 'root'@'%' = '0101001';` or `alter`, not `update mysql.user` which might lead to the condition that the password in other nodes is not refreshed timely.
+Run `FLUSH PRIVILEGES` to apply changed permissions immediately.
 
 It is recommended to use the official standard statements when modifying the user password and privilege. For details, see [TiDB user account management](sql/user-account-management.md).
 

--- a/sql/user-account-management.md
+++ b/sql/user-account-management.md
@@ -43,6 +43,7 @@ mysql> GRANT ALL PRIVILEGES ON *.* TO 'finley'@'%' WITH GRANT OPTION;
 mysql> CREATE USER 'admin'@'localhost' IDENTIFIED BY 'admin_pass';
 mysql> GRANT RELOAD,PROCESS ON *.* TO 'admin'@'localhost';
 mysql> CREATE USER 'dummy'@'localhost';
+mysql> FLUSH PRIVILEGES;
 ```
 
 To see the privileges for an account, use `SHOW GRANTS`:
@@ -93,3 +94,13 @@ Or:
 ```sql
 ALTER USER 'jeffrey'@'localhost' IDENTIFIED BY 'mypass';
 ```
+
+## Flush privileges 
+
+Please run the following command to apply changed permissions immediately:
+
+```sql
+FLUSH PRIVILEGES;
+```
+
+See [Privilege Management](privilege.md) for details.


### PR DESCRIPTION
It looked like FLUSH PRIVILEGES is not implemented because of pingcap/tidb#674. user-account-management.md also didn't mention it. I've added to all relevant pages.