### PR TITLE
sql: update constraints to show lazy checking occurs on primary key too

### DIFF
--- a/sql/constraints.md
+++ b/sql/constraints.md
@@ -4,7 +4,7 @@
 
 TiDB supports the same basic constraints supported in MySQL with the follwing exceptions:
 
-- `UNIQUE` constraints are checked lazily by default. By batching checks until when the transaction commits, TiDB is able to reduce network communication. This behavior can be changed by setting `tidb_constraint_check_in_place` to `TRUE`.
+- `PRIMARY KEY` and `UNIQUE` constraints are checked lazily by default. By batching checks until when the transaction commits, TiDB is able to reduce network communication. This behavior can be changed by setting `tidb_constraint_check_in_place` to `TRUE`.
 
 - `FOREIGN KEY` constraints are not currently enforced by DML.
 
@@ -81,7 +81,18 @@ Query OK, 1 row affected (0.03 sec)
 
 ## Primary Key
 
-TiDB supports `PRIMARY KEY` constraints with similar semantics to MySQL. For example:
+In TiDB, `PRIMARY KEY` constraints are checked lazily by default. By batching checks until when the transaction commits, TiDB is able to reduce network communication. For example:
+
+```
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+START TRANSACTION;
+INSERT INTO t1 VALUES (1); -- does not error
+INSERT INTO t1 VALUES (2);
+COMMIT; -- triggers an error
+```
+
+`PRIMARY KEY` constraints otherwise have similar behavior and restritions to MySQL:
 
 ```
 mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY);
@@ -97,7 +108,7 @@ mysql> CREATE TABLE t4 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b));
 Query OK, 0 rows affected (0.10 sec)
 ```
 
-* Table `t2` failed to be created because the column `a` permitted `NULL` values.
+* Table `t2` failed to be created because the column `a` pemitted `NULL` values.
 * Table `t3` failed because there can only be one `PRIMARY KEY` on a table.
 * Table `t4` was successful, because even though there can only be one primary key, it may be defined as a composite of multiple columns.
 

--- a/sql/constraints.md
+++ b/sql/constraints.md
@@ -12,7 +12,7 @@ TiDB supports the same basic constraints supported in MySQL with the follwing ex
 
 TiDB currently only supports `FOREIGN KEY` creation in DDL commands. For example:
 
-```
+```sql
 CREATE TABLE users (
  id INT NOT NULL PRIMARY KEY auto_increment,
  doc JSON
@@ -39,14 +39,14 @@ FROM information_schema.key_column_usage WHERE table_name IN ('users', 'orders')
 
 TiDB also supports the syntax to `DROP FOREIGN KEY` and `ADD FOREIGN KEY` via the `ALTER TABLE` command:
 
-```
+```sql
 ALTER TABLE orders DROP FOREIGN KEY fk_user_id;
 ALTER TABLE orders ADD FOREIGN KEY fk_user_id (user_id) REFERENCES users(id); 
 ```
 
 Currently foreign keys are not enforced as part of DML operations. For example, in TiDB the following transaction commits successfully even though there is no `user_id` with `id=123`:
 
-```
+```sql
 START TRANSACTION;
 INSERT INTO orders (user_id, doc) VALUES (123, NULL);
 COMMIT;
@@ -56,7 +56,7 @@ COMMIT;
 
 TiDB supports the `NOT NULL` constraint with identical semantics to MySQL. For example:
 
-```
+```sql
 CREATE TABLE users (
  id INT NOT NULL PRIMARY KEY auto_increment,
  age INT NOT NULL,
@@ -83,18 +83,29 @@ Query OK, 1 row affected (0.03 sec)
 
 In TiDB, `PRIMARY KEY` constraints are checked lazily by default. By batching checks until when the transaction commits, TiDB is able to reduce network communication. For example:
 
-```
-CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY);
-INSERT INTO t1 VALUES (1);
-START TRANSACTION;
-INSERT INTO t1 VALUES (1); -- does not error
-INSERT INTO t1 VALUES (2);
-COMMIT; -- triggers an error
+```sql
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY);
+Query OK, 0 rows affected (0.01 sec)
+
+mysql> INSERT INTO t1 VALUES (1);
+Query OK, 1 row affected (0.00 sec)
+
+mysql> START TRANSACTION;
+Query OK, 0 rows affected (0.00 sec)
+
+mysql> INSERT INTO t1 VALUES (1); -- does not error
+Query OK, 1 row affected (0.00 sec)
+
+mysql> INSERT INTO t1 VALUES (2);
+Query OK, 1 row affected (0.00 sec)
+
+mysql> COMMIT; -- triggers an error
+ERROR 1062 (23000): Duplicate entry '1' for key 'PRIMARY'
 ```
 
 `PRIMARY KEY` constraints otherwise have similar behavior and restrictions to MySQL:
 
-```
+```sql
 mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY);
 Query OK, 0 rows affected (0.12 sec)
 
@@ -118,7 +129,7 @@ In addition to these semantics, TiDB also imposes the restriction that once a ta
 
 In TiDB, `UNIQUE` constraints are checked lazily by default. By batching checks until when the transaction commits, TiDB is able to reduce network communication. For example:
 
-```
+```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
  id INT NOT NULL PRIMARY KEY auto_increment,
@@ -146,7 +157,7 @@ ERROR 1062 (23000): Duplicate entry 'bill' for key 'username'
 
 By changing `tidb_constraint_check_in_place` to `TRUE`, `UNIQUE` constraints will be checked as statements are executed. For example:
 
-```
+```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
  id INT NOT NULL PRIMARY KEY auto_increment,

--- a/sql/constraints.md
+++ b/sql/constraints.md
@@ -92,7 +92,7 @@ INSERT INTO t1 VALUES (2);
 COMMIT; -- triggers an error
 ```
 
-`PRIMARY KEY` constraints otherwise have similar behavior and restritions to MySQL:
+`PRIMARY KEY` constraints otherwise have similar behavior and restrictions to MySQL:
 
 ```
 mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY);
@@ -108,7 +108,7 @@ mysql> CREATE TABLE t4 (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b));
 Query OK, 0 rows affected (0.10 sec)
 ```
 
-* Table `t2` failed to be created because the column `a` pemitted `NULL` values.
+* Table `t2` failed to be created because the column `a` permitted `NULL` values.
 * Table `t3` failed because there can only be one `PRIMARY KEY` on a table.
 * Table `t4` was successful, because even though there can only be one primary key, it may be defined as a composite of multiple columns.
 


### PR DESCRIPTION
Important to document it is both types of constraints.