### PR TITLE
sql: move error codes page

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -211,7 +211,7 @@
   + System Databases
     - [`mysql`](dev/reference/system-databases/mysql.md)
     - [`information_schema`](dev/reference/system-databases/information-schema.md)
-  - [Errors Codes](sql/error.md)
+  - [Errors Codes](dev/reference/error-codes.md)
   - [Supported Client Drivers](dev/reference/supported-clients.md)
   - [Garbage Collection (GC)](dev/reference/garbage-collection.md)
   + Performance

--- a/dev/reference/error-codes.md
+++ b/dev/reference/error-codes.md
@@ -2,6 +2,7 @@
 title: Error Codes and Troubleshooting
 summary: Learn about the error codes and solutions in TiDB.
 category: reference
+aliases: ['/docs/sql/error/']
 ---
 
 # Error Codes and Troubleshooting
@@ -23,8 +24,8 @@ TiDB is compatible with the error codes in MySQL, and in most cases returns the 
 | 9004 | This error occurs when a large number of transactional conflicts exist in the database. | Check the code of application. |
 | 9005 | A certain Raft Group is not available, such as the number of replicas is not enough. This error usually occurs when the TiKV server is busy or the TiKV node is down. | Check the state/monitor/log of the TiKV server. |
 | 9006 | The interval of GC Life Time is too short and the data that should be read by the long transactions might be cleared. | Extend the interval of GC Life Time. |
-| 9500 | A single transaction is too large. | See [here](/FAQ.md#the-error-message-transaction-too-large-is-displayed) for the solution. |
+| 9500 | A single transaction is too large. | See [here](/faq/tidb.md#the-error-message-transaction-too-large-is-displayed) for the solution. |
 
 ## Troubleshooting
 
-See the [troubleshooting](/trouble-shooting.md) and [FAQ](/FAQ.md) documents.
+See the [troubleshooting](/dev/how-to/troubleshoot/cluster-setup.md) and [FAQ](/faq/tidb.md) documents.


### PR DESCRIPTION
This PR moves the error codes page, which was temporarily moved back in a hotfix: https://github.com/pingcap/docs/pull/1131

Please notify the EE team before merging, since it could break CI -- but I am not sure why it did last time.