### PR TITLE
releases: remove one note of tidb binlog

### DIFF
--- a/releases/3.0.0-rc.2.md
+++ b/releases/3.0.0-rc.2.md
@@ -115,7 +115,7 @@ On May 28, 2019, TiDB 3.0.0-rc.2 is released. The corresponding TiDB Ansible ver
 
 + TiDB Binlog
     - Add a metric to track the delay of data replication downstream [#594](https://github.com/pingcap/tidb-binlog/pull/594)
-    - Upgrade the parser version of TiDB Binlog [#608](https://github.com/pingcap/tidb-binlog/pull/608)
+
 
 + TiDB Lightning
     


### PR DESCRIPTION
### Removal Reason
Checked with devs, tidb binlog doesn't upgrade the Parser in 3.0, it's in 2.1. So remove this note.