### PR TITLE
README, dm: update the files that refer to "manually-handling-sharding-ddl-locks.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
       + Sharding Support
         - [Introduction](/tools/dm/sharding-solution.md)
         - [Restrictions](/tools/dm/sharding-solution.md#sharding-ddl-usage-restrictions)
-        - [Troubleshoot](/tools/dm/troubleshooting-sharding-ddl-locks.md)
+        - [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md)
     + Usage Scenarios
       - [Simple Scenario](/tools/dm/simple-synchronization-scenario.md)
       - [Shard Merge Scenario](/tools/dm/shard-merge-scenario.md)

--- a/tools/dm/cluster-operations.md
+++ b/tools/dm/cluster-operations.md
@@ -71,7 +71,7 @@ The information maintained by DM-master includes the following two major types, 
 
 When DM-master is restarted, it automatically requests the task information from each DM-worker instance and rebuilds the corresponding relationship between the task and DM-worker. However, at this time, DM-worker does not resend the sharding DDL information, so it might occur that the sharding DDL lock synchronization cannot be finished automatically because of the lost lock information.
 
-To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
+To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md).
 
 #### Restarting dmctl considerations
 

--- a/tools/dm/cluster-operations.md
+++ b/tools/dm/cluster-operations.md
@@ -60,7 +60,7 @@ For the binlog during incremental data import, DM uses the downstream database t
 
         At this time, DM tries again to synchronize these DDL statements that are not skipped. However, the restarted DM-worker instances will be blocked at the position of the binlog event corresponding to the DDL binlog event, because the DM-worker instance that is not restarted has executed to the place after this DDL binlog event.
 
-        To resolve this issue, follow the steps described in [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks.md#condition-two-a-dm-worker-restarts-or-is-unreachable-temporarily)
+        To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md#some-dm-workers-restart-during-the-ddl-unlocking-process).
 
 #### Restarting DM-master considerations
 
@@ -71,7 +71,7 @@ The information maintained by DM-master includes the following two major types, 
 
 When DM-master is restarted, it automatically requests the task information from each DM-worker instance and rebuilds the corresponding relationship between the task and DM-worker. However, at this time, DM-worker does not resend the sharding DDL information, so it might occur that the sharding DDL lock synchronization cannot be finished automatically because of the lost lock information.
 
-To resolve this issue, follow the steps described in [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks.md#condition-three-dm-master-restarts).
+To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
 
 #### Restarting dmctl considerations
 

--- a/tools/dm/cluster-operations.md
+++ b/tools/dm/cluster-operations.md
@@ -60,7 +60,7 @@ For the binlog during incremental data import, DM uses the downstream database t
 
         At this time, DM tries again to synchronize these DDL statements that are not skipped. However, the restarted DM-worker instances will be blocked at the position of the binlog event corresponding to the DDL binlog event, because the DM-worker instance that is not restarted has executed to the place after this DDL binlog event.
 
-        To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md#some-dm-workers-restart-during-the-ddl-unlocking-process).
+        To resolve this issue, follow the steps described in [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md#some-dm-workers-restart-during-the-ddl-unlocking-process).
 
 #### Restarting DM-master considerations
 

--- a/tools/dm/manage-task.md
+++ b/tools/dm/manage-task.md
@@ -555,7 +555,7 @@ update-task [-w "127.0.0.1:10181"] ./task.yaml
 
 ## Manage the DDL locks
 
-See [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks.md).
+See [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
 
 ## Refresh worker tasks
 

--- a/tools/dm/manage-task.md
+++ b/tools/dm/manage-task.md
@@ -555,7 +555,7 @@ update-task [-w "127.0.0.1:10181"] ./task.yaml
 
 ## Manage the DDL locks
 
-See [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
+See [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md).
 
 ## Refresh worker tasks
 

--- a/tools/dm/overview.md
+++ b/tools/dm/overview.md
@@ -95,4 +95,4 @@ Before using the DM tool, note the following restrictions:
 
     - After DM-worker is restarted, the data synchronization task cannot be automatically restored. You need to manually run `start-task`. For details, see [Manage the Data Synchronization Task](/tools/dm/manage-task.md).
 
-    - After DM-worker or DM-master is restarted, the DDL lock synchronization cannot be automatically restored in some conditions. You need to manually handle it. For details, see [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks.md).
+    - After DM-worker or DM-master is restarted, the DDL lock synchronization cannot be automatically restored in some conditions. You need to manually handle it. For details, see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).

--- a/tools/dm/overview.md
+++ b/tools/dm/overview.md
@@ -95,4 +95,4 @@ Before using the DM tool, note the following restrictions:
 
     - After DM-worker is restarted, the data synchronization task cannot be automatically restored. You need to manually run `start-task`. For details, see [Manage the Data Synchronization Task](/tools/dm/manage-task.md).
 
-    - After DM-worker or DM-master is restarted, the DDL lock synchronization cannot be automatically restored in some conditions. You need to manually handle it. For details, see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
+    - After DM-worker or DM-master is restarted, the DDL lock synchronization cannot be automatically restored in some conditions. You need to manually handle it. For details, see [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md).

--- a/tools/dm/query-status.md
+++ b/tools/dm/query-status.md
@@ -182,7 +182,7 @@ This document introduces the query result and subtask status of Data Migration (
 ```
 
 For the status description and status switch relationship of "stage" of "subTaskStatus" of "workers", see [Subtask status](#subtask-status).
-For operation details of "unresolvedDDLLockID" of "subTaskStatus" of "workers", see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
+For operation details of "unresolvedDDLLockID" of "subTaskStatus" of "workers", see [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md).
 
 ## Subtask status
 

--- a/tools/dm/query-status.md
+++ b/tools/dm/query-status.md
@@ -182,7 +182,7 @@ This document introduces the query result and subtask status of Data Migration (
 ```
 
 For the status description and status switch relationship of "stage" of "subTaskStatus" of "workers", see [Subtask status](#subtask-status).
-For operation details of "unresolvedDDLLockID" of "subTaskStatus" of "workers", see [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks/).
+For operation details of "unresolvedDDLLockID" of "subTaskStatus" of "workers", see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
 
 ## Subtask status
 

--- a/tools/dm/sharding-solution.md
+++ b/tools/dm/sharding-solution.md
@@ -8,7 +8,7 @@ category: tools
 
 This document introduces the sharding solution provided by Data Migration, its background, design details, and sharding DDL restrictions.
 
-Data Migration supports merging the data of multiple sharded MySQL instances and tables into a single TiDB instance. Generally, Data Migration does it automatically and you need to do nothing. But when some abnormal conditions occur, you need to handle them manually. For details, see [Troubleshooting Sharding DDL Locks](/tools/dm/troubleshooting-sharding-ddl-locks.md).
+Data Migration supports merging the data of multiple sharded MySQL instances and tables into a single TiDB instance. Generally, Data Migration does it automatically and you need to do nothing. But when some abnormal conditions occur, you need to handle them manually. For details, see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
 
 ## Background
 

--- a/tools/dm/sharding-solution.md
+++ b/tools/dm/sharding-solution.md
@@ -8,7 +8,7 @@ category: tools
 
 This document introduces the sharding solution provided by Data Migration, its background, design details, and sharding DDL restrictions.
 
-Data Migration supports merging the data of multiple sharded MySQL instances and tables into a single TiDB instance. Generally, Data Migration does it automatically and you need to do nothing. But when some abnormal conditions occur, you need to handle them manually. For details, see [Manual Solution](/tools/dm/manually-handle-sharding-ddl-locks.md).
+Data Migration supports merging the data of multiple sharded MySQL instances and tables into a single TiDB instance. Generally, Data Migration does it automatically and you need to do nothing. But when some abnormal conditions occur, you need to handle them manually. For details, see [Manual Solution](/tools/dm/manually-handling-sharding-ddl-locks.md).
 
 ## Background
 


### PR DESCRIPTION
Because the original "troubleshooting-sharding-ddl-locks.md" has been renamed to "manually-handling-sharding-ddl-locks.md", I updated the README file and all the DM files that refer to this file. PTAL. @GregoryIan 