### PR TITLE
dev/reference/sql/statements: remove invalid links

### DIFF
--- a/dev/reference/sql/statements/alter-table.md
+++ b/dev/reference/sql/statements/alter-table.md
@@ -67,7 +67,6 @@ mysql> EXPLAIN SELECT * FROM t1 WHERE c1 = 3;
 
 * [ADD COLUMN](/dev/reference/sql/statements/add-column.md)
 * [DROP COLUMN](/dev/reference/sql/statements/drop-column.md)
-* [RENAME COLUMN](/dev/reference/sql/statements/rename-column.md)
 * [ADD INDEX](/dev/reference/sql/statements/add-index.md)
 * [DROP INDEX](/dev/reference/sql/statements/drop-index.md)
 * [RENAME INDEX](/dev/reference/sql/statements/rename-index.md)

--- a/dev/reference/sql/statements/create-database.md
+++ b/dev/reference/sql/statements/create-database.md
@@ -57,6 +57,4 @@ This statement is understood to be fully compatible with MySQL. Any compatibilit
 ## See also
 
 * [USE](/dev/reference/sql/statements/use.md)
-* [ALTER DATABASE](/dev/reference/sql/statements/alter-database.md)
 * [DROP DATABASE](/dev/reference/sql/statements/drop-database.md)
-* [SHOW CREATE DATABASE](/dev/reference/sql/statements/show-create-database.md)

--- a/dev/reference/sql/statements/flush-privileges.md
+++ b/dev/reference/sql/statements/flush-privileges.md
@@ -35,6 +35,4 @@ This statement is understood to be fully compatible with MySQL. Any compatibilit
 
 ## See also
 
-* [GRANT](/dev/reference/sql/statements/grant.md)
-* [REVOKE](/dev/reference/sql/statements/revoke.md)
 * [Privilege Management](/dev/reference/security/privilege-system.md)

--- a/dev/reference/sql/statements/flush-tables.md
+++ b/dev/reference/sql/statements/flush-tables.md
@@ -51,5 +51,4 @@ ERROR 1105 (HY000): FLUSH TABLES WITH READ LOCK is not supported.  Please use @@
 
 ## See also
 
-* [LOCK TABLES](/dev/reference/sql/statements/lock-tables.md)
 * [Read historical data](/dev/how-to/get-started/read-historical-data.md)

--- a/dev/reference/sql/statements/show-variables.md
+++ b/dev/reference/sql/statements/show-variables.md
@@ -103,6 +103,3 @@ mysql> SHOW GLOBAL VARIABLES LIKE 'time_zone%';
 
 This statement is understood to be fully compatible with MySQL. Any compatibility differences should be [reported via an issue](/report-issue.md) on GitHub.
 
-## See also
-
-* [SET](/dev/reference/sql/statements/set-session-variable.md)


### PR DESCRIPTION
These files do not exist. Invalid links affect SEO ranking, so I remove them.
Once these files are ready, we can add these links back.
@dcalvin @morgo @lilin90