### PR TITLE
dev/how-to/get-started: Fix broken link using absolute reference

### DIFF
--- a/dev/how-to/get-started/local-cluster/install-from-dbdeployer.md
+++ b/dev/how-to/get-started/local-cluster/install-from-dbdeployer.md
@@ -8,7 +8,7 @@ category: how-to
 
 DBdeployer is designed to allow multiple versions of TiDB deployed concurrently. It is recommended for advanced users who are testing out new builds of TiDB, or testing compatibility across releases.
 
-Similar to [Homebrew](../local-cluster/install-from-homebrew.md), the DBdeployer installation method installs the tidb-server **without** the tikv-server or pd-server. This is useful for development environments, since you can test your application's compatibility with TiDB without needing to deploy a full TiDB platform.
+Similar to [Homebrew](/dev/how-to/get-started/local-cluster/install-from-homebrew.md), the DBdeployer installation method installs the tidb-server **without** the tikv-server or pd-server. This is useful for development environments, since you can test your application's compatibility with TiDB without needing to deploy a full TiDB platform.
 
 > **Note**: Internally this installation uses goleveldb as the storage engine. It is much slower than TiKV, and any benchmarks will be unreliable.
 


### PR DESCRIPTION
@YiniXu9506 confirmed that we have to use absolute urls for now. We can take a look at using a regex to help porting between versions easier.