### PR TITLE
op-guide: split binary deployment into three sections

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -89,7 +89,10 @@
   + Deploy
     - [Ansible Deployment (Recommended)](op-guide/ansible-deployment.md)
     - [Offline Deployment Using Ansible](op-guide/offline-ansible-deployment.md)
-    - [Binary Deployment](op-guide/binary-deployment.md)
+    + Binary Deployment
+      - [Local Install](op-guide/binary-local-deployment.md)
+      - [Testing Environment](op-guide/binary-testing-deployment.md)
+      - [Production Deployment](op-guide/binary-deployment.md)
     - [Docker Deployment](op-guide/docker-deployment.md)
     - [Docker Compose Deployment](op-guide/docker-compose.md)
     - [Cross-DC Deployment Solutions](op-guide/cross-dc-deployment.md)

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -1,12 +1,12 @@
 ---
-title: Deploy TiDB Using the Binary
+title: Production Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: operations
 ---
 
-# Deploy TiDB Using the Binary
+# Production Deployment from Binary Tarball
 
-This guide provides installation instructions from tarball on Linux. A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
+This guide provides installation instructions from a binary tarball on Linux. A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
 
 This document describes binary deployment for production usage. See also [local deployment](binary-local-deployment.md) and [testing enviroment](binary-testing-deployment.md) deployment.
 

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -8,7 +8,7 @@ category: operations
 
 This guide provides installation instructions from a binary tarball on Linux. A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
 
-This document describes binary deployment for production usage. See also [local deployment](../op-guide/binary-local-deployment.md) and [testing enviroment](../op-guide/binary-testing-deployment.md) deployment.
+See also [local deployment](../op-guide/binary-local-deployment.md) and [testing enviroment](../op-guide/binary-testing-deployment.md) deployment.
 
 ## Prepare
 

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -8,7 +8,7 @@ category: operations
 
 This guide provides installation instructions from a binary tarball on Linux. A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
 
-This document describes binary deployment for production usage. See also [local deployment](binary-local-deployment.md) and [testing enviroment](binary-testing-deployment.md) deployment.
+This document describes binary deployment for production usage. See also [local deployment](../op-guide/binary-local-deployment.md) and [testing enviroment](../op-guide/binary-testing-deployment.md) deployment.
 
 ## Prepare
 

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -8,11 +8,7 @@ category: operations
 
 This guide provides installation instructions from tarball on Linux. A complete TiDB cluster contains PD, TiKV, and TiDB. To start the database service, follow the order of PD -> TiKV -> TiDB. To stop the database service, follow the order of stopping TiDB -> TiKV -> PD.
 
-This document describes the binary deployment of three scenarios:
-
-1. [Single node cluster deployment](#single-node-cluster-deployment) for trying out TiDB.
-2. [Multiple nodes cluster deployment for testing](#multiple-nodes-cluster-deployment-for-test) TiDB across multiple nodes and exploring features in more detail.
-3. [Multiple nodes cluster deployment](#multiple-nodes-cluster-deployment) for production deployments.
+This document describes binary deployment for production usage. See also [local deployment](binary-local-deployment.md) and [testing enviroment](binary-testing-deployment.md) deployment.
 
 ## Prepare
 
@@ -120,98 +116,6 @@ $ sha256sum -c tidb-latest-linux-amd64.sha256
 $ tar -xzf tidb-latest-linux-amd64.tar.gz
 $ cd tidb-latest-linux-amd64
 ```
-
-## Single node cluster deployment
-
-After downloading the TiDB binary package, you can run and test the TiDB cluster on a standalone server. Follow the steps below to start PD, TiKV and TiDB:
-
-1. Start PD.
-
-    ```bash
-    $ ./bin/pd-server --data-dir=pd \
-                    --log-file=pd.log &
-    ```
-
-2. Start TiKV.
-
-    ```bash
-    $ ./bin/tikv-server --pd="127.0.0.1:2379" \
-                      --data-dir=tikv \
-                      --log-file=tikv.log &
-    ```
-
-3. Start TiDB.
-
-    ```bash
-    $ ./bin/tidb-server --store=tikv \
-                      --path="127.0.0.1:2379" \
-                      --log-file=tidb.log &
-    ```
-
-4. Use the MySQL client to connect to TiDB.
-
-    ```sh
-    $ mysql -h 127.0.0.1 -P 4000 -u root -D test
-    ```
-
-## Multiple nodes cluster deployment for test
-
-If you want to test TiDB but have a limited number of nodes, you can use one PD instance to test the entire cluster.
-
-Assuming that you have four nodes, you can deploy 1 PD instance, 3 TiKV instances, and 1 TiDB instance. See the following table for details:
-
-| Name | Host IP | Services |
-| :-- | :-- | :------------------- |
-| Node1 | 192.168.199.113 | PD1, TiDB |
-| Node2 | 192.168.199.114 | TiKV1 |
-| Node3 | 192.168.199.115 | TiKV2 |
-| Node4 | 192.168.199.116 | TiKV3 |
-
-Follow the steps below to start PD, TiKV and TiDB:
-
-1. Start PD on Node1.
-
-    ```bash
-    $ ./bin/pd-server --name=pd1 \
-                    --data-dir=pd \
-                    --client-urls="http://192.168.199.113:2379" \
-                    --peer-urls="http://192.168.199.113:2380" \
-                    --initial-cluster="pd1=http://192.168.199.113:2380" \
-                    --log-file=pd.log &
-    ```
-
-2. Start TiKV on Node2, Node3 and Node4.
-
-    ```bash
-    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
-                      --addr="192.168.199.114:20160" \
-                      --data-dir=tikv \
-                      --log-file=tikv.log &
-
-    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
-                      --addr="192.168.199.115:20160" \
-                      --data-dir=tikv \
-                      --log-file=tikv.log &
-
-    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
-                      --addr="192.168.199.116:20160" \
-                      --data-dir=tikv \
-                      --log-file=tikv.log &
-    ```
-
-3. Start TiDB on Node1.
-
-    ```bash
-    $ ./bin/tidb-server --store=tikv \
-                      --path="192.168.199.113:2379" \
-                      --log-file=tidb.log
-    ```
-
-4. Use the MySQL client to connect to TiDB.
-
-    ```sh
-    $ mysql -h 192.168.199.113 -P 4000 -u root -D test
-    ```
 
 ## Multiple nodes cluster deployment
 

--- a/op-guide/binary-local-deployment.md
+++ b/op-guide/binary-local-deployment.md
@@ -65,7 +65,7 @@ $ tar -xzf tidb-latest-linux-amd64.tar.gz
 $ cd tidb-latest-linux-amd64
 ```
 
-### Start Binaries
+### Start
 
 Follow the steps below to start PD, TiKV and TiDB:
 

--- a/op-guide/binary-local-deployment.md
+++ b/op-guide/binary-local-deployment.md
@@ -34,7 +34,7 @@ EOF
 sudo cp /tmp/tidb.conf /etc/security/limits.d/
 sudo sysctl -w fs.file-max=1000000
 ```
-See the [production deployment](binary-deployment.md) optional kernel tuning parameters.
+See the [production deployment](../op-guide/binary-deployment.md) optional kernel tuning parameters.
 
 ### Create a database running user account
 

--- a/op-guide/binary-local-deployment.md
+++ b/op-guide/binary-local-deployment.md
@@ -8,6 +8,8 @@ category: operations
 
 This guide provides installation instructions for all TiDB components on a single developer machine. It is intended for evaluation purposes, and does not match the recommended usage for production systems.
 
+See also [testing environment](../op-guide/binary-testing-deployment.md) and [production enviroment](../op-guide/binary-deployment.md) deployment.
+
 The following local TCP ports will be used:
 
 | Component | Port  | Protocol | Description |

--- a/op-guide/binary-local-deployment.md
+++ b/op-guide/binary-local-deployment.md
@@ -19,7 +19,7 @@ The following local TCP ports will be used:
 | PD        | 2380  | TCP      | the inter-node communication port within the PD cluster |
 
 
-### Operating System (Pre-check)
+### Prepare
 
 This guide is for deployment on Linux only. It is recommended to use RHEL/CentOS 7.3 or higher. TiKV requires you to raise the open files limit:
 

--- a/op-guide/binary-local-deployment.md
+++ b/op-guide/binary-local-deployment.md
@@ -1,0 +1,99 @@
+---
+title: Local Deployment from Binary Tarball
+summary: Use the binary to deploy a TiDB cluster.
+category: operations
+---
+
+# Local Deployment from Binary Tarball
+
+This guide provides installation instructions for all TiDB components on a single developer machine. It is intended for evaluation purposes, and does not match the recommended usage for production systems.
+
+The following local TCP ports will be used:
+
+| Component | Port  | Protocol | Description |
+| --------- | ----- | -------- | ----------- |
+| TiDB      | 4000  | TCP      | the communication port for the application and DBA tools |
+| TiDB      | 10080 | TCP      | the communication port to report TiDB status |
+| TiKV      | 20160 | TCP      | the TiKV communication port  |
+| PD        | 2379  | TCP      | the communication port between TiDB and PD |
+| PD        | 2380  | TCP      | the inter-node communication port within the PD cluster |
+
+
+### Operating System (Pre-check)
+
+This guide is for deployment on Linux only. It is recommended to use RHEL/CentOS 7.3 or higher. TiKV requires you to raise the open files limit:
+
+```bash
+tidbuser="tidb"
+
+cat << EOF > /tmp/tidb.conf
+$tidbuser        soft        nofile        1000000
+$tidbuser        hard        nofile        1000000
+EOF
+
+sudo cp /tmp/tidb.conf /etc/security/limits.d/
+sudo sysctl -w fs.file-max=1000000
+```
+See the [production deployment](binary-deployment.md) optional kernel tuning parameters.
+
+### Create a database running user account
+
+1. Log in to the machine using the `root` user account and create a database running user account (`tidb`) using the following command:
+
+    ```bash
+    # useradd tidb -m
+    ```
+
+2. Switch the user from `root` to `tidb` by using the following command. You can use this `tidb` user account to deploy your TiDB cluster.
+
+    ```bash
+    # su - tidb
+    ```
+
+### Download the official binary package
+
+```
+# Download the package.
+$ wget http://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
+$ wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+
+# Check the file integrity. If the result is OK, the file is correct.
+$ sha256sum -c tidb-latest-linux-amd64.sha256
+
+# Extract the package.
+$ tar -xzf tidb-latest-linux-amd64.tar.gz
+$ cd tidb-latest-linux-amd64
+```
+
+### Start Binaries
+
+Follow the steps below to start PD, TiKV and TiDB:
+
+1. Start PD.
+
+    ```bash
+    $ ./bin/pd-server --data-dir=pd \
+                    --log-file=pd.log &
+    ```
+
+2. Start TiKV.
+
+    ```bash
+    $ ./bin/tikv-server --pd="127.0.0.1:2379" \
+                      --data-dir=tikv \
+                      --log-file=tikv.log &
+    ```
+
+3. Start TiDB.
+
+    ```bash
+    $ ./bin/tidb-server --store=tikv \
+                      --path="127.0.0.1:2379" \
+                      --log-file=tidb.log &
+    ```
+
+4. Use the MySQL client to connect to TiDB.
+
+    ```sh
+    $ mysql -h 127.0.0.1 -P 4000 -u root -D test
+    ```

--- a/op-guide/binary-testing-deployment.md
+++ b/op-guide/binary-testing-deployment.md
@@ -1,0 +1,177 @@
+---
+title: Testing Deployment from Binary Tarball
+summary: Use the binary to deploy a TiDB cluster.
+category: operations
+---
+
+# Testing Deployment from Binary Tarball
+
+This guide provides installation instructions for all TiDB components across multiple nodes for testing purposes. It does not match the recommended usage for production systems.
+
+See also [local deployment](binary-local-deployment.md) and [production enviroment](binary-deployment.md) deployment.
+
+## Prepare
+
+Before you start, see [TiDB architecture](/overview.md#tidb-architecture) and [Software and Hardware Requirements](/op-guide/recommendation.md). Make sure the following requirements are satisfied:
+
+### Operating system
+
+For the operating system, it is recommended to use RHEL/CentOS 7.3 or higher. The following additional requirements are recommended:
+
+| Configuration | Description |
+| :-- | :-------------------- |
+| Supported Platform | RHEL/CentOS 7.3+ ([more details](/op-guide/recommendation.md)) |
+| File System  |  ext4 is recommended |
+| Swap Space  |  Should be disabled  |
+| Disk Block Size  |  Set the system disk `Block` size to `4096` |
+
+### Network and firewall
+
+| Configuration | Description |
+| :-- | :------------------- |
+| Firewall/Port | Check whether the ports required by TiDB are accessible between the nodes |
+
+### Operating system parameters
+
+| Configuration | Description |
+| :-- | :-------------------------- |
+| Nice Limits | For system users, set the default value of `nice` in TiDB to `0` |
+| min_free_kbytes | The setting for `vm.min_free_kbytes` in `sysctl.conf` needs to be high enough |
+| User Open Files Limit | For database administrators, set the number of TiDB open files to `1000000` |
+| System Open File Limits | Set the number of system open files to `1000000` |
+| User Process Limits | For TiDB users, set the `nproc` value to `4096` in `limits.conf` |
+| Address Space Limits | For TiDB users, set the space to `unlimited` in `limits.conf` |
+| File Size Limits | For TiDB users, set the `fsize` value to `unlimited` in `limits.conf` |
+| Disk Readahead | Set the value of the `readahead` data disk to `4096` at a minimum |
+| NTP service | Configure the NTP time synchronization service for each node |
+| SELinux  | Turn off the SELinux service for each node |
+| CPU Frequency Scaling | It is recommended to turn on CPU overclocking |
+| Transparent Hugepages | For Red Hat 7+ and CentOS 7+ systems, it is required to set the Transparent Hugepages to `always` |
+| I/O Scheduler | Set the I/O Scheduler of data disks to the `deadline` mode |
+| vm.swappiness | Set `vm.swappiness = 0` in `sysctl.conf` |
+| net.core.somaxconn | Set `net.core.somaxconn = 32768` in `sysctl.conf` |
+| net.ipv4.tcp_syncookies | Set `net.ipv4.tcp_syncookies = 0` in `sysctl.conf` |
+
+### Database running user settings
+
+| Configuration | Description |
+| :-- | :---------------------------- |
+| LANG environment | Set `LANG = en_US.UTF8` |
+| TZ time zone | Set the TZ time zone of all nodes to the same value |
+
+## TiDB components and default ports
+
+Before you deploy a TiDB cluster, see the [required components](#tidb-database-components-required) and [optional components](#tidb-database-components-optional).
+
+### TiDB database components (required)
+
+See the following table for the default ports for the TiDB components:
+
+| Component | Default Port | Protocol | Description |
+| :-- | :-- | :-- | :----------- |
+| ssh | 22 | TCP | the sshd service |
+| TiDB|  4000  | TCP | the communication port for the application and DBA tools |
+| TiDB| 10080  |  TCP | the communication port to report TiDB status |
+| TiKV|  20160 |  TCP | the TiKV communication port  |
+| PD | 2379 | TCP | the communication port between TiDB and PD |
+| PD | 2380 | TCP | the inter-node communication port within the PD cluster |
+
+### TiDB database components (optional)
+
+See the following table for the default ports for the optional TiDB components:
+
+| Component | Default Port | Protocol | Description |
+| :-- | :-- | :-- | :------------------------ |
+| Prometheus |  9090| TCP | the communication port for the Prometheus service |
+| Pushgateway |  9091 | TCP | the aggregation and report port for TiDB, TiKV, and PD monitor |
+| Node_exporter|  9100| TCP | the communication port to report the system information of every TiDB cluster node |
+| Grafana | 3000 | TCP | the port for the external Web monitoring service and client (Browser) access |
+| alertmanager | 9093 | TCP | the port for the alert service |
+
+## Create a database running user account
+
+1. Log in to the machine using the `root` user account and create a database running user account (`tidb`) using the following command:
+
+    ```bash
+    # useradd tidb -m
+    ```
+
+2. Switch the user from `root` to `tidb` by using the following command. You can use this `tidb` user account to deploy your TiDB cluster.
+
+    ```bash
+    # su - tidb
+    ```
+
+## Download the official binary package
+
+```
+# Download the package.
+$ wget http://download.pingcap.org/tidb-latest-linux-amd64.tar.gz
+$ wget http://download.pingcap.org/tidb-latest-linux-amd64.sha256
+
+# Check the file integrity. If the result is OK, the file is correct.
+$ sha256sum -c tidb-latest-linux-amd64.sha256
+
+# Extract the package.
+$ tar -xzf tidb-latest-linux-amd64.tar.gz
+$ cd tidb-latest-linux-amd64
+```
+
+## Multiple nodes cluster deployment for test
+
+If you want to test TiDB but have a limited number of nodes, you can use one PD instance to test the entire cluster.
+
+Assuming that you have four nodes, you can deploy 1 PD instance, 3 TiKV instances, and 1 TiDB instance. See the following table for details:
+
+| Name | Host IP | Services |
+| :-- | :-- | :------------------- |
+| Node1 | 192.168.199.113 | PD1, TiDB |
+| Node2 | 192.168.199.114 | TiKV1 |
+| Node3 | 192.168.199.115 | TiKV2 |
+| Node4 | 192.168.199.116 | TiKV3 |
+
+Follow the steps below to start PD, TiKV and TiDB:
+
+1. Start PD on Node1.
+
+    ```bash
+    $ ./bin/pd-server --name=pd1 \
+                    --data-dir=pd \
+                    --client-urls="http://192.168.199.113:2379" \
+                    --peer-urls="http://192.168.199.113:2380" \
+                    --initial-cluster="pd1=http://192.168.199.113:2380" \
+                    --log-file=pd.log &
+    ```
+
+2. Start TiKV on Node2, Node3 and Node4.
+
+    ```bash
+    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
+                      --addr="192.168.199.114:20160" \
+                      --data-dir=tikv \
+                      --log-file=tikv.log &
+
+    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
+                      --addr="192.168.199.115:20160" \
+                      --data-dir=tikv \
+                      --log-file=tikv.log &
+
+    $ ./bin/tikv-server --pd="192.168.199.113:2379" \
+                      --addr="192.168.199.116:20160" \
+                      --data-dir=tikv \
+                      --log-file=tikv.log &
+    ```
+
+3. Start TiDB on Node1.
+
+    ```bash
+    $ ./bin/tidb-server --store=tikv \
+                      --path="192.168.199.113:2379" \
+                      --log-file=tidb.log
+    ```
+
+4. Use the MySQL client to connect to TiDB.
+
+    ```sh
+    $ mysql -h 192.168.199.113 -P 4000 -u root -D test
+    ```

--- a/op-guide/binary-testing-deployment.md
+++ b/op-guide/binary-testing-deployment.md
@@ -8,7 +8,7 @@ category: operations
 
 This guide provides installation instructions for all TiDB components across multiple nodes for testing purposes. It does not match the recommended usage for production systems.
 
-See also [local deployment](binary-local-deployment.md) and [production enviroment](binary-deployment.md) deployment.
+See also [local deployment](../op-guide/binary-local-deployment.md) and [production enviroment](../op-guide/binary-deployment.md) deployment.
 
 ## Prepare
 


### PR DESCRIPTION
This is required for the DITA manual where these appear in different sections.