### PR TITLE
dev/*: add `exists_in_docs_cn: false` in metadata block for 12 files

### DIFF
--- a/dev/how-to/deploy/from-tarball/production-environment.md
+++ b/dev/how-to/deploy/from-tarball/production-environment.md
@@ -3,6 +3,7 @@ title: Production Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
 aliases: ['/docs/op-guide/binary-deployment/']
+exists_in_docs_cn: false
 ---
 
 # Production Deployment from Binary Tarball

--- a/dev/how-to/deploy/from-tarball/testing-environment.md
+++ b/dev/how-to/deploy/from-tarball/testing-environment.md
@@ -3,6 +3,7 @@ title: Testing Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
 aliases: ['/docs/op-guide/binary-testing-deployment/']
+exists_in_docs_cn: false
 ---
 
 # Testing Deployment from Binary Tarball

--- a/dev/how-to/deploy/orchestrated/ansible-operations.md
+++ b/dev/how-to/deploy/orchestrated/ansible-operations.md
@@ -3,6 +3,7 @@ title: TiDB-Ansible Common Operations
 summary: Learn some common operations when using TiDB-Ansible to administer a TiDB cluster.
 category: how-to
 aliases: ['/docs/op-guide/ansible-operation/']
+exists_in_docs_cn: false
 ---
 
 # TiDB-Ansible Common Operations

--- a/dev/how-to/deploy/orchestrated/kubernetes.md
+++ b/dev/how-to/deploy/orchestrated/kubernetes.md
@@ -3,6 +3,7 @@ title: TiDB Deployment on Kubernetes
 summary: Use TiDB Operator to quickly deploy a TiDB cluster on Kubernetes
 category: how-to
 aliases: ['/docs/op-guide/kubernetes/']
+exists_in_docs_cn: false
 ---
 
 # TiDB Deployment on Kubernetes

--- a/dev/how-to/get-started/data-migration.md
+++ b/dev/how-to/get-started/data-migration.md
@@ -2,6 +2,7 @@
 title: TiDB DM (Data Migration) Tutorial
 summary: Learn the basics of the TiDB DM (Data Migration) platform, to migrate a simple sharded schema from MySQL to TiDB.
 category: how-to
+exists_in_docs_cn: false
 ---
 
 # TiDB DM (Data Migration) Tutorial

--- a/dev/how-to/get-started/import-example-database.md
+++ b/dev/how-to/get-started/import-example-database.md
@@ -3,6 +3,7 @@ title: Import Example Database
 summary: Install the Bikeshare example database.
 category: how-to 
 aliases: ['/docs/bikeshare-example-database/']
+exists_in_docs_cn: false
 ---
 
 # Import Example Database

--- a/dev/how-to/get-started/local-cluster/install-from-binary.md
+++ b/dev/how-to/get-started/local-cluster/install-from-binary.md
@@ -3,6 +3,7 @@ title: Local Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
 aliases: ['/docs/op-guide/binary-local-deployment/']
+exists_in_docs_cn: false
 ---
 
 # Local Deployment from Binary Tarball

--- a/dev/how-to/get-started/local-cluster/install-from-dbdeployer.md
+++ b/dev/how-to/get-started/local-cluster/install-from-dbdeployer.md
@@ -2,6 +2,7 @@
 title: Install from DBdeployer 
 summary: Install TiDB using the DBdeployer package manager.
 category: how-to
+exists_in_docs_cn: false
 ---
 
 # Install from DBdeployer

--- a/dev/how-to/get-started/local-cluster/install-from-homebrew.md
+++ b/dev/how-to/get-started/local-cluster/install-from-homebrew.md
@@ -2,6 +2,7 @@
 title: Install from Homebrew 
 summary: Install TiDB using the Homebrew package manager.
 category: how-to
+exists_in_docs_cn: false
 ---
 
 # Install from Homebrew

--- a/dev/how-to/get-started/local-cluster/install-from-kubernetes.md
+++ b/dev/how-to/get-started/local-cluster/install-from-kubernetes.md
@@ -2,7 +2,8 @@
 title: Deploy TiDB to Kubernetes Locally
 summary: Use TiDB Operator to quickly deploy a TiDB cluster on Kubernetes
 category: how-to
-aliases: ['/docs/op-guide/kubernetes-local/'] 
+aliases: ['/docs/op-guide/kubernetes-local/']
+exists_in_docs_cn: false
 ---
 
 # Deploy TiDB to Kubernetes Locally

--- a/dev/how-to/upgrade/data-migration.md
+++ b/dev/how-to/upgrade/data-migration.md
@@ -3,6 +3,7 @@ title: Upgrade Data Migration
 summary: Learn how to upgrade a Data Migration version to an incompatible version.
 category: how-to
 aliases: ['/docs/tools/dm/dm-upgrade/','/docs/dev/how-to/maintain/upgrade/data-migration/']
+exists_in_docs_cn: false
 ---
 
 # Upgrade Data Migration

--- a/dev/how-to/upgrade/data-migration.md
+++ b/dev/how-to/upgrade/data-migration.md
@@ -3,7 +3,6 @@ title: Upgrade Data Migration
 summary: Learn how to upgrade a Data Migration version to an incompatible version.
 category: how-to
 aliases: ['/docs/tools/dm/dm-upgrade/','/docs/dev/how-to/maintain/upgrade/data-migration/']
-exists_in_docs_cn: false
 ---
 
 # Upgrade Data Migration

--- a/dev/reference/sql/statements/add-column.md
+++ b/dev/reference/sql/statements/add-column.md
@@ -2,6 +2,7 @@
 title: ADD COLUMN | TiDB SQL Statement Reference 
 summary: An overview of the usage of ADD COLUMN for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ADD COLUMN 

--- a/dev/reference/sql/statements/add-index.md
+++ b/dev/reference/sql/statements/add-index.md
@@ -2,6 +2,7 @@
 title: ADD INDEX | TiDB SQL Statement Reference 
 summary: An overview of the usage of ADD INDEX for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ADD INDEX 


### PR DESCRIPTION
Currently, these files have no corresponding Chinese version.
I add the `exists_in_docs_cn: false` attribute for these files to avoid broken links.
Once the Chinese docs are ready, we can remove the attribute.
@dcalvin @YiniXu9506 @lilin90 PTAL