### PR TITLE
sql: update wording

### DIFF
--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -97,9 +97,9 @@ mysql> EXPLAIN ANALYZE SELECT count(*) FROM trips WHERE start_date BETWEEN '2017
 
 ### Introduction to task
 
-Currently, there are two types of task execution: cop tasks and root tasks. A cop task refers to a computing task that is executed using TiKV Coprocessor. A root task refers to a computing task that is executed in TiDB.
+Currently, there are two types of task execution: cop tasks and root tasks. A cop task refers to a computing task that is executed using the TiKV coprocessor. A root task refers to a computing task that is executed in TiDB.
 
-One of the goals of SQL optimization is to push the calculation down to TiKV as much as possible. Coprocessor is able to assist in execution of SQL functions (both aggregate and scalar), SQL `LIMIT` operations, index scans, and table scans. All join operations, however, will be performed as root tasks.
+One of the goals of SQL optimization is to push the calculation down to TiKV as much as possible. The TiKV coprocessor is able to assist in execution of SQL functions (both aggregate and scalar), SQL `LIMIT` operations, index scans, and table scans. All join operations, however, will be performed as root tasks.
 
 ### Table data and index data
 

--- a/sql/understanding-the-query-execution-plan.md
+++ b/sql/understanding-the-query-execution-plan.md
@@ -97,9 +97,9 @@ mysql> EXPLAIN ANALYZE SELECT count(*) FROM trips WHERE start_date BETWEEN '2017
 
 ### Introduction to task
 
-Currently, there are two types of task execution: cop tasks and root tasks. A cop task refers to a computing task that is executed using the coprocessor in TiKV. A root task refers to a computing task that is executed in TiDB.
+Currently, there are two types of task execution: cop tasks and root tasks. A cop task refers to a computing task that is executed using TiKV Coprocessor. A root task refers to a computing task that is executed in TiDB.
 
-One of the goals of SQL optimization is to push the calculation down to TiKV as much as possible. The coprocessor is able to assist in execution of SQL functions (both aggregate and scalar), SQL `LIMIT` operations, index scans, and table scans. All join operations, however, will be performed as root tasks.
+One of the goals of SQL optimization is to push the calculation down to TiKV as much as possible. Coprocessor is able to assist in execution of SQL functions (both aggregate and scalar), SQL `LIMIT` operations, index scans, and table scans. All join operations, however, will be performed as root tasks.
 
 ### Table data and index data
 


### PR DESCRIPTION
As @zz-jason said, our "Coprocessor" in TiKV is not the same as a coprocessor with a conventional meaning “a microprocessor circuit that operates alongside and supplements the capabilities of the main processor, providing, for example, high-speed arithmetic”. Therefore, we replace "the coprocessor in TiKV" with "TiKV Coprocessor".

@morgo @lilin90 @zz-jason PTAL ^_^