### PR TITLE
[DNM] tools/lightning: fix download URL for 2.1.9

### DIFF
--- a/tools/lightning/deployment.md
+++ b/tools/lightning/deployment.md
@@ -169,7 +169,9 @@ You can find deployment instructions in [TiDB Quick Start Guide](https://pingcap
 
 Download the TiDB-Lightning package (choose the same version as that of the TiDB cluster):
 
-- **v2.1.9**: https://download.pingcap.org/tidb-v2.1.9-linux-amd64.tar.gz
+- **v2.1.9**:
+    * tidb-lightning: https://download.pingcap.org/tidb-toolkit-v2.1.9-linux-amd64.tar.gz
+    * tikv-importer: https://download.pingcap.org/tidb-v2.1.9-linux-amd64.tar.gz
 - **v2.0.9**: https://download.pingcap.org/tidb-lightning-v2.0.9-linux-amd64.tar.gz
 - Latest unstable version: https://download.pingcap.org/tidb-lightning-test-xx-latest-linux-amd64.tar.gz
 


### PR DESCRIPTION
It has been split into two tarballs.

DNM: Awaiting decision if we should fix the docs or fix the tarballs.