### PR TITLE
tools: harmonize download links

### DIFF
--- a/tools/loader.md
+++ b/tools/loader.md
@@ -10,7 +10,7 @@ category: tools
 
 Loader is a data import tool to load data to TiDB.
 
-[Download the Binary](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz).
+It can be [downloaded](../tools/download.md) as part of the Enterprise Tools package.
 
 ## Why did we develop Loader?
 

--- a/tools/mydumper.md
+++ b/tools/mydumper.md
@@ -10,7 +10,7 @@ category: tools
 
 `mydumper` is a fork of the [mydumper](https://github.com/maxbube/mydumper) project with additional functionality specific to TiDB. It is the recommended method to use for logical backups of TiDB.
 
-[Download the Binary](http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz).
+It can be [downloaded](../tools/download.md) as part of the Enterprise Tools package.
 
 ## What enhancements does this contain over regular mydumper?
 

--- a/tools/syncer.md
+++ b/tools/syncer.md
@@ -8,26 +8,13 @@ category: tools
 
 ## About Syncer
 
-Syncer is a tool used to import data incrementally. It is a part of the TiDB enterprise toolset. To obtain Syncer, see [Download the TiDB enterprise toolset](#download-the-tidb-enterprise-toolset-linux).
+Syncer is a tool used to import data incrementally. It is a part of the TiDB enterprise toolset. 
+
+It can be [downloaded](../tools/download.md) as part of the Enterprise Tools package.
 
 ## Syncer architecture
 
 ![syncer sharding](../media/syncer_architecture.png)
-
-## Download the TiDB enterprise toolset (Linux)
-
-```bash
-# Download the tool package.
-wget http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz
-wget http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.sha256
-
-# Check the file integrity. If the result is OK, the file is correct.
-sha256sum -c tidb-enterprise-tools-latest-linux-amd64.sha256
-
-# Extract the package.
-tar -xzf tidb-enterprise-tools-latest-linux-amd64.tar.gz
-cd tidb-enterprise-tools-latest-linux-amd64
-```
 
 ## Where to deploy Syncer
 

--- a/tools/tidb-binlog.md
+++ b/tools/tidb-binlog.md
@@ -33,20 +33,9 @@ Drainer collects binlog files from each Pump node, converts them into specified 
 
 ## Install TiDB-Binlog
 
-### Download Binary for the CentOS 7.3+ platform
+### Download
 
-```bash
-# Download the tool package.
-wget http://download.pingcap.org/tidb-binlog-latest-linux-amd64.tar.gz
-wget http://download.pingcap.org/tidb-binlog-latest-linux-amd64.sha256
-
-# Check the file integrity. If the result is OK, the file is correct. 
-sha256sum -c tidb-binlog-latest-linux-amd64.sha256
-
-# Extract the package.
-tar -xzf tidb-binlog-latest-linux-amd64.tar.gz
-cd tidb-binlog-latest-linux-amd64
-```
+TiDB-Binlog can be [downloaded](../tools/download.md) as part of the Enterprise Tools package.
 
 ### Deploy TiDB-Binlog
 


### PR DESCRIPTION
The other manual pages have direct links to download.  We should harmonize on `download.md`.