### PR TITLE
tikv: fix the transactional API example

### DIFF
--- a/tikv/go-client-api.md
+++ b/tikv/go-client-api.md
@@ -202,7 +202,7 @@ import (
     "github.com/juju/errors"
     "github.com/pingcap/tidb/kv"
     "github.com/pingcap/tidb/store/tikv"
-    "github.com/pingcap/tidb/terror"
+    "github.com/pingcap/parser/terror"
 
     goctx "golang.org/x/net/context"
 )


### PR DESCRIPTION
This PR fixes the transactional API example. The related issue is tikv/client-go#4.