### PR TITLE
Moved "scale" and "upgrade" from "maintain" to top-level "how-to"

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -70,14 +70,14 @@
     - [Migrate from CSV](tools/lightning/csv.md)
   + Maintain
     - [Backup and Restore](dev/how-to/maintain/backup-and-restore.md)
-    + Scale
-      - [Scale a TiDB Cluster](dev/how-to/maintain/scale/horizontally.md)
-      - [Scale using Ansible](dev/how-to/maintain/scale/with-ansible.md)
     - [Identify Slow Queries](dev/how-to/maintain/identify-slow-queries.md)
-    + Upgrade
-      - [Upgrade from TiDB 2.1](dev/how-to/maintain/upgrade/from-previous-version.md)
-      - [Upgrade Data Migration](dev/how-to/maintain/upgrade/data-migration.md)
-      - [Rolling updates with Ansible](dev/how-to/maintain/upgrade/rolling-updates-with-ansible.md)
+  + Scale
+    - [Scale a TiDB Cluster](dev/how-to/scale/horizontally.md)
+    - [Scale using Ansible](dev/how-to/scale/with-ansible.md)
+  + Upgrade
+    - [Upgrade from TiDB 2.1](dev/how-to/upgrade/from-previous-version.md)
+    - [Upgrade Data Migration](dev/how-to/upgrade/data-migration.md)
+    - [Rolling updates with Ansible](dev/how-to/upgrade/rolling-updates-with-ansible.md)
   - Troubleshoot
     - [Troubleshoot Cluster Setup](dev/how-to/troubleshoot/cluster-setup.md)
     - [Troubleshoot Data Migration](dev/how-to/troubleshoot/data-migration.md)

--- a/dev/how-to/scale/horizontally.md
+++ b/dev/how-to/scale/horizontally.md
@@ -2,7 +2,7 @@
 title: Scale a TiDB cluster
 summary: Learn how to add or delete PD, TiKV and TiDB nodes.
 category: how-to
-aliases: ['/docs/op-guide/horizontal-scale/']
+aliases: ['/docs/op-guide/horizontal-scale/','/docs/dev/how-to/maintain/scale/horizontally/']
 ---
 
 # Scale a TiDB cluster

--- a/dev/how-to/scale/with-ansible.md
+++ b/dev/how-to/scale/with-ansible.md
@@ -2,7 +2,7 @@
 title: Scale the TiDB Cluster Using TiDB-Ansible
 summary: Use TiDB-Ansible to increase/decrease the capacity of a TiDB/TiKV/PD node.
 category: how-to
-aliases: ['/docs/op-guide/ansible-deployment-scale/']
+aliases: ['/docs/op-guide/ansible-deployment-scale/','/docs/dev/how-to/maintain/scale/with-ansible/']
 ---
 
 # Scale the TiDB Cluster Using TiDB-Ansible

--- a/dev/how-to/upgrade/data-migration.md
+++ b/dev/how-to/upgrade/data-migration.md
@@ -2,7 +2,7 @@
 title: Upgrade Data Migration
 summary: Learn how to upgrade a Data Migration version to an incompatible version.
 category: how-to
-aliases: ['/docs/tools/dm/dm-upgrade/']
+aliases: ['/docs/tools/dm/dm-upgrade/','/docs/dev/how-to/maintain/upgrade/data-migration/']
 ---
 
 # Upgrade Data Migration

--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -2,7 +2,7 @@
 title: TiDB 2.1 Upgrade Guide
 summary: Learn how to upgrade from TiDB 2.0 (TiDB 2.0.1 or later) or TiDB 2.1 RC version to TiDB 2.1 GA version.
 category: how-to
-aliases: ['/docs/op-guide/tidb-v2.1-upgrade-guide/']
+aliases: ['/docs/op-guide/tidb-v2.1-upgrade-guide/','/docs/dev/how-to/maintain/upgrade/from-previous-version/']
 ---
 
 # TiDB 2.1 Upgrade Guide

--- a/dev/how-to/upgrade/rolling-updates-with-ansible.md
+++ b/dev/how-to/upgrade/rolling-updates-with-ansible.md
@@ -2,7 +2,7 @@
 title: Upgrade TiDB Using TiDB-Ansible
 summary: Use TiDB-Ansible to perform a rolling update for a TiDB cluster.
 category: how-to
-aliases: ['/docs/op-guide/ansible-deployment-rolling-update/','/dev/how-to/maintain/upgrade/rolling-updates-with-ansible/']
+aliases: ['/docs/op-guide/ansible-deployment-rolling-update/','/docs/dev/how-to/maintain/upgrade/rolling-updates-with-ansible/']
 ---
 
 # Upgrade TiDB Using TiDB-Ansible

--- a/dev/how-to/upgrade/rolling-updates-with-ansible.md
+++ b/dev/how-to/upgrade/rolling-updates-with-ansible.md
@@ -2,7 +2,7 @@
 title: Upgrade TiDB Using TiDB-Ansible
 summary: Use TiDB-Ansible to perform a rolling update for a TiDB cluster.
 category: how-to
-aliases: ['/docs/op-guide/ansible-deployment-rolling-update/']
+aliases: ['/docs/op-guide/ansible-deployment-rolling-update/','/dev/how-to/maintain/upgrade/rolling-updates-with-ansible/']
 ---
 
 # Upgrade TiDB Using TiDB-Ansible


### PR DESCRIPTION
It doesn't seem to me like "scale" and "upgrade" are necessarily natural fits for the "maintain" section. I like the idea that semantically meaningful phrases can be formed by combining "how to" and the verb of the sections that fall below it, for example "how to" + "scale" = "how to scale", and "how to" + "upgrade" = "how to upgrade". That didn't work very well when you had "how to" + "maintain" + "scale".

So, I moved "scale" and "upgrade" from under "maintain" to being top-level items under "how-to".