### PR TITLE
dev-reference: mention shared block cache is only for 3.0

### DIFF
--- a/dev/reference/performance/tune-tikv.md
+++ b/dev/reference/performance/tune-tikv.md
@@ -24,7 +24,9 @@ TiKV implements `Column Families` (CF) from RocksDB.
     
     - The `default` CF stores the Raft log. The corresponding parameters are in `[raftdb.defaultcf]`.
 
-By default, all CFs share one block cache instance. You can configure the size of the cache by setting the `capacity` parameter under `[storage.block-cache]`. The bigger the block cache, the more hot data can be cached, and the easier to read data, in the meantime, the more system memory is occupied. To use a separate block cache instance for each CF, set `shared=false` under `[storage.block-cache]`, and configure individual block cache size for each CF. For example, you can configure the size of `write` CF by setting the `block-cache-size` parameter under `[rocksdb.writecf]`.
+After TiKV 3.0, by default, all CFs share one block cache instance. You can configure the size of the cache by setting the `capacity` parameter under `[storage.block-cache]`. The bigger the block cache, the more hot data can be cached, and the easier to read data, in the meantime, the more system memory is occupied. To use a separate block cache instance for each CF, set `shared=false` under `[storage.block-cache]`, and configure individual block cache size for each CF. For example, you can configure the size of `write` CF by setting the `block-cache-size` parameter under `[rocksdb.writecf]`.
+
+Before TiKV 3.0, shared block cache is not supported, and you need to configure block cache for each CF individually.
 
 Each CF also has a separate `write buffer`. You can configure the size by setting the `write-buffer-size` parameter.
 

--- a/tools/tikv-control.md
+++ b/tools/tikv-control.md
@@ -220,7 +220,7 @@ You can use the `modify-tikv-config` command to dynamically modify the configura
 # Set shared block cache size.
 $ tikv-ctl modify-tikv-config -m storage -n block_cache.capacity -v 10GB
 success!
-# Set block cache size for individual CF when shared block cache is not used.
+# Set block cache size for write CF when shared block cache is not used.
 $ tikv-ctl modify-tikv-config -m kvdb -n write.block_cache_size -v 256MB
 success!
 $ tikv-ctl modify-tikv-config -m kvdb -n max_background_jobs -v 8

--- a/tools/tikv-control.md
+++ b/tools/tikv-control.md
@@ -217,7 +217,11 @@ You can use the `modify-tikv-config` command to dynamically modify the configura
 - `-v` is used to specify the configuration value.
 
 ```bash
+# Set shared block cache size.
 $ tikv-ctl modify-tikv-config -m storage -n block_cache.capacity -v 10GB
+success!
+# Set block cache size for individual CF when shared block cache is not used.
+$ tikv-ctl modify-tikv-config -m kvdb -n write.block_cache_size -v 256MB
 success!
 $ tikv-ctl modify-tikv-config -m kvdb -n max_background_jobs -v 8
 success!


### PR DESCRIPTION
Description for shared block cache was added in #1114, but it fail to mention the change is for 3.0 only.