### PR TITLE
overview, intro: move content around

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -2,7 +2,7 @@
 
 ## Documentation List
 
-+ [Introduction](QUICKSTART.md)
++ [Introduction](overview.md)
 + Concepts
   - [Architecture](architecture.md)
   + [Key Features](key-features.md)

--- a/TOC.md
+++ b/TOC.md
@@ -5,7 +5,7 @@
 + [Introduction](QUICKSTART.md)
 + Concepts
   - [Architecture](architecture.md)
-  + [Key Features](overview.md)
+  + [Key Features](key-features.md)
     - [Horizontal Scalability](overview.md#horizontal-scalability)
     - [MySQL Compatible Syntax](overview.md#mysql-compatible-syntax)
     - [Replicate from and to MySQL](overview.md#replicate-from-and-to-mysql)

--- a/key-features.md
+++ b/key-features.md
@@ -6,7 +6,7 @@ category: concepts
 
 # Key Features
 
-### Horizontal Scalability
+## Horizontal Scalability
 
 TiDB expands both SQL processing and storage by simply adding new nodes. This makes infrastructure capacity planning both easier and more cost-effective than traditional relational databases which only scale vertically.
 

--- a/key-features.md
+++ b/key-features.md
@@ -10,19 +10,19 @@ category: concepts
 
 TiDB expands both SQL processing and storage by simply adding new nodes. This makes infrastructure capacity planning both easier and more cost-effective than traditional relational databases which only scale vertically.
 
-### MySQL Compatible Syntax
+## MySQL Compatible Syntax
 
 TiDB acts like it is a MySQL 5.7 server to your applications. You can continue to use all of the existing MySQL client libraries, and in many cases, you will not need to change a single line of code in your application.
 
 TiDB does not have 100% MySQL compatibility because we built the layer from scratch in order to maximize the performance advantages inherent to a distributed system. We believe in being transparent about the level of MySQL compatibility that TiDB provides. Please check out the list of [known compatibility differences](./sql/mysql-compatibility.md).
 
-### Replicate from and to MySQL
+## Replicate from and to MySQL
 
 TiDB supports the ability to replicate from a MySQL or MariaDB installation, using its Data Migration (DM) toolchain. Replication is also possible in the direction of TiDB to MySQL using the TiDB-Binlog.
 
 We believe that being able to replicate in both directions lowers the risk when either evaluating or migrating to TiDB from MySQL.
 
-### Distributed Transactions with Strong Consistency
+## Distributed Transactions with Strong Consistency
 
 TiDB internally shards table into small range-based chunks that we refer to as "Regions". Each Region defaults to approximately 100MiB in size, and TiDB uses a Two-phase commit internally to ensure that Regions are maintained in a transactionally consistent way.
 
@@ -30,69 +30,69 @@ Transactions in TiDB are strongly consistent, with snapshot isolation level cons
 
 These behaviors are transparent to your application(s), which only need to connect to TiDB using a MySQL 5.7 compatible client library.
 
-### Cloud Native Architecture
+## Cloud Native Architecture
 
 TiDB is designed to work in the cloud -- public, private, or hybrid -- making deployment, provisioning, operations, and maintenance simple.
 
 The storage layer of TiDB, called TiKV, [became](https://www.cncf.io/blog/2018/08/28/cncf-to-host-tikv-in-the-sandbox/) a [Cloud Native Computing Foundation](https://www.cncf.io/) member project in 2018. The architecture of the TiDB platform also allows SQL processing and storage to be scaled independently of each other in a very cloud-friendly manner.
 
-### Minimize ETL with HTAP
+## Minimize ETL with HTAP
 
 TiDB is designed to support both transaction processing (OLTP) and analytical processing (OLAP) workloads. This means that while you may have traditionally transacted on MySQL and then Extracted, Transformed and Loaded (ETL) data into a column store for analytical processing, this step is no longer required.
 
 With trends in business such as moving from two-day delivery to instant, it is important to be able to run analytics with minimal delay. The future is in HTAP databases which can perform the _hybrid_ of Transactional and Analytical processing.
 
-### Fault Tolerance & Recovery with Raft
+## Fault Tolerance & Recovery with Raft
 
 TiDB uses the Raft consensus algorithm to ensure that data is safely replicated throughout storage in Raft groups. In the event of failure, a Raft group will automatically elect a new leader for the failed member, and self-heal the TiDB cluster without any required manual intervention.
 
 Failure and self-healing operations are also transparent to applications. TiDB servers will retry accessing the data after the leadership change, with the only impact being slightly higher latency for queries attempting to access this specific data in between when the failure is detected and fixed.
 
-### Automatic Rebalancing
+## Automatic Rebalancing
 
 The storage in TiKV is automatically rebalanced to match changes in your workload. For example, if part of your data is more frequently accessed, this hotspot will be detected and may trigger the data to be rebalanced among other TiKV servers. Chunks of data ("Regions" in TiDB terminology) will automatically be split or merged as needed.
 
 This helps remove some of the headaches associated with maintaining a large database cluster and also leads to better utilization over traditional master-slave read-write splitting that is commonly used with MySQL deployments.
 
-### Deployment and Orchestration with Ansible, Kubernetes, Docker
+## Deployment and Orchestration with Ansible, Kubernetes, Docker
 
 TiDB supports several deployment and orchestration methods, like Ansible, Kubernetes, and Docker. Whether your environment is bare metal, virtualized or containerized, TiDB can be deployed, upgraded, operated, and maintained using the best toolset most suited to your needs.
 
-### JSON Support
+## JSON Support
 
 TiDB supports a built-in JSON data type and set of built-in functions to search, manipulate and create JSON data. This enables you to build your application without enforcing a strict schema up front.
 
-### Spark Integration
+## Spark Integration
 
 TiDB natively supports an Apache Spark plug-in, called TiSpark, with a SparkSQL interface that enables users to run analytical workloads using Spark directly on TiKV, where the data is stored. This plug-in does not interfere with transactional processing in the TiDB server. This integration takes advantage of TiDB’s modular architecture to support HTAP workloads.
 
-### Read Historical Data without Restoring from Backup
+## Read Historical Data without Restoring from Backup
 
 Many restore-from-backup events are the result of accidental deletion or modification of the wrong data. With TiDB, you can access the older versions from MVCC by specifying a timestamp in the past from when you would like to access the data.
 
 Your session will be placed in read-only mode while reading the earlier versions of rows, but you can use this to export the data and reload it to the current time if required.
 
-### Fast Import and Restore of Data
+## Fast Import and Restore of Data
 
 TiDB supports the ability to fast-import both mydumper and .csv formatted data using an optimized insert mode that disables redo logging, and applies a number of optimizations.
 
 With TiDB Lightning, you can import data into TiDB at over 100GiB/hour using production-grade hardware.
 
-### Hybrid of Column and Row Storage
+## Hybrid of Column and Row Storage
 
 TiDB supports the ability to store data in both row-oriented and (coming soon) column-oriented storage. This enables a wide spectrum of both transactional and analytical queries to be executed efficiently in TiDB and TiSpark. The TiDB optimizer is also able to determine which queries are best served by column storage, and route the queries appropriately.
 
-### SQL Plan Management
+## SQL Plan Management
 
 In both MySQL and TiDB, optimizer hints are available to override the default query execution plan with a better known plan. The problem with this approach is that it requires an application developer to make modifications to query text to inject the hint. This can also be undesirable in the case that an ORM is used to generate the query.
  
 In TiDB 3.0, you will be able to bind queries to a specific execution plan directly within the TiDB server. This method is entirely transparent to application code.
 
-### Open Source
+## Open Source
 
 TiDB has been released under the Apache 2.0 license since its initial launch in 2015. The TiDB server has (to our knowledge) the highest contributor count on GitHub of any relational database project.
 
-### Online Schema Changes
+## Online Schema Changes
 
 TiDB implements the _Online, Asynchronous Schema Change_ algorithm first described in [Google's F1 paper](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/41376.pdf).
 

--- a/key-features.md
+++ b/key-features.md
@@ -1,14 +1,10 @@
 ---
-title: TiDB Introduction
-summary: An introduction to the TiDB database platform
-category: introduction
+title: Key Features
+summary: Key features of the TiDB database platform.
+category: concepts
 ---
 
-# TiDB Introduction
-
-TiDB ("Ti" stands for Titanium) is an open-source NewSQL database that supports Hybrid Transactional and Analytical Processing (HTAP) workloads. It is MySQL compatible and features horizontal scalability, strong consistency, and high availability.
-
-## Key Features
+# Key Features
 
 ### Horizontal Scalability
 

--- a/overview.md
+++ b/overview.md
@@ -1,10 +1,11 @@
 ---
-title: TiDB Quick Start Guide
+title: TiDB Introduction
 summary: Learn how to quickly start a TiDB cluster.
-category: quick start
+category: introduction
+aliases: ['/docs/QUICKSTART']
 ---
 
-# TiDB Quick Start Guide
+# TiDB Introduction
 
 TiDB ("Ti" stands for Titanium) is an open-source NewSQL database that supports Hybrid Transactional and Analytical Processing (HTAP) workloads. It is MySQL compatible and features horizontal scalability, strong consistency, and high availability.
 

--- a/overview.md
+++ b/overview.md
@@ -23,7 +23,7 @@ The following list collects deployment guides and tutorials from the community. 
 
 - [How To Spin Up an HTAP Database in 5 Minutes with TiDB + TiSpark](https://www.pingcap.com/blog/how_to_spin_up_an_htap_database_in_5_minutes_with_tidb_tispark/)
 - [Developer install guide (single machine)](http://www.tocker.ca/this-blog-now-powered-by-wordpress-tidb.html)
-
+-  [TiDB Best Practices](https://pingcap.com/blog/2017-07-24-tidbbestpractice/)
 _Your contribution is also welcome! Feel free to open a [pull request](https://github.com/pingcap/docs/edit/master/QUICKSTART.md) to add additional links._
 
 ## Source Code


### PR DESCRIPTION
This PR moves the key-features introduction under concepts/key-features. The index page becomes what was QUICKSTART (for now).

The plan is to change QUICKSTART to be a proper quickstart, with an overview of each of the key sections of the manual. We will work with the designers to make this possible.

It is important to merge this intermediate version because of an inconsistency:
If you visit pingcap.com/docs you will land on key-features, but if you click on the 'introduction' heading again you will get Quickstart.