### PR TITLE
sql: update the USE command explanation in util document

### DIFF
--- a/sql/util.md
+++ b/sql/util.md
@@ -96,7 +96,7 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the currently selected database is used by default.
 
 ## `TRACE` statement
 

--- a/sql/util.md
+++ b/sql/util.md
@@ -96,7 +96,7 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the default database is used.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.
 
 ## `TRACE` statement
 

--- a/v1.0/sql/util.md
+++ b/v1.0/sql/util.md
@@ -93,4 +93,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the default database is used.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.

--- a/v1.0/sql/util.md
+++ b/v1.0/sql/util.md
@@ -93,4 +93,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the currently selected database is used by default.

--- a/v2.0/sql/util.md
+++ b/v2.0/sql/util.md
@@ -96,4 +96,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the default database is used.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.

--- a/v2.0/sql/util.md
+++ b/v2.0/sql/util.md
@@ -96,4 +96,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the currently selected database is used by default.

--- a/v2.1/sql/util.md
+++ b/v2.1/sql/util.md
@@ -96,4 +96,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the default database is used.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.

--- a/v2.1/sql/util.md
+++ b/v2.1/sql/util.md
@@ -96,4 +96,4 @@ If the `dot` program is not installed on your computer, copy the result to [this
 USE db_name
 ```
 
-The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.
+The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the currently selected database is used by default.


### PR DESCRIPTION
### PR background
User provided feedback that our explanation of TiDB 'USE' command in util document is not quite accurate: the meaning of default database is confusing.

Detailed at the issue link: https://github.com/pingcap/docs-cn/issues/1112
And the docs-cn PR link: https://github.com/pingcap/docs-cn/pull/1269

### What has done in the PR
I updated the explanation of TiDB 'USE' command in sql/util.md documents (1.0/2.0/2.1).

Previously: 'The USE statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the default database is used.'

Updated: 'The `USE` statement is used to switch the default database. If the table in this SQL statement does not correspond to an explicitly specified database, then the current selected database will be used by default.'