### PR TITLE
tools: Move tools to new location

### DIFF
--- a/dev/reference/tools/data-migration/dm-worker-intro.md
+++ b/dev/reference/tools/data-migration/dm-worker-intro.md
@@ -1,7 +1,8 @@
 ---
 title: DM-worker Introduction
 summary: Learn the features of DM-worker.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/dm-worker-intro/'] 
 ---
 
 # DM-worker Introduction

--- a/dev/reference/tools/data-migration/precheck.md
+++ b/dev/reference/tools/data-migration/precheck.md
@@ -1,7 +1,8 @@
 ---
 title: Precheck the upstream MySQL instance configuration
 summary: Use the precheck feature provided by DM to detect errors in the upstream MySQL instance configuration.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/precheck/']
 ---
 
 # Precheck the upstream MySQL instance configuration
@@ -41,7 +42,7 @@ Upstream and downstream database users must have the corresponding read and writ
     TiDB differs from MySQL in compatibility in the following aspects:
 
     - TiDB does not support the foreign key.
-    - [Character set compatibility differs](/sql/character-set-support.md).
+    - [Character set compatibility differs](/dev/reference/sql/character-set.md).
 
 + The consistency of the sharded tables in the multiple upstream MySQL instances
 

--- a/dev/reference/tools/data-migration/query-status.md
+++ b/dev/reference/tools/data-migration/query-status.md
@@ -1,7 +1,8 @@
 ---
 title: Data Migration Query Status
 summary: Learn the DM query result and subtask status.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/query-status/']
 ---
 
 # Data Migration Query Status

--- a/dev/reference/tools/data-migration/relay-log.md
+++ b/dev/reference/tools/data-migration/relay-log.md
@@ -1,7 +1,8 @@
 ---
 title: Data Migration Relay Log
 summary: Learn the directory structure, initial synchronization rules and data purge of DM relay logs.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/relay-log/'] 
 ---
 
 # Data Migration Relay Log
@@ -36,7 +37,7 @@ An example of the directory structure of the local storage for a relay log:
 
     - `subdir` is named `<Upstream database UUID>.<Local subdir serial number>`.
 
-    - After [a switch between master and slave instances](/tools/dm/cluster-operations.md#switch-between-master-and-slave-instances) in the upstream, DM-worker generates a new `subdir` directory with an incremental serial number.
+    - After [a switch between master and slave instances](/dev/reference/tools/data-migration/cluster-operations.md#switch-between-master-and-slave-instances) in the upstream, DM-worker generates a new `subdir` directory with an incremental serial number.
     
         - In the above example, for the `7e427cc0-091c-11e9-9e45-72b7c59d52d7.000001` directory, `7e427cc0-091c-11e9-9e45-72b7c59d52d7` is the upstream database UUID and `000001` is the local `subdir` serial number.
 

--- a/dev/reference/tools/data-migration/skip-replace-sqls.md
+++ b/dev/reference/tools/data-migration/skip-replace-sqls.md
@@ -1,14 +1,15 @@
 ---
 title: Skip or Replace Abnormal SQL Statements
 summary: Learn how to skip or replace abnormal SQL statements when you use Data Migration.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/skip-replace-sqls/'] 
 ---
 
 # Skip or Replace Abnormal SQL Statements
 
 This document introduces how to handle abnormal SQL statements using Data Migration (DM). 
 
-Currently, TiDB is not completely compatible with all MySQL syntax (see [the DDL statements supported by TiDB](/sql/ddl.md)). Therefore, when DM is replicating data from MySQL to TiDB and TiDB does not support the corresponding SQL statement, an error might occur and break the replication process. In this case, there are two ways to resume the replication:
+Currently, TiDB is not completely compatible with all MySQL syntax (see [the DDL statements supported by TiDB](/dev/reference/mysql-compatibility.md#ddl)). Therefore, when DM is replicating data from MySQL to TiDB and TiDB does not support the corresponding SQL statement, an error might occur and break the replication process. In this case, there are two ways to resume the replication:
 
 - Use dmctl to manually skip the binlog event to which this SQL statement corresponds
 
@@ -19,7 +20,7 @@ If you know in advance that an unsupported SQL statement is going to be replicat
 #### Restrictions
 
 - The skip or replace operation is a one-time operation that is only used to skip or replace the SQL statement unsupported by the downstream TiDB. Do not handle other replication errors with this approach.
-    - For other replication errors, try to handle them using [Black and white table lists](/tools/dm/data-synchronization-features.md#black-and-white-table-lists) or [Binlog event filtering](/tools/dm/data-synchronization-features.md#binlog-event-filtering).
+    - For other replication errors, try to handle them using [Black and white table lists](/dev/reference/tools/data-migration/features/overview.md#black-and-white-table-lists) or [Binlog event filtering](/dev/reference/tools/data-migration/features/overview.md#binlog-event-filter).
 
 - If it is unacceptable in the actual production environment that the abnormal DDL statement is skipped in the downstream TiDB and it cannot be replaced with other DDL statements, then do not use this approach.
     - For example: `DROP PRIMARY KEY`
@@ -29,7 +30,7 @@ If you know in advance that an unsupported SQL statement is going to be replicat
 
 - `--sharding` is only used to preset the operation to the sharding group. You must preset it before executing the DDL statement and presetting it after executing the DDL is not allowed.
     - `--sharding` only supports presetting operations, and in this mode, you can only use `--sql-pattern` to match the binlog event.
-    - For the principles of replicating sharding DDL statements using DM, see [Merge and replicate data from sharded tables](/tools/dm/shard-merge.md#principles)
+    - For the principles of replicating sharding DDL statements using DM, see [Merge and replicate data from sharded tables](/dev/reference/tools/data-migration/features/shard-merge.md#principles)
 
 #### Match the binlog event
 

--- a/dev/reference/tools/data-migration/table-selector.md
+++ b/dev/reference/tools/data-migration/table-selector.md
@@ -1,7 +1,8 @@
 ---
 title: Table Selector
 summary: Learn about Table Selector used by the table routing, binlog event filtering, and column mapping rule of Data Migration.
-category: tools
+category: reference
+aliases: ['/docs/tools/dm/table-selector/']
 ---
 
 # Table Selector

--- a/dev/reference/tools/sync-diff-inspector.md
+++ b/dev/reference/tools/sync-diff-inspector.md
@@ -1,7 +1,8 @@
 ---
 title: sync-diff-inspector User Guide
 summary: Use sync-diff-inspector to compare data and repair inconsistent data.
-category: tools
+category: reference
+aliases: ['/docs/tools/sync-diff-inspector/']
 ---
 
 # sync-diff-inspector User Guide
@@ -163,7 +164,7 @@ password = ""
 
 Assuming that you have two MySQL instances, use a synchronization tool to synchronize the data into TiDB as shown below:
 
-![shard-table-sync](../media/shard-table-sync.png)
+![shard-table-sync](/media/shard-table-sync.png)
 
 If you need to check the data consistency after synchronization, you can use the following configuration to compare data:
 

--- a/dev/reference/tools/tikv-control.md
+++ b/dev/reference/tools/tikv-control.md
@@ -1,7 +1,8 @@
 ---
 title: TiKV Control User Guide
 summary: Use TiKV Control to manage a TiKV cluster.
-category: tools
+category: reference
+aliases: ['/docs/tools/tikv-control/']
 ---
 
 # TiKV Control User Guide


### PR DESCRIPTION
Moves the remainder of tools/* to a versioned location using the new structure (dev/reference/tools).

Redirects are put in place to move users to new location.