### PR TITLE
tools: update docs for Lightning

### DIFF
--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -43,8 +43,6 @@ To achieve the best performance, it is recommended to use the following hardware
     - 10 Gigabit network card (should be capable of transferring at ≥300 MB/s)
     - `tikv-importer` fully consumes all CPU, disk I/O and network bandwidth when running,
         and deploying on a dedicated machine is strongly recommended.
-        If not possible, `tikv-importer` could be deployed together with other components like
-        `tikv-server`, but the import speed might be affected.
 
 If you have sufficient machines, you can deploy multiple Lightning/Importer servers, with each working on a distinct set of tables, to import the data in parallel.
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -268,10 +268,17 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # This value affects the memory usage of tikv-importer.
     # Must not exceed the max-open-engines setting for tikv-importer.
     table-concurrency = 8
+
     # The concurrency number of data. It is set to the number of logical CPU
     # cores by default. When deploying together with other components, you can
     # set it to 75% of the size of logical CPU cores to limit the CPU usage.
     #region-concurrency =
+
+    # The maximum IO concurrency. Excessive IO concurrency causes increase in
+    # IO latency because the disk's internal buffer is frequently refreshed,
+    # causing, cache miss and slow down read speed. Depending on the storage
+    # medium, this value may need to adjusted for optimal performance.
+    io-concurrency = 5
 
     # Logging
     level = "info"

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -29,7 +29,7 @@ To achieve the best performance, it is recommended to use the following hardware
 
     - 32+ logical cores CPU
     - An SSD large enough to store the entire SQL dump, preferring higher read speed
-    - 10 Gigabit network card (should be capable of transferring at ≥300 MB/s)
+    - 10 Gigabit network card (capable of transferring at ≥300 MB/s)
     - `tidb-lightning` fully consumes all CPU cores when running,
         and deploying on a dedicated machine is highly recommended.
         If not possible, `tidb-lightning` could be deployed together with other components like
@@ -40,7 +40,7 @@ To achieve the best performance, it is recommended to use the following hardware
     - 32+ logical cores CPU
     - 32 GB+ memory
     - 1 TB+ SSD, preferring higher IOPS (≥ 8000 is recommended)
-    - 10 Gigabit network card (should be capable of transferring at ≥300 MB/s)
+    - 10 Gigabit network card (capable of transferring at ≥300 MB/s)
     - `tikv-importer` fully consumes all CPU, disk I/O and network bandwidth when running,
         and deploying on a dedicated machine is strongly recommended.
 
@@ -262,10 +262,10 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # set it to 75% of the size of logical CPU cores to limit the CPU usage.
     #region-concurrency =
 
-    # The maximum IO concurrency. Excessive IO concurrency causes increase in
-    # IO latency because the disk's internal buffer is frequently refreshed,
-    # causing, cache miss and slow down read speed. Depending on the storage
-    # medium, this value may need to adjusted for optimal performance.
+    # The maximum I/O concurrency. Excessive I/O concurrency causes an increase in
+    # I/O latency because the disk's internal buffer is frequently refreshed,
+    # which causes the cache miss and slows down the read speed. Depending on the storage
+    # medium, this value might need to be adjusted for optimal performance.
     io-concurrency = 5
 
     # Logging

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -213,7 +213,7 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
 
     [import]
     # The directory to store engine files.
-    import-dir = "/tmp/tikv/import"
+    import-dir = "/mnt/ssd/data.import/"
     # Number of threads to handle RPC requests.
     num-threads = 16
     # Number of concurrent import jobs.

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -313,9 +313,6 @@ Download the TiDB-Lightning package (choose the same version as that of the TiDB
     # Block size for file reading. Keep it longer than the longest string of
     # the data source.
     read-block-size = 65536 # Byte (default = 64 KB)
-    # Each data file is split into multiple chunks of this size. Each chunk
-    # is processed in parallel.
-    region-min-size = 268435456 # Byte (default = 256 MB)
     # mydumper local source data directory
     data-source-dir = "/data/my_database"
     # If no-schema is set to true, tidb-lightning assumes that the table skeletons

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -21,18 +21,15 @@ Before starting TiDB-Lightning, note that:
 
 ## Hardware requirements
 
-`tidb-lightning` and `tikv-importer` are both resource-intensive programs. It is recommended to deploy them into two separate machines. If your hardware resources are limited, you can deploy `tidb-lightning` and `tikv-importer` on the same machine.
-
-### Hardware requirements of separate deployment
+`tidb-lightning` and `tikv-importer` are both resource-intensive programs. It is recommended to deploy them into two separate machines.
 
 To achieve the best performance, it is recommended to use the following hardware configuration:
 
 - `tidb-lightning`:
 
     - 32+ logical cores CPU
-    - 16 GB+ memory
-    - 1 TB+ SSD, preferring higher read speed
-    - 10 Gigabit network card
+    - An SSD large enough to store the entire SQL dump, preferring higher read speed
+    - 10 Gigabit network card (should be capable of transferring at ≥300 MB/s)
     - `tidb-lightning` fully consumes all CPU cores when running,
         and deploying on a dedicated machine is highly recommended.
         If not possible, `tidb-lightning` could be deployed together with other components like
@@ -42,25 +39,14 @@ To achieve the best performance, it is recommended to use the following hardware
 
     - 32+ logical cores CPU
     - 32 GB+ memory
-    - 1 TB+ SSD, preferring higher IOPS
-    - 10 Gigabit network card
+    - 1 TB+ SSD, preferring higher IOPS (≥ 8000 is recommended)
+    - 10 Gigabit network card (should be capable of transferring at ≥300 MB/s)
     - `tikv-importer` fully consumes all CPU, disk I/O and network bandwidth when running,
         and deploying on a dedicated machine is strongly recommended.
         If not possible, `tikv-importer` could be deployed together with other components like
         `tikv-server`, but the import speed might be affected.
 
 If you have sufficient machines, you can deploy multiple Lightning/Importer servers, with each working on a distinct set of tables, to import the data in parallel.
-
-### Hardware requirements of mixed deployment
-
-If your hardware resources are severely under constraint, it is possible to deploy `tidb-lightning` and `tikv-importer` and other components on the same machine, but the import performance is affected.
-
-It is recommended to use the following configuration of the single machine:
-
-- 32+ logical cores CPU
-- 32 GB+ memory
-- 1 TB+ SSD, preferring higher IOPS
-- 10 Gigabit network card
 
 > **Notes:** `tidb-lightning` is a CPU intensive program. In an environment with mixed components, the resources allocated to `tidb-lightning` must be limited. Otherwise, other components might not be able to run. It is recommended to set the `region-concurrency` to 75% of CPU logical cores. For instance, if the CPU has 32 logical cores, you can set the `region-concurrency` to 24.
 

--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -50,6 +50,10 @@ If you have sufficient machines, you can deploy multiple Lightning/Importer serv
 
 > **Notes:** `tidb-lightning` is a CPU intensive program. In an environment with mixed components, the resources allocated to `tidb-lightning` must be limited. Otherwise, other components might not be able to run. It is recommended to set the `region-concurrency` to 75% of CPU logical cores. For instance, if the CPU has 32 logical cores, you can set the `region-concurrency` to 24.
 
+Additionally, the target TiKV cluster should have enough space to absorb the new data.
+Besides [the standard requirements](../../op-guide/recommendation.md), the total free space of the target TiKV cluster should be larger than **Size of SQL dump × [Number of replicas](../../FAQ.md#is-the-number-of-replicas-in-each-region-configurable-if-yes-how-to-configure-it) × 2**.
+With the default replica count of 3, this means the total free space should be at least 6 times the size of SQL dump.
+
 ## Export data
 
 Use the [`mydumper` tool](../../tools/mydumper.md) to export data from MySQL by using the following command:

--- a/tools/lightning/errors.md
+++ b/tools/lightning/errors.md
@@ -12,7 +12,7 @@ This document summarizes some commonly encountered errors in the `tidb-lightning
 
 ## Import speed is too slow
 
-Normally it takes Lightning 2 minutes per thread to import a 256 MB Chunk. It is an error if the speed is much slower than this. The time taken for each chunk can be checked from the log mentioning `restore chunk … takes`. This can also be observed from metrics on Grafana.
+Normally it takes Lightning 2 minutes per thread to import a 256 MB data file. It is an error if the speed is much slower than this. The time taken for each data file can be checked from the log mentioning `restore chunk … takes`. This can also be observed from metrics on Grafana.
 
 There are several reasons why Lightning becomes slow:
 

--- a/tools/lightning/faq.md
+++ b/tools/lightning/faq.md
@@ -105,3 +105,16 @@ If `tidb-lightning` abnormally exited, the cluster might be stuck in the "import
 ```sh
 tidb-lightning-ctl --switch-mode=normal
 ```
+
+## Can TiDB-Lightning be used with 1-Gigabit network card?
+
+The TiDB-Lightning toolset requires a 10-Gigabit network card. The 1-Gigabit network card is *not acceptable*, especially for `tikv-importer`.
+A 1-Gigabit network card can only provide a total bandwidth of 120 MB/s, which has to be shared among all target TiKV stores.
+TiDB-Lightning can easily saturate all bandwidth of the 1-Gigabit network, and brings down the cluster as PD is unable to contact it anymore.
+
+## Why TiDB-Lightning requires so much free space in the target TiKV cluster?
+
+With the default settings of 3 replicas, the space requirement of the target TiKV cluster is 6 times the size of SQL dump. The extra multiple of “2” is a conservative estimation for factors not reflected in the SQL dump:
+
+1. The SQL dump does not include space occupied by indices
+2. Space amplification in RocksDB

--- a/tools/lightning/faq.md
+++ b/tools/lightning/faq.md
@@ -110,11 +110,11 @@ tidb-lightning-ctl --switch-mode=normal
 
 The TiDB-Lightning toolset requires a 10-Gigabit network card. The 1-Gigabit network card is *not acceptable*, especially for `tikv-importer`.
 A 1-Gigabit network card can only provide a total bandwidth of 120 MB/s, which has to be shared among all target TiKV stores.
-TiDB-Lightning can easily saturate all bandwidth of the 1-Gigabit network, and brings down the cluster as PD is unable to contact it anymore.
+TiDB-Lightning can easily saturate all bandwidth of the 1-Gigabit network, and brings down the cluster because PD is unable to contact it anymore.
 
 ## Why TiDB-Lightning requires so much free space in the target TiKV cluster?
 
-With the default settings of 3 replicas, the space requirement of the target TiKV cluster is 6 times the size of SQL dump. The extra multiple of “2” is a conservative estimation for factors not reflected in the SQL dump:
+With the default settings of 3 replicas, the space requirement of the target TiKV cluster is 6 times the size of SQL dump. The extra multiple of “2” is a conservative estimation because the following factors are not reflected in the SQL dump:
 
-1. The SQL dump does not include space occupied by indices
-2. Space amplification in RocksDB
+- The space occupied by indices
+- Space amplification in RocksDB

--- a/tools/lightning/monitor.md
+++ b/tools/lightning/monitor.md
@@ -145,11 +145,11 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
 - **`lightning_chunk_parser_read_block_seconds`** (Histogram)
 
-    Bucketed histogram of the time needed for the data file parser read a block.
+    Bucketed histogram of the time needed by the data file parser to read a block.
 
 - **`lightning_chunk_parser_read_row_seconds`** (Histogram)
 
-    Bucketed histogram of the time needed for the data file parser read a row.
+    Bucketed histogram of the time needed by the data file parser to read a row.
 
 - **`lightning_checksum_seconds`** (Histogram)
 
@@ -157,6 +157,6 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
 - **`lightning_apply_worker_seconds`** (Histogram)
 
-    Bucketed histogram of the time taken acquire an idle worker. Labels:
+    Bucketed histogram of the time taken to acquire an idle worker. Labels:
 
     - **name**: `table` / `region` / `io`

--- a/tools/lightning/monitor.md
+++ b/tools/lightning/monitor.md
@@ -96,9 +96,9 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
 - **`lightning_idle_workers`** (Gauge)
 
-    Counting idle workers. Values should be less than the `table-concurrency`/`region-concurrency` settings and are typically zero. Labels:
+    Counting idle workers. Values should be less than the `*-concurrency` settings and are typically zero. Labels:
 
-    - **name**: `table` / `region`
+    - **name**: `table` / `region` / `io`
 
 - **`lightning_kv_encoder`** (Counter)
 
@@ -143,6 +143,20 @@ Metrics provided by `tidb-lightning` are listed under the namespace `lightning_*
 
     Bucketed histogram of the size of a block of KV pairs.
 
+- **`lightning_chunk_parser_read_block_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed for the data file parser read a block.
+
+- **`lightning_chunk_parser_read_row_seconds`** (Histogram)
+
+    Bucketed histogram of the time needed for the data file parser read a row.
+
 - **`lightning_checksum_seconds`** (Histogram)
 
     Bucketed histogram of the time taken to compute the checksum of a table.
+
+- **`lightning_apply_worker_seconds`** (Histogram)
+
+    Bucketed histogram of the time taken acquire an idle worker. Labels:
+
+    - **name**: `table` / `region` / `io`


### PR DESCRIPTION
1. Updated the config to include the new `io-concurrency` setting, and delete the `region-min-size` setting.
2. Included several new metrics introduced recently.
3. **Removed description about mixed deployment** (putting Lightning and Importer together). This deployment mode causes too many problem in the past and is no longer officially supported.
4. Clarified some SSD and network requirement with explicit numbers.
5. **Clarified the space requirement of the TiKV cluster** (6 × SQL size). 