### PR TITLE
dev/reference/sql: add `exists_in_docs_cn: false` meta info for 76 files

### DIFF
--- a/dev/reference/sql/data-types/date-and-time.md
+++ b/dev/reference/sql/data-types/date-and-time.md
@@ -3,6 +3,7 @@ title: Date and Time Types
 summary: Learn about the supported date and time types.
 category: reference
 aliases: ['/docs/sql/date-and-time-types/']
+exists_in_docs_cn: false
 ---
 
 # Date and Time Types

--- a/dev/reference/sql/data-types/default-values.md
+++ b/dev/reference/sql/data-types/default-values.md
@@ -2,6 +2,7 @@
 title: TiDB Data Type
 summary: Learn about default values for data types in TiDB.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # Default Values

--- a/dev/reference/sql/data-types/json.md
+++ b/dev/reference/sql/data-types/json.md
@@ -2,6 +2,7 @@
 title: TiDB Data Type
 summary: Learn about the JSON data type in TiDB.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # JSON Type

--- a/dev/reference/sql/data-types/numeric.md
+++ b/dev/reference/sql/data-types/numeric.md
@@ -2,6 +2,7 @@
 title: Numeric Types
 summary: Learn about numeric data types supported in TiDB.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # Numeric Types

--- a/dev/reference/sql/data-types/overview.md
+++ b/dev/reference/sql/data-types/overview.md
@@ -3,6 +3,7 @@ title: Data Types
 summary: Learn about the data types supported in TiDB.
 category: reference
 aliases: ['/docs/sql/datatype/','/docs/dev/reference/sql/data-types/']
+exists_in_docs_cn: false
 ---
 
 # Data Types

--- a/dev/reference/sql/data-types/string.md
+++ b/dev/reference/sql/data-types/string.md
@@ -2,6 +2,7 @@
 title: String types
 summary: Learn about the string types supported in TiDB.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # String Types

--- a/dev/reference/sql/statements/alter-table.md
+++ b/dev/reference/sql/statements/alter-table.md
@@ -2,6 +2,7 @@
 title: ALTER TABLE | TiDB SQL Statement Reference 
 summary: An overview of the usage of ALTER TABLE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ALTER TABLE

--- a/dev/reference/sql/statements/alter-user.md
+++ b/dev/reference/sql/statements/alter-user.md
@@ -2,6 +2,7 @@
 title: ALTER USER | TiDB SQL Statement Reference 
 summary: An overview of the usage of ALTER USER for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ALTER USER

--- a/dev/reference/sql/statements/analyze-table.md
+++ b/dev/reference/sql/statements/analyze-table.md
@@ -2,6 +2,7 @@
 title: ANALYZE TABLE | TiDB SQL Statement Reference 
 summary: An overview of the usage of ANALYZE TABLE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ANALYZE TABLE 

--- a/dev/reference/sql/statements/begin.md
+++ b/dev/reference/sql/statements/begin.md
@@ -2,6 +2,7 @@
 title: BEGIN | TiDB SQL Statement Reference 
 summary: An overview of the usage of BEGIN for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # BEGIN

--- a/dev/reference/sql/statements/change-column.md
+++ b/dev/reference/sql/statements/change-column.md
@@ -2,6 +2,7 @@
 title: CHANGE COLUMN | TiDB SQL Statement Reference 
 summary: An overview of the usage of CHANGE COLUMN for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CHANGE COLUMN

--- a/dev/reference/sql/statements/commit.md
+++ b/dev/reference/sql/statements/commit.md
@@ -2,6 +2,7 @@
 title: COMMIT | TiDB SQL Statement Reference 
 summary: An overview of the usage of COMMIT for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # COMMIT

--- a/dev/reference/sql/statements/create-database.md
+++ b/dev/reference/sql/statements/create-database.md
@@ -2,6 +2,7 @@
 title: CREATE DATABASE | TiDB SQL Statement Reference 
 summary: An overview of the usage of CREATE DATABASE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CREATE DATABASE

--- a/dev/reference/sql/statements/create-index.md
+++ b/dev/reference/sql/statements/create-index.md
@@ -2,6 +2,7 @@
 title: CREATE INDEX | TiDB SQL Statement Reference 
 summary: An overview of the usage of CREATE INDEX for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CREATE INDEX

--- a/dev/reference/sql/statements/create-table-like.md
+++ b/dev/reference/sql/statements/create-table-like.md
@@ -2,6 +2,7 @@
 title: CREATE TABLE LIKE | TiDB SQL Statement Reference 
 summary: An overview of the usage of CREATE TABLE AS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CREATE TABLE LIKE

--- a/dev/reference/sql/statements/create-table.md
+++ b/dev/reference/sql/statements/create-table.md
@@ -3,6 +3,7 @@ title: CREATE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE TABLE for the TiDB database.
 category: reference
 aliases: ['/docs/sql/ddl/']
+exists_in_docs_cn: false
 ---
 
 # CREATE TABLE 

--- a/dev/reference/sql/statements/create-user.md
+++ b/dev/reference/sql/statements/create-user.md
@@ -2,6 +2,7 @@
 title: CREATE USER | TiDB SQL Statement Reference 
 summary: An overview of the usage of CREATE USER for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CREATE USER

--- a/dev/reference/sql/statements/create-view.md
+++ b/dev/reference/sql/statements/create-view.md
@@ -2,6 +2,7 @@
 title: CREATE VIEW | TiDB SQL Statement Reference 
 summary: An overview of the usage of CREATE VIEW for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # CREATE VIEW

--- a/dev/reference/sql/statements/deallocate.md
+++ b/dev/reference/sql/statements/deallocate.md
@@ -2,6 +2,7 @@
 title: DEALLOCATE | TiDB SQL Statement Reference 
 summary: An overview of the usage of DEALLOCATE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DEALLOCATE 

--- a/dev/reference/sql/statements/delete.md
+++ b/dev/reference/sql/statements/delete.md
@@ -2,6 +2,7 @@
 title: DELETE | TiDB SQL Statement Reference 
 summary: An overview of the usage of DELETE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DELETE

--- a/dev/reference/sql/statements/desc.md
+++ b/dev/reference/sql/statements/desc.md
@@ -2,6 +2,7 @@
 title: DESC | TiDB SQL Statement Reference 
 summary: An overview of the usage of DESC for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DESC

--- a/dev/reference/sql/statements/describe.md
+++ b/dev/reference/sql/statements/describe.md
@@ -2,6 +2,7 @@
 title: DESCRIBE | TiDB SQL Statement Reference 
 summary: An overview of the usage of DESCRIBE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DESCRIBE

--- a/dev/reference/sql/statements/do.md
+++ b/dev/reference/sql/statements/do.md
@@ -2,6 +2,7 @@
 title: DO | TiDB SQL Statement Reference 
 summary: An overview of the usage of DO for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DO 

--- a/dev/reference/sql/statements/drop-column.md
+++ b/dev/reference/sql/statements/drop-column.md
@@ -2,6 +2,7 @@
 title: DROP COLUMN | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP COLUMN for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP COLUMN

--- a/dev/reference/sql/statements/drop-database.md
+++ b/dev/reference/sql/statements/drop-database.md
@@ -2,6 +2,7 @@
 title: DROP DATABASE | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP DATABASE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP DATABASE
@@ -61,5 +62,3 @@ This statement is understood to be fully compatible with MySQL. Any compatibilit
 ## See also
 
 * [CREATE DATABASE](/dev/reference/sql/statements/create-database.md)
-* [ALTER DATABASE](/dev/reference/sql/statements/alter-database.md)
-* [SHOW CREATE DATABASE](/dev/reference/sql/statements/show-create-database.md)

--- a/dev/reference/sql/statements/drop-index.md
+++ b/dev/reference/sql/statements/drop-index.md
@@ -2,6 +2,7 @@
 title: DROP INDEX | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP INDEX for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP INDEX

--- a/dev/reference/sql/statements/drop-table.md
+++ b/dev/reference/sql/statements/drop-table.md
@@ -2,6 +2,7 @@
 title: DROP TABLE | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP TABLE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP TABLE

--- a/dev/reference/sql/statements/drop-user.md
+++ b/dev/reference/sql/statements/drop-user.md
@@ -2,6 +2,7 @@
 title: DROP USER | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP USER for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP USER

--- a/dev/reference/sql/statements/drop-view.md
+++ b/dev/reference/sql/statements/drop-view.md
@@ -2,6 +2,7 @@
 title: DROP VIEW | TiDB SQL Statement Reference 
 summary: An overview of the usage of DROP VIEW for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # DROP VIEW

--- a/dev/reference/sql/statements/execute.md
+++ b/dev/reference/sql/statements/execute.md
@@ -2,6 +2,7 @@
 title: EXECUTE | TiDB SQL Statement Reference 
 summary: An overview of the usage of EXECUTE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # EXECUTE

--- a/dev/reference/sql/statements/explain-analyze.md
+++ b/dev/reference/sql/statements/explain-analyze.md
@@ -2,6 +2,7 @@
 title: EXPLAIN ANALYZE | TiDB SQL Statement Reference 
 summary: An overview of the usage of EXPLAIN ANALYZE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # EXPLAIN ANALYZE

--- a/dev/reference/sql/statements/explain.md
+++ b/dev/reference/sql/statements/explain.md
@@ -3,6 +3,7 @@ title: EXPLAIN | TiDB SQL Statement Reference
 summary: An overview of the usage of EXPLAIN for the TiDB database.
 category: reference
 aliases: ['/docs/sql/util/']
+exists_in_docs_cn: false
 ---
 
 # EXPLAIN

--- a/dev/reference/sql/statements/flush-privileges.md
+++ b/dev/reference/sql/statements/flush-privileges.md
@@ -2,6 +2,7 @@
 title: FLUSH PRIVILEGES | TiDB SQL Statement Reference 
 summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # FLUSH PRIVILEGES

--- a/dev/reference/sql/statements/flush-status.md
+++ b/dev/reference/sql/statements/flush-status.md
@@ -2,6 +2,7 @@
 title: FLUSH STATUS | TiDB SQL Statement Reference 
 summary: An overview of the usage of FLUSH STATUS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # FLUSH STATUS

--- a/dev/reference/sql/statements/flush-tables.md
+++ b/dev/reference/sql/statements/flush-tables.md
@@ -2,6 +2,7 @@
 title: FLUSH TABLES | TiDB SQL Statement Reference 
 summary: An overview of the usage of FLUSH TABLES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # FLUSH TABLES

--- a/dev/reference/sql/statements/grant-privileges.md
+++ b/dev/reference/sql/statements/grant-privileges.md
@@ -2,6 +2,7 @@
 title: GRANT <privileges> | TiDB SQL Statement Reference 
 summary: An overview of the usage of GRANT <privileges> for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # GRANT <privileges>

--- a/dev/reference/sql/statements/insert.md
+++ b/dev/reference/sql/statements/insert.md
@@ -2,6 +2,7 @@
 title: INSERT | TiDB SQL Statement Reference 
 summary: An overview of the usage of INSERT for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # INSERT

--- a/dev/reference/sql/statements/kill.md
+++ b/dev/reference/sql/statements/kill.md
@@ -2,6 +2,7 @@
 title: KILL [TIDB] | TiDB SQL Statement Reference 
 summary: An overview of the usage of KILL [TIDB] for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # KILL [TIDB] 

--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -2,6 +2,7 @@
 title: LOAD DATA | TiDB SQL Statement Reference 
 summary: An overview of the usage of LOAD DATA for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # LOAD DATA

--- a/dev/reference/sql/statements/modify-column.md
+++ b/dev/reference/sql/statements/modify-column.md
@@ -2,6 +2,7 @@
 title: MODIFY COLUMN | TiDB SQL Statement Reference 
 summary: An overview of the usage of MODIFY COLUMN for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # MODIFY COLUMN

--- a/dev/reference/sql/statements/rename-index.md
+++ b/dev/reference/sql/statements/rename-index.md
@@ -2,6 +2,7 @@
 title: RENAME INDEX | TiDB SQL Statement Reference 
 summary: An overview of the usage of RENAME INDEX for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # RENAME INDEX

--- a/dev/reference/sql/statements/rename-table.md
+++ b/dev/reference/sql/statements/rename-table.md
@@ -2,6 +2,7 @@
 title: RENAME TABLE | TiDB SQL Statement Reference 
 summary: An overview of the usage of RENAME TABLE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # RENAME TABLE

--- a/dev/reference/sql/statements/replace.md
+++ b/dev/reference/sql/statements/replace.md
@@ -2,6 +2,7 @@
 title: REPLACE | TiDB SQL Statement Reference 
 summary: An overview of the usage of REPLACE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # REPLACE

--- a/dev/reference/sql/statements/revoke-privileges.md
+++ b/dev/reference/sql/statements/revoke-privileges.md
@@ -2,6 +2,7 @@
 title: REVOKE <privileges> | TiDB SQL Statement Reference 
 summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # REVOKE <privileges>

--- a/dev/reference/sql/statements/rollback.md
+++ b/dev/reference/sql/statements/rollback.md
@@ -2,6 +2,7 @@
 title: ROLLBACK | TiDB SQL Statement Reference 
 summary: An overview of the usage of ROLLBACK for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # ROLLBACK 

--- a/dev/reference/sql/statements/select.md
+++ b/dev/reference/sql/statements/select.md
@@ -3,6 +3,7 @@ title: SELECT | TiDB SQL Statement Reference
 summary: An overview of the usage of SELECT for the TiDB database.
 category: reference
 aliases: ['/docs/sql/dml/']
+exists_in_docs_cn: false
 ---
 
 # SELECT 

--- a/dev/reference/sql/statements/set-names.md
+++ b/dev/reference/sql/statements/set-names.md
@@ -2,6 +2,7 @@
 title: SET [NAMES|CHARACTER SET] |  TiDB SQL Statement Reference 
 summary: An overview of the usage of SET [NAMES|CHARACTER SET] for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SET [NAMES|CHARACTER SET]

--- a/dev/reference/sql/statements/set-password.md
+++ b/dev/reference/sql/statements/set-password.md
@@ -2,6 +2,7 @@
 title: SET PASSWORD | TiDB SQL Statement Reference 
 summary: An overview of the usage of SET PASSWORD for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SET PASSWORD

--- a/dev/reference/sql/statements/set-transaction.md
+++ b/dev/reference/sql/statements/set-transaction.md
@@ -2,6 +2,7 @@
 title: SET TRANSACTION | TiDB SQL Statement Reference 
 summary: An overview of the usage of SET TRANSACTION for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SET TRANSACTION

--- a/dev/reference/sql/statements/set-variable.md
+++ b/dev/reference/sql/statements/set-variable.md
@@ -2,6 +2,7 @@
 title: SET [GLOBAL|SESSION] <variable> | TiDB SQL Statement Reference 
 summary: An overview of the usage of SET [GLOBAL|SESSION] <variable> for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SET [GLOBAL|SESSION] <variable>

--- a/dev/reference/sql/statements/show-character-set.md
+++ b/dev/reference/sql/statements/show-character-set.md
@@ -2,6 +2,7 @@
 title: SHOW CHARACTER SET | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW CHARACTER SET for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW CHARACTER SET 

--- a/dev/reference/sql/statements/show-collation.md
+++ b/dev/reference/sql/statements/show-collation.md
@@ -2,6 +2,7 @@
 title: SHOW COLLATION | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW COLLATION for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW COLLATION

--- a/dev/reference/sql/statements/show-columns-from.md
+++ b/dev/reference/sql/statements/show-columns-from.md
@@ -2,6 +2,7 @@
 title: SHOW [FULL] COLUMNS FROM | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [FULL] COLUMNS FROM for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [FULL] COLUMNS FROM

--- a/dev/reference/sql/statements/show-create-table.md
+++ b/dev/reference/sql/statements/show-create-table.md
@@ -2,6 +2,7 @@
 title: SHOW CREATE TABLE | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW CREATE TABLE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW CREATE TABLE

--- a/dev/reference/sql/statements/show-create-user.md
+++ b/dev/reference/sql/statements/show-create-user.md
@@ -2,6 +2,7 @@
 title: SHOW CREATE USER | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW CREATE USER for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW CREATE USER 

--- a/dev/reference/sql/statements/show-databases.md
+++ b/dev/reference/sql/statements/show-databases.md
@@ -2,6 +2,7 @@
 title: SHOW DATABASES | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW DATABASES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW DATABASES

--- a/dev/reference/sql/statements/show-engines.md
+++ b/dev/reference/sql/statements/show-engines.md
@@ -2,6 +2,7 @@
 title: SHOW ENGINES | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW ENGINES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW ENGINES

--- a/dev/reference/sql/statements/show-errors.md
+++ b/dev/reference/sql/statements/show-errors.md
@@ -2,6 +2,7 @@
 title: SHOW ERRORS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW ERRORS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW ERRORS 

--- a/dev/reference/sql/statements/show-fields-from.md
+++ b/dev/reference/sql/statements/show-fields-from.md
@@ -2,6 +2,7 @@
 title: SHOW [FULL] FIELDS FROM | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [FULL] FIELDS FROM for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [FULL] FIELDS FROM

--- a/dev/reference/sql/statements/show-grants.md
+++ b/dev/reference/sql/statements/show-grants.md
@@ -2,6 +2,7 @@
 title: SHOW GRANTS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW GRANTS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW GRANTS
@@ -54,4 +55,4 @@ This statement is understood to be fully compatible with MySQL. Any compatibilit
 ## See also
 
 * [SHOW CREATE USER](/dev/reference/sql/statements/show-create-user.md)
-* [GRANT](/dev/reference/sql/statements/grant.md)
+

--- a/dev/reference/sql/statements/show-index.md
+++ b/dev/reference/sql/statements/show-index.md
@@ -2,6 +2,7 @@
 title: SHOW INDEX [FROM|IN] | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW INDEX [FROM|IN] for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW INDEX [FROM|IN]

--- a/dev/reference/sql/statements/show-indexes.md
+++ b/dev/reference/sql/statements/show-indexes.md
@@ -2,6 +2,7 @@
 title: SHOW INDEXES [FROM|IN] | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW INDEXES [FROM|IN] for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW INDEXES [FROM|IN]

--- a/dev/reference/sql/statements/show-keys.md
+++ b/dev/reference/sql/statements/show-keys.md
@@ -2,6 +2,7 @@
 title: SHOW KEYS [FROM|IN] | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW KEYS [FROM|IN] for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW KEYS [FROM|IN]

--- a/dev/reference/sql/statements/show-privileges.md
+++ b/dev/reference/sql/statements/show-privileges.md
@@ -2,6 +2,7 @@
 title: SHOW PRIVILEGES | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW PRIVILEGES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW PRIVILEGES

--- a/dev/reference/sql/statements/show-processlist.md
+++ b/dev/reference/sql/statements/show-processlist.md
@@ -2,6 +2,7 @@
 title: SHOW [FULL] PROCESSLIST | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [FULL] PROCESSLIST for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [FULL] PROCESSLIST

--- a/dev/reference/sql/statements/show-schemas.md
+++ b/dev/reference/sql/statements/show-schemas.md
@@ -2,6 +2,7 @@
 title: SHOW SCHEMAS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW SCHEMAS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW SCHEMAS

--- a/dev/reference/sql/statements/show-status.md
+++ b/dev/reference/sql/statements/show-status.md
@@ -2,6 +2,7 @@
 title: SHOW [GLOBAL|SESSION] STATUS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] STATUS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [GLOBAL|SESSION] STATUS 

--- a/dev/reference/sql/statements/show-table-status.md
+++ b/dev/reference/sql/statements/show-table-status.md
@@ -2,6 +2,7 @@
 title: SHOW TABLE STATUS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW TABLE STATUS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW TABLE STATUS 

--- a/dev/reference/sql/statements/show-tables.md
+++ b/dev/reference/sql/statements/show-tables.md
@@ -2,6 +2,7 @@
 title: SHOW [FULL] TABLES | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [FULL] TABLES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [FULL] TABLES

--- a/dev/reference/sql/statements/show-variables.md
+++ b/dev/reference/sql/statements/show-variables.md
@@ -2,6 +2,7 @@
 title: SHOW [GLOBAL|SESSION] VARIABLES | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] VARIABLES for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW [GLOBAL|SESSION] VARIABLES

--- a/dev/reference/sql/statements/show-warnings.md
+++ b/dev/reference/sql/statements/show-warnings.md
@@ -2,6 +2,7 @@
 title: SHOW WARNINGS | TiDB SQL Statement Reference 
 summary: An overview of the usage of SHOW WARNINGS for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # SHOW WARNINGS 

--- a/dev/reference/sql/statements/start-transaction.md
+++ b/dev/reference/sql/statements/start-transaction.md
@@ -2,6 +2,7 @@
 title: START TRANSACTION | TiDB SQL Statement Reference 
 summary: An overview of the usage of START TRANSACTION for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # START TRANSACTION 

--- a/dev/reference/sql/statements/trace.md
+++ b/dev/reference/sql/statements/trace.md
@@ -2,6 +2,7 @@
 title: TRACE | TiDB SQL Statement Reference 
 summary: An overview of the usage of TRACE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # TRACE

--- a/dev/reference/sql/statements/truncate.md
+++ b/dev/reference/sql/statements/truncate.md
@@ -2,6 +2,7 @@
 title: TRUNCATE | TiDB SQL Statement Reference 
 summary: An overview of the usage of TRUNCATE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # TRUNCATE

--- a/dev/reference/sql/statements/update.md
+++ b/dev/reference/sql/statements/update.md
@@ -2,6 +2,7 @@
 title: UPDATE | TiDB SQL Statement Reference 
 summary: An overview of the usage of UPDATE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # UPDATE

--- a/dev/reference/sql/statements/use.md
+++ b/dev/reference/sql/statements/use.md
@@ -2,6 +2,7 @@
 title: USE | TiDB SQL Statement Reference 
 summary: An overview of the usage of USE for the TiDB database.
 category: reference
+exists_in_docs_cn: false
 ---
 
 # USE


### PR DESCRIPTION
Currently, these files have no corresponding Chinese version.
I add the `exists_in_docs_cn: false` attribute for these files to avoid broken links.
Once the Chinese docs are ready, we can remove the attribute.
Related PR: https://github.com/pingcap/docs/pull/1182
@dcalvin @YiniXu9506 @lilin90 PTAL