### PR TITLE
report-issue, contribute, support: new documents

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -1,0 +1,26 @@
+# Contribute
+
+## Contribute to TiDB
+
+We recommend starting with an existing issue with the [help-wanted](https://github.com/pingcap/tidb/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) label. These issues are well suited for new contributors. 
+
+If a PR (Pull Request) submitted to the [TiDB/TiKV/TiSpark/PD/Docs/Docs-cn](https://github.com/pingcap) projects by you is approved and merged, then you become a TiDB Contributor. 
+
+Before submitting a pull request, sign the [CLA](https://cla-assistant.io/pingcap/tidb?pullRequest=5567).
+
+If you want to work on a new idea of relatively small scope:
+
+1. Submit an issue describing your proposed change to the repo in question.
+2. The repo owners will respond to your issue promptly.
+3. If your proposed change is accepted, sign the [CLA](https://cla-assistant.io/pingcap/tidb?pullRequest=5567), and start work in your fork.
+4. Submit a [pull request](https://github.com/pingcap/tidb/pull/3113) containing a tested change. 
+
+Contributions are welcomed and greatly appreciated. See [CONTRIBUTING.md](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+
+## Improve the Docs
+
+We welcome contributions to help improve the documentation!
+
+The TiDB docs are written in Markdown and use the [Google Developer Documentation Style Guide](https://developers.google.com/style/). Don't worry if this is new to you, we are happy to guide you along the way.
+
+To contribute, please fork the [docs repository](https://github.com/pingcap/docs) and send a Pull Request.

--- a/report-issue.md
+++ b/report-issue.md
@@ -1,0 +1,5 @@
+# Report an Issue
+
+We strive to make TiDB compatible with MySQL 5.7. If you discover a difference in behavior that is not documented, a bug, or strange performance characteristics please [create a new issue in GitHub](https://github.com/pingcap/tidb/issues).
+
+You may use GitHub issues for Bug Reports, Feature Requests, General Questions and Performance Questions. Please make sure that you fill out the issue template completely so we can respond appropriately.

--- a/support.md
+++ b/support.md
@@ -1,0 +1,12 @@
+# Support Resources
+
+You can reach out to the community members via any one of the following ways: 
+
++ Google Groups: [https://groups.google.com/forum/#!forum/tidb-user](https://groups.google.com/forum/#!forum/tidb-user)
++ Stack Overflow: [https://stackoverflow.com/questions/tagged/tidb](https://stackoverflow.com/questions/tagged/tidb)
++ Twitter: [https://twitter.com/PingCAP](https://twitter.com/PingCAP)
++ Facebook: [https://www.facebook.com/pingcap2015](https://www.facebook.com/pingcap2015)
++ Reddit: [https://www.reddit.com/r/TiDB](https://www.reddit.com/r/TiDB)
++ GitHub: [https://github.com/pingcap/tidb/issues](https://github.com/pingcap/tidb/issues)
+
+Please [contact us](https://pingcap.com/contact-us/) for more information on Enterprise support contracts.


### PR DESCRIPTION
(There are a few very safe changes in the DITA re-org we can make now. This pre-work helps reduce the scope of the conversion.)

This adds new content which will be used in the DITA version of the manual