### PR TITLE
sql, op-guide: fix the default value of feedback-probability

### DIFF
--- a/op-guide/tidb-config-file.md
+++ b/op-guide/tidb-config-file.md
@@ -186,7 +186,7 @@ Configuration about performance.
 ### `feedback-probability`
 
 - The probability that TiDB collects the feedback statistics of each query
-- Default: 0
+- Default: 0.0
 - TiDB collects the feedback of each query at the probability of `feedback-probability`, to update statistics
 
 ## prepared-plan-cache

--- a/sql/statistics.md
+++ b/sql/statistics.md
@@ -49,7 +49,7 @@ Three system variables related to automatic update of statistics are as follows:
 
 When the ratio of the number of modified rows to the total number of rows of `tbl` in a table is greater than `tidb_auto_analyze_ratio`, and the current time is between `tidb_auto_analyze_start_time` and `tidb_auto_analyze_end_time`, TiDB executes the `ANALYZE TABLE tbl` statement in the background to automatically update the statistics of this table.
 
-When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0`.
+When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0.0`.
 
 ### Control `ANALYZE` concurrency
 

--- a/v2.1/op-guide/tidb-config-file.md
+++ b/v2.1/op-guide/tidb-config-file.md
@@ -185,7 +185,7 @@ Configuration about performance.
 ### `feedback-probability`
 
 - The probability that TiDB collects the feedback statistics of each query
-- Default: 0
+- Default: 0.0
 - TiDB collects the feedback of each query at the probability of `feedback-probability`, to update statistics
 
 ## prepared-plan-cache

--- a/v2.1/sql/statistics.md
+++ b/v2.1/sql/statistics.md
@@ -49,7 +49,7 @@ Three system variables related to automatic update of statistics are as follows:
 
 When the ratio of the number of modified rows to the total number of rows of `tbl` in a table is greater than `tidb_auto_analyze_ratio`, and the current time is between `tidb_auto_analyze_start_time` and `tidb_auto_analyze_end_time`, TiDB executes the `ANALYZE TABLE tbl` statement in the background to automatically update the statistics of this table.
 
-When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0`.
+When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0.0`.
 
 ### Control `ANALYZE` concurrency
 


### PR DESCRIPTION
@yikeke PTAL

Via: https://github.com/pingcap/docs-cn/pull/1163