### PR TITLE
tools: update the loader pprof-addr default port

### DIFF
--- a/tools/loader.md
+++ b/tools/loader.md
@@ -60,7 +60,7 @@ Since tools like mysqldump will take us days to migrate massive amounts of data,
 
   -p string: the account and password of TiDB
 
-  -pprof-addr string: the pprof address of Loader. It tunes the performance of Loader (default: ":10084")
+  -pprof-addr string: the pprof address of Loader. It tunes the performance of Loader (default: ":8272")
 
   -t int: the number of thread,increase this as TiKV nodes increase (default: 16)
 
@@ -81,8 +81,8 @@ log-file = "loader.log"
 # Directory of the dump to import (default: "./")
 dir = "./"
 
-# Loader pprof address, used to tune the performance of Loader (default: "127.0.0.1:10084")
-pprof-addr = "127.0.0.1:10084"
+# Loader pprof address, used to tune the performance of Loader (default: ":8272")
+pprof-addr = ":8272"
 
 # The checkpoint data is saved to TiDB, and the schema name is defined here.
 checkpoint-schema = "tidb_loader"


### PR DESCRIPTION
This PR updates the pprof-addr default port in Loader documents.

According to the https://internal.pingcap.net/confluence/pages/viewpage.action?pageId=21273346, Loader pprof-addr default port has changed from 10084 to 8272 while the public documents is out of date.

Loader code for reference:
https://github.com/pingcap/tidb-enterprise-tools/blob/master/loader/config.go
fs.StringVar(&cfg.PprofAddr, "pprof-addr", ":8272", "Loader pprof addr")

And the same PR in docs-cn： https://github.com/pingcap/docs-cn/pull/1256