### PR TITLE
tidb-in-kubernetes: migrate google deployment doc to docs repo

### DIFF
--- a/tidb-in-kubernetes/gcp-gke-tutorial.md
+++ b/tidb-in-kubernetes/gcp-gke-tutorial.md
@@ -85,7 +85,7 @@ The default setup creates a new VPC, two subnetworks, and an f1-micro instance a
 * 3 n1-standard-16 instances for TiDB
 * 3 n1-standard-2 instances for monitor
 
-> *Note*:
+> **Note:**
 >
 > The number of nodes created depends on how many availability zones there are in the chosen region. Most have 3 zones, but us-central1 has 4. See [Regions and Zones](https://cloud.google.com/compute/docs/regions-zones/) for more information and see the [Customize](#customize) section on how to customize node pools in a regional cluster.
 
@@ -150,7 +150,7 @@ gcloud compute ssh bastion --zone <zone>
 mysql -h <tidb_ilb_ip> -P 4000 -u root
 ```
 
-> **Note**:
+> **Note:**
 >
 > You need to install the MySQL client before you connect to TiDB via MySQL.
 
@@ -327,7 +327,3 @@ You have to manually delete disks in the Google Cloud Console, or with `gcloud` 
 > **Note:**
 >
 > When `terraform destroy` is running, an error with the following message might occur: `Error reading Container Cluster "my-cluster": Cluster "my-cluster" has status "RECONCILING" with message""`. This happens when GCP is upgrading the kubernetes master node, which it does automatically at times. While this is happening, it is not possible to delete the cluster. When it is done, run `terraform destroy` again.
-
-## More information
-
-Please view our [operation guide](./operation-guide.md).

--- a/tidb-in-kubernetes/gcp-gke-tutorial.md
+++ b/tidb-in-kubernetes/gcp-gke-tutorial.md
@@ -1,0 +1,243 @@
+# Deploy TiDB Operator and TiDB cluster on GCP GKE
+
+This document describes how to deploy TiDB Operator and a TiDB cluster on GCP GKE with your laptop (Linux or macOS) for development or testing.
+
+## Prerequisites
+
+First of all, make sure the following items are installed on your machine:
+
+* [Google Cloud SDK](https://cloud.google.com/sdk/install)
+* [terraform](https://www.terraform.io/downloads.html) >= 0.12
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) >= 1.14
+* [helm](https://github.com/helm/helm/blob/master/docs/install.md#installing-the-helm-client) >= 2.9.0 and < 3.0.0
+* [jq](https://stedolan.github.io/jq/download/)
+
+## Configure
+
+Before deploying, you need to configure several items to guarantee a smooth deployment.
+
+### Configure Cloud SDK
+
+After you install Google Cloud SDK, you need to run `gcloud init` to [perform initial setup tasks](https://cloud.google.com/sdk/docs/initializing).
+
+### Configure APIs
+
+If the GCP project is new, make sure the relevant APIs are enabled:
+
+```bash
+gcloud services enable cloudresourcemanager.googleapis.com && \
+gcloud services enable cloudbilling.googleapis.com && \
+gcloud services enable iam.googleapis.com && \
+gcloud services enable compute.googleapis.com && \
+gcloud services enable container.googleapis.com
+```
+
+### Configure Terraform
+
+The terraform script expects three environment variables. You can let Terraform prompt you for them, or `export` them in the `~/.bash_profile` file ahead of time. The required environment variables are:
+
+* `TF_VAR_GCP_CREDENTIALS_PATH`: Path to a valid GCP credentials file.
+    - It is recommended to create a new service account to be used by Terraform. See [this page](https://cloud.google.com/iam/docs/creating-managing-service-accounts) to create a service account and grant `Project Editor` role to it.
+    - See [this page](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) to create service account keys, and choose `JSON` key type during creation. The downloaded `JSON` file that contains the private key is the credentials file you need.
+* `TF_VAR_GCP_REGION`: The region to create the resources in, for example: `us-west1`.
+* `TF_VAR_GCP_PROJECT`: The name of the GCP project.
+
+> *Note*: The service account must have sufficient permissions to create resources in the project. The `Project Editor` primitive will accomplish this.
+
+To set the three environment variables, for example, you can enter in your terminal:
+
+```bash
+# Replace the values with the path to the JSON file you have downloaded, the GCP region and your GCP project name.
+export TF_VAR_GCP_CREDENTIALS_PATH="/Path/to/my-project.json"
+export TF_VAR_GCP_REGION="us-west1"
+export TF_VAR_GCP_PROJECT="my-project"
+```
+
+You can also append them in your `~/.bash_profile` so they will be exported automatically next time.
+
+## Deploy
+
+The default setup creates a new VPC, two subnetworks, and an f1-micro instance as a bastion machine. The GKE cluster is created with the following instance types as worker nodes:
+
+* 3 n1-standard-4 instances for PD
+* 3 n1-highmem-8 instances for TiKV
+* 3 n1-standard-16 instances for TiDB
+* 3 n1-standard-2 instances for monitor
+
+> *Note*: The number of nodes created depends on how many availability zones there are in the chosen region. Most have 3 zones, but us-central1 has 4. See [Regions and Zones](https://cloud.google.com/compute/docs/regions-zones/) for more information and see the [Customize](#customize) section on how to customize node pools in a regional cluster.
+
+The default setup, as listed above, requires at least 91 CPUs which exceed the default CPU quota of a GCP project. To increase your project's quota, follow the instructions [here](https://cloud.google.com/compute/quotas). You need more CPUs if you need to scale out.
+
+Now that you have configured everything needed, you can launch the script to deploy the TiDB cluster:
+
+```bash
+git clone --depth=1 https://github.com/pingcap/tidb-operator
+cd tidb-operator/deploy/gcp
+terraform init
+terraform apply
+```
+
+When you run `terraform apply`, you may be asked to set three environment variables if you have not exported them in advance. See [Configure Terraform](#configure-terraform) for details.
+
+It might take 10 minutes or more to finish the process. A successful deployment gives the output like:
+
+```
+Apply complete! Resources: 17 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+cluster_id = my-cluster
+cluster_name = my-cluster
+how_to_connect_to_mysql_from_bastion = mysql -h 172.31.252.20 -P 4000 -u root
+how_to_ssh_to_bastion = gcloud compute ssh bastion --zone us-west1-b
+kubeconfig_file = ./credentials/kubeconfig_my-cluster
+monitor_ilb_ip = 35.227.134.146
+monitor_port = 3000
+region = us-west1
+tidb_ilb_ip = 172.31.252.20
+tidb_port = 4000
+tidb_version = v3.0.0-rc.1
+```
+
+## Access the database
+
+After `terraform apply` is successful, the TiDB cluster can be accessed by SSHing into the bastion machine and connecting via MySQL:
+
+```bash
+# Replace the `<>` parts with values from the output.
+gcloud compute ssh bastion --zone <zone>
+mysql -h <tidb_ilb_ip> -P 4000 -u root
+```
+
+> *Note*: You need to install the MySQL client before you connect to TiDB via MySQL.
+
+## Interact with the cluster
+
+You can interact with the cluster using `kubectl` and `helm` with the kubeconfig file `credentials/kubeconfig_<cluster_name>` as follows. The default `cluster_name` is `my-cluster`, which can be changed in `variables.tf`.
+
+```bash
+# By specifying --kubeconfig argument.
+kubectl --kubeconfig credentials/kubeconfig_<cluster_name> get po -n tidb
+helm --kubeconfig credentials/kubeconfig_<cluster_name> ls
+
+# Or setting KUBECONFIG environment variable.
+export KUBECONFIG=$PWD/credentials/kubeconfig_<cluster_name>
+kubectl get po -n tidb
+helm ls
+```
+
+## Upgrade
+
+To upgrade the TiDB cluster, modify the `tidb_version` variable to a higher version in the `variables.tf` file, and run `terraform apply`.
+
+For example, to upgrade the cluster to the 3.0.0-rc.2 version, modify the `tidb_version` to `v3.0.0-rc.2`:
+
+```
+variable "tidb_version" {
+  description = "TiDB version"
+  default     = "v3.0.0-rc.2"
+}
+```
+
+The upgrading does not finish immediately. You can run `kubectl --kubeconfig credentials/kubeconfig_<cluster_name> get po -n tidb --watch` to verify that all pods are in `Running` state. Then you can [access the database](#access-the-database) and use `tidb_version()` to see whether the cluster has been upgraded successfully:
+
+```sql
+MySQL [(none)]> select tidb_version();
+*************************** 1. row ***************************
+tidb_version(): Release Version: v3.0.0-rc.2
+Git Commit Hash: 06f3f63d5a87e7f0436c0618cf524fea7172eb93
+Git Branch: HEAD
+UTC Build Time: 2019-05-28 12:48:52
+GoVersion: go version go1.12 linux/amd64
+Race Enabled: false
+TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
+Check Table Before Drop: false
+1 row in set (0.001 sec)
+```
+
+## Scale
+
+To scale the TiDB cluster, modify `tikv_count`, `tikv_replica_count`, `tidb_count`, and `tidb_replica_count` in the `variables.tf` file to your desired count, and run `terraform apply`.
+
+Currently, scaling in is not supported since we cannot determine which node to remove. Scaling out needs a few minutes to complete, you can watch the scaling-out process by `kubectl --kubeconfig credentials/kubeconfig_<cluster_name> get po -n tidb --watch`.
+
+For example, to scale out the cluster, you can modify the number of TiDB instances from 1 to 2:
+
+```
+variable "tidb_count" {
+  description = "Number of TiDB nodes per availability zone"
+  default     = 2
+}
+```
+
+> *Note*: Incrementing the node count creates a node per GCP availability zone.
+
+## Customize
+
+You can change default values in `variables.tf` (such as the cluster name and the TiDB version) as needed.
+
+### Customize GCP resources
+
+GCP allows attaching a local SSD to any instance type that is `n1-standard-1` or greater. This allows for good customizability.
+
+### Customize TiDB parameters
+
+Currently, there are not too many parameters exposed to be customized. However, you can modify `templates/tidb-cluster-values.yaml.tpl` before deploying. If you modify it after the cluster is created and then run `terraform apply`, it can not take effect unless the pod(s) is manually deleted.
+
+### Customize node pools
+
+The cluster is created as a regional, as opposed to a zonal cluster. This means that GKE replicates node pools to each availability zone. This is desired to maintain high availability, however for the monitoring services, like Grafana, this is potentially unnecessary. It is possible to manually remove nodes if desired via `gcloud`.
+
+> *Note*: GKE node pools are managed instance groups, so a node deleted by `gcloud compute instances delete` will be automatically recreated and added back to the cluster.
+
+Suppose that you need to delete a node from the monitor pool. You can first do:
+
+```bash
+gcloud compute instance-groups managed list | grep monitor
+```
+
+And the result will be something like this:
+
+```bash
+gke-my-cluster-monitor-pool-08578e18-grp  us-west1-b  zone   gke-my-cluster-monitor-pool-08578e18  0     0            gke-my-cluster-monitor-pool-08578e18  no
+gke-my-cluster-monitor-pool-7e31100f-grp  us-west1-c  zone   gke-my-cluster-monitor-pool-7e31100f  1     1            gke-my-cluster-monitor-pool-7e31100f  no
+gke-my-cluster-monitor-pool-78a961e5-grp  us-west1-a  zone   gke-my-cluster-monitor-pool-78a961e5  1     1            gke-my-cluster-monitor-pool-78a961e5  no
+```
+
+The first column is the name of the managed instance group, and the second column is the zone in which it was created. You also need the name of the instance in that group, and you can get it by running:
+
+```bash
+gcloud compute instance-groups managed list-instances <the-name-of-the-managed-instance-group> --zone <zone>
+```
+
+For example:
+
+```bash
+$ gcloud compute instance-groups managed list-instances gke-my-cluster-monitor-pool-08578e18-grp --zone us-west1-b
+
+NAME                                       ZONE        STATUS   ACTION  INSTANCE_TEMPLATE                     VERSION_NAME  LAST_ERROR
+gke-my-cluster-monitor-pool-08578e18-c7vd  us-west1-b  RUNNING  NONE    gke-my-cluster-monitor-pool-08578e18
+```
+
+Now you can delete the instance by specifying the name of the managed instance group and the name of the instance, for example:
+
+```bash
+gcloud compute instance-groups managed delete-instances gke-my-cluster-monitor-pool-08578e18-grp --instances=gke-my-cluster-monitor-pool-08578e18-c7vd --zone us-west1-b
+```
+
+## Destroy
+
+When you are done, the infrastructure can be torn down by running:
+
+```bash
+terraform destroy
+```
+
+You have to manually delete disks in the Google Cloud Console, or with `gcloud` after running `terraform destroy` if you do not need the data anymore.
+
+> *Note*: When `terraform destroy` is running, an error with the following message might occur: `Error reading Container Cluster "my-cluster": Cluster "my-cluster" has status "RECONCILING" with message""`. This happens when GCP is upgrading the kubernetes master node, which it does automatically at times. While this is happening, it is not possible to delete the cluster. When it is done, run `terraform destroy` again.
+
+
+## More information
+
+Please view our [operation guide](./operation-guide.md).

--- a/tidb-in-kubernetes/google-kubernetes-tutorial.md
+++ b/tidb-in-kubernetes/google-kubernetes-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy TiDB to Kubernetes on Google Cloud
 summary: Learn how to deploy TiDB on Google Cloud using Kubernetes.
-category: operations
+category: how-to
 ---
 
 # Deploy TiDB to Kubernetes on Google Cloud
@@ -94,7 +94,7 @@ Install `helm`:
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
 ```
 
-Copy `helm` to your `$HOME` directory so that it will persist after the Cloud Shell reaches its idle timeout:
+Copy `helm` to your `$HOME` directory so that it persists after the Cloud Shell reaches its idle timeout:
 
 {{< copyable "shell-regular" >}}
 
@@ -130,36 +130,45 @@ Helm repo (http://charts.pingcap.org/) houses PingCAP managed charts, such as ti
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm repo add pingcap http://charts.pingcap.org/
+helm repo add pingcap http://charts.pingcap.org/ && \
 helm repo list
 ```
 
-Then you can check the avaliable charts:
+Then you can check the available charts:
 
 {{< copyable "shell-regular" >}}
 
 ```shell
 helm repo update
+```
+
+{{< copyable "shell-regular" >}}
+
+```shell
 helm search tidb-cluster -l
+```
+
+{{< copyable "shell-regular" >}}
+
+```shell
 helm search tidb-operator -l
 ```
 
 ## Deploy TiDB Operator
 
-> **Note:** ${chartVersion} will be used in the rest of the document to represent the chart version, e.g. `v1.0.0-beta.3`.
+Note that `${chartVersion}` is used in the rest of the document to represent the chart version, e.g. `v1.0.0-beta.3`.
 
 The first TiDB component we are going to install is the TiDB Operator, using a Helm Chart. TiDB Operator is the management system that works with Kubernetes to bootstrap your TiDB cluster and keep it running. This step assumes you are in the `tidb-operator` working directory:
 
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl apply -f ./manifests/crd.yaml &&
-kubectl apply -f ./manifests/gke/persistent-disk.yml &&
+kubectl apply -f ./manifests/crd.yaml && \
+kubectl apply -f ./manifests/gke/persistent-disk.yml && \
 helm install pingcap/tidb-operator -n tidb-admin --namespace=tidb-admin --version=${chartVersion}
 ```
 
 We can watch the operator come up with:
-
 
 {{< copyable "shell-regular" >}}
 
@@ -179,7 +188,7 @@ Now with a single command we can bring-up a full TiDB cluster:
 helm install pingcap/tidb-cluster -n demo --namespace=tidb --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd --version=${chartVersion}
 ```
 
-It will take a few minutes to launch. You can monitor the progress with:
+It takes a few minutes to launch. You can monitor the progress with:
 
 {{< copyable "shell-regular" >}}
 
@@ -269,7 +278,7 @@ To do so, use the following command:
 kubectl -n tidb port-forward svc/demo-grafana 3000:3000 &>/dev/null &
 ```
 
-In Cloud Shell, click on the Web Preview button and enter 3000 for the port. This will open a new browser tab pointing to the Grafana dashboards. Alternatively, use the following URL https://ssh.cloud.google.com/devshell/proxy?port=3000 in a new tab or window.
+In Cloud Shell, click on the Web Preview button and enter 3000 for the port. This opens a new browser tab pointing to the Grafana dashboards. Alternatively, use the following URL https://ssh.cloud.google.com/devshell/proxy?port=3000 in a new tab or window.
 
 If not using Cloud Shell, point a browser to `localhost:3000`.
 
@@ -288,7 +297,7 @@ The above commands only delete the running pods, the data is persistent. If you 
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl delete pvc -n tidb -l app.kubernetes.io/instance=demo,app.kubernetes.io/managed-by=tidb-operator &&
+kubectl delete pvc -n tidb -l app.kubernetes.io/instance=demo,app.kubernetes.io/managed-by=tidb-operator && \
 kubectl get pv -l app.kubernetes.io/namespace=tidb,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/instance=demo -o name | xargs -I {} kubectl patch {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
 ```
 

--- a/tidb-in-kubernetes/google-kubernetes-tutorial.md
+++ b/tidb-in-kubernetes/google-kubernetes-tutorial.md
@@ -1,0 +1,200 @@
+---
+title: Deploy TiDB, a distributed MySQL compatible database, to Kubernetes on Google Cloud
+summary: Tutorial for deploying TiDB on Google Cloud using Kubernetes.
+category: operations
+---
+
+# Deploy TiDB, a distributed MySQL compatible database, to Kubernetes on Google Cloud
+
+## Introduction
+
+This tutorial is designed to be [run in Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md). It takes you through these steps:
+
+- Launch a new 3-node Kubernetes cluster (optional)
+- Install the Helm package manager for Kubernetes
+- Deploy the TiDB Operator
+- Deploy your first TiDB cluster
+- Connect to the TiDB cluster
+- Scale out the TiDB cluster
+- Shut down the Kubernetes cluster (optional)
+
+## Select a project
+
+This tutorial launches a 3-node Kubernetes cluster of `n1-standard-1` machines. Pricing information can be [found here](https://cloud.google.com/compute/pricing).
+
+Please select a project before proceeding:
+
+<walkthrough-project-billing-setup key="project-id">
+</walkthrough-project-billing-setup>
+
+## Enable API access
+
+This tutorial will require use of the Compute and Container APIs. Please enable them before proceeding:
+
+<walkthrough-enable-apis apis="container.googleapis.com,compute.googleapis.com">
+</walkthrough-enable-apis>
+
+## Configure gcloud defaults
+
+This step defaults gcloud to your preferred project and [zone](https://cloud.google.com/compute/docs/regions-zones/), which will simplify the commands used for the rest of this tutorial:
+
+	gcloud config set project {{project-id}} &&
+	gcloud config set compute/zone us-west1-a
+
+## Launch a 3-node Kubernetes cluster
+
+It's now time to launch a 3-node kubernetes cluster! The following command launches a 3-node cluster of `n1-standard-1` machines.
+
+It will take a few minutes to complete:
+
+	gcloud container clusters create tidb
+
+Once the cluster has launched, set it to be the default:
+
+	gcloud config set container/cluster tidb
+
+The last step is to verify that `kubectl` can connect to the cluster, and all three machines are running:
+
+	kubectl get nodes
+
+If you see `Ready` for all nodes, congratulations! You've setup your first Kubernetes cluster.
+
+## Install Helm
+
+Helm is the package manager for Kubernetes, and is what allows us to install all of the distributed components of TiDB in a single step. Helm requires both a server-side and a client-side component to be installed.
+
+Install `helm`:
+
+	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+
+Copy `helm` to your `$HOME` directory so that it will persist after the Cloud Shell reaches its idle timeout:
+
+	mkdir -p ~/bin &&
+	cp /usr/local/bin/helm ~/bin &&
+	echo 'PATH="$PATH:$HOME/bin"' >> ~/.bashrc
+
+Helm will also need a couple of permissions to work properly:
+
+	kubectl apply -f ./manifests/tiller-rbac.yaml &&
+	helm init --service-account tiller --upgrade
+
+It takes a minute for helm to initialize `tiller`, its server component:
+
+	watch "kubectl get pods --namespace kube-system | grep tiller"
+
+When you see `Running`, it's time to hit <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed to the next step!
+
+## Add Helm repo
+
+Helm repo (http://charts.pingcap.org/) houses PingCAP managed charts, such as tidb-operator, tidb-cluster and tidb-backup, etc. Add and check the repo with following commands:
+
+	helm repo add pingcap http://charts.pingcap.org/
+	helm repo list
+
+Then you can check the avaliable charts:
+
+	helm repo update
+	helm search tidb-cluster -l
+	helm search tidb-operator -l
+
+## Deploy TiDB Operator
+
+> **Note:** ${chartVersion} will be used in the rest of the document to represent the chart version, e.g. `v1.0.0-beta.3`.
+
+The first TiDB component we are going to install is the TiDB Operator, using a Helm Chart. TiDB Operator is the management system that works with Kubernetes to bootstrap your TiDB cluster and keep it running. This step assumes you are in the `tidb-operator` working directory:
+
+	kubectl apply -f ./manifests/crd.yaml &&
+	kubectl apply -f ./manifests/gke/persistent-disk.yml &&
+	helm install pingcap/tidb-operator -n tidb-admin --namespace=tidb-admin --version=${chartVersion}
+
+We can watch the operator come up with:
+
+	watch kubectl get pods --namespace tidb-admin -o wide
+
+When you see both tidb-scheduler and tidb-controller-manager are `Running`, press <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed to launch a TiDB cluster!
+
+## Deploy your first TiDB cluster
+
+Now with a single command we can bring-up a full TiDB cluster:
+
+	helm install pingcap/tidb-cluster -n demo --namespace=tidb --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd --version=${chartVersion}
+
+It will take a few minutes to launch. You can monitor the progress with:
+
+	watch kubectl get pods --namespace tidb -o wide
+
+The TiDB cluster includes 2 TiDB pods, 3 TiKV pods, and 3 PD pods. When you see all pods `Running`, it's time to <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed forward!
+
+## Connect to the TiDB cluster
+
+There can be a small delay between the pod being up and running, and the service being available. You can watch list services available with:
+
+	watch "kubectl get svc -n tidb"
+
+When you see `demo-tidb` appear, you can <kbd>Ctrl</kbd>+<kbd>C</kbd>. The service is ready to connect to!
+
+To connect to TiDB within the Kubernetes cluster, you can establish a tunnel between the TiDB service and your Cloud Shell. This is recommended only for debugging purposes, because the tunnel will not automatically be transferred if your Cloud Shell restarts. To establish a tunnel:
+
+	kubectl -n tidb port-forward svc/demo-tidb 4000:4000 &>/tmp/port-forward.log &
+
+From your Cloud Shell:
+
+	sudo apt-get install -y mysql-client &&
+	mysql -h 127.0.0.1 -u root -P 4000
+
+Try out a MySQL command inside your MySQL terminal:
+
+	select tidb_version();
+
+If you did not specify a password in helm, set one now:
+
+	SET PASSWORD FOR 'root'@'%' = '<change-to-your-password>';
+
+_Note that, this command contains some special characters which cannot be
+auto-populated in the google cloud shell tutorial: you need to copy and paste it into your console manually._
+
+Congratulations, you are now up and running with a distributed TiDB database compatible with MySQL!
+
+## Scale out the TiDB cluster
+
+With a single command we can easily scale out the TiDB cluster. To scale out TiKV:
+
+	helm upgrade demo pingcap/tidb-cluster --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd,tikv.replicas=5 --version=${chartVersion}
+
+Now the number of TiKV pods is increased from the default 3 to 5. You can check it with:
+
+	kubectl get po -n tidb
+
+## Accessing the Grafana dashboard
+
+To access the Grafana dashboards, you can create a tunnel between the Grafana service and your shell.
+To do so, use the following command:
+
+    kubectl -n tidb port-forward svc/demo-grafana 3000:3000 &>/dev/null &
+
+In Cloud Shell, click on the Web Preview button and enter 3000 for the port. This will open a new browser tab pointing to the Grafana dashboards. Alternatively, use the following URL https://ssh.cloud.google.com/devshell/proxy?port=3000 in a new tab or window.
+
+If not using Cloud Shell, point a browser to `localhost:3000`.
+
+## Destroy the TiDB cluster
+
+When the TiDB cluster is not needed, you can delete it with the following command:
+
+	helm delete demo --purge
+
+The above commands only delete the running pods, the data is persistent. If you do not need the data anymore, you should run the following commands to clean the data and the dynamically created persistent disks:
+
+	kubectl delete pvc -n tidb -l app.kubernetes.io/instance=demo,app.kubernetes.io/managed-by=tidb-operator &&
+	kubectl get pv -l app.kubernetes.io/namespace=tidb,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/instance=demo -o name | xargs -I {} kubectl patch {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+
+## Shut down the Kubernetes cluster
+
+Once you have finished experimenting, you can delete the Kubernetes cluster with:
+
+	gcloud container clusters delete tidb
+
+
+## More information
+
+For production deployments, view our [operation guide](./operation-guide.md), and look at the GKE section.
+We also have a simple [terraform based deployment](./gcp-gke-tutorial.md).

--- a/tidb-in-kubernetes/google-kubernetes-tutorial.md
+++ b/tidb-in-kubernetes/google-kubernetes-tutorial.md
@@ -1,12 +1,10 @@
 ---
-title: Deploy TiDB, a distributed MySQL compatible database, to Kubernetes on Google Cloud
-summary: Tutorial for deploying TiDB on Google Cloud using Kubernetes.
+title: Deploy TiDB to Kubernetes on Google Cloud
+summary: Learn how to deploy TiDB on Google Cloud using Kubernetes.
 category: operations
 ---
 
-# Deploy TiDB, a distributed MySQL compatible database, to Kubernetes on Google Cloud
-
-## Introduction
+# Deploy TiDB to Kubernetes on Google Cloud
 
 This tutorial is designed to be [run in Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/tidb-operator&tutorial=docs/google-kubernetes-tutorial.md). It takes you through these steps:
 
@@ -24,38 +22,63 @@ This tutorial launches a 3-node Kubernetes cluster of `n1-standard-1` machines. 
 
 Please select a project before proceeding:
 
+```
 <walkthrough-project-billing-setup key="project-id">
 </walkthrough-project-billing-setup>
+```
 
 ## Enable API access
 
-This tutorial will require use of the Compute and Container APIs. Please enable them before proceeding:
+This tutorial requires use of the Compute and Container APIs. Please enable them before proceeding:
 
+```
 <walkthrough-enable-apis apis="container.googleapis.com,compute.googleapis.com">
 </walkthrough-enable-apis>
+```
 
 ## Configure gcloud defaults
 
-This step defaults gcloud to your preferred project and [zone](https://cloud.google.com/compute/docs/regions-zones/), which will simplify the commands used for the rest of this tutorial:
+This step defaults gcloud to your preferred project and [zone](https://cloud.google.com/compute/docs/regions-zones/), which simplifies the commands used for the rest of this tutorial:
 
-	gcloud config set project {{project-id}} &&
-	gcloud config set compute/zone us-west1-a
+{{< copyable "shell-regular" >}}
+
+```shell
+gcloud config set project {{project-id}}
+```
+
+{{< copyable "shell-regular" >}}
+
+```shell
+gcloud config set compute/zone us-west1-a
+```
 
 ## Launch a 3-node Kubernetes cluster
 
 It's now time to launch a 3-node kubernetes cluster! The following command launches a 3-node cluster of `n1-standard-1` machines.
 
-It will take a few minutes to complete:
+It takes a few minutes to complete:
 
-	gcloud container clusters create tidb
+{{< copyable "shell-regular" >}}
+
+```shell
+gcloud container clusters create tidb
+```
 
 Once the cluster has launched, set it to be the default:
 
-	gcloud config set container/cluster tidb
+{{< copyable "shell-regular" >}}
+
+```shell
+gcloud config set container/cluster tidb
+```
 
 The last step is to verify that `kubectl` can connect to the cluster, and all three machines are running:
 
-	kubectl get nodes
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl get nodes
+```
 
 If you see `Ready` for all nodes, congratulations! You've setup your first Kubernetes cluster.
 
@@ -65,22 +88,38 @@ Helm is the package manager for Kubernetes, and is what allows us to install all
 
 Install `helm`:
 
-	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+{{< copyable "shell-regular" >}}
+
+```shell
+curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+```
 
 Copy `helm` to your `$HOME` directory so that it will persist after the Cloud Shell reaches its idle timeout:
 
-	mkdir -p ~/bin &&
-	cp /usr/local/bin/helm ~/bin &&
-	echo 'PATH="$PATH:$HOME/bin"' >> ~/.bashrc
+{{< copyable "shell-regular" >}}
 
-Helm will also need a couple of permissions to work properly:
+```shell
+mkdir -p ~/bin && \
+cp /usr/local/bin/helm ~/bin && \
+echo 'PATH="$PATH:$HOME/bin"' >> ~/.bashrc
+```
 
-	kubectl apply -f ./manifests/tiller-rbac.yaml &&
-	helm init --service-account tiller --upgrade
+Helm also needs a couple of permissions to work properly:
+
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl apply -f ./manifests/tiller-rbac.yaml && \
+helm init --service-account tiller --upgrade
+```
 
 It takes a minute for helm to initialize `tiller`, its server component:
 
-	watch "kubectl get pods --namespace kube-system | grep tiller"
+{{< copyable "shell-regular" >}}
+
+```shell
+watch "kubectl get pods --namespace kube-system | grep tiller"
+```
 
 When you see `Running`, it's time to hit <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed to the next step!
 
@@ -88,14 +127,22 @@ When you see `Running`, it's time to hit <kbd>Ctrl</kbd>+<kbd>C</kbd> and procee
 
 Helm repo (http://charts.pingcap.org/) houses PingCAP managed charts, such as tidb-operator, tidb-cluster and tidb-backup, etc. Add and check the repo with following commands:
 
-	helm repo add pingcap http://charts.pingcap.org/
-	helm repo list
+{{< copyable "shell-regular" >}}
+
+```shell
+helm repo add pingcap http://charts.pingcap.org/
+helm repo list
+```
 
 Then you can check the avaliable charts:
 
-	helm repo update
-	helm search tidb-cluster -l
-	helm search tidb-operator -l
+{{< copyable "shell-regular" >}}
+
+```shell
+helm repo update
+helm search tidb-cluster -l
+helm search tidb-operator -l
+```
 
 ## Deploy TiDB Operator
 
@@ -103,13 +150,22 @@ Then you can check the avaliable charts:
 
 The first TiDB component we are going to install is the TiDB Operator, using a Helm Chart. TiDB Operator is the management system that works with Kubernetes to bootstrap your TiDB cluster and keep it running. This step assumes you are in the `tidb-operator` working directory:
 
-	kubectl apply -f ./manifests/crd.yaml &&
-	kubectl apply -f ./manifests/gke/persistent-disk.yml &&
-	helm install pingcap/tidb-operator -n tidb-admin --namespace=tidb-admin --version=${chartVersion}
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl apply -f ./manifests/crd.yaml &&
+kubectl apply -f ./manifests/gke/persistent-disk.yml &&
+helm install pingcap/tidb-operator -n tidb-admin --namespace=tidb-admin --version=${chartVersion}
+```
 
 We can watch the operator come up with:
 
-	watch kubectl get pods --namespace tidb-admin -o wide
+
+{{< copyable "shell-regular" >}}
+
+```shell
+watch kubectl get pods --namespace tidb-admin -o wide
+```
 
 When you see both tidb-scheduler and tidb-controller-manager are `Running`, press <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed to launch a TiDB cluster!
 
@@ -117,11 +173,19 @@ When you see both tidb-scheduler and tidb-controller-manager are `Running`, pres
 
 Now with a single command we can bring-up a full TiDB cluster:
 
-	helm install pingcap/tidb-cluster -n demo --namespace=tidb --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd --version=${chartVersion}
+{{< copyable "shell-regular" >}}
+
+```shell
+helm install pingcap/tidb-cluster -n demo --namespace=tidb --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd --version=${chartVersion}
+```
 
 It will take a few minutes to launch. You can monitor the progress with:
 
-	watch kubectl get pods --namespace tidb -o wide
+{{< copyable "shell-regular" >}}
+
+```shell
+watch kubectl get pods --namespace tidb -o wide
+```
 
 The TiDB cluster includes 2 TiDB pods, 3 TiKV pods, and 3 PD pods. When you see all pods `Running`, it's time to <kbd>Ctrl</kbd>+<kbd>C</kbd> and proceed forward!
 
@@ -129,29 +193,50 @@ The TiDB cluster includes 2 TiDB pods, 3 TiKV pods, and 3 PD pods. When you see 
 
 There can be a small delay between the pod being up and running, and the service being available. You can watch list services available with:
 
-	watch "kubectl get svc -n tidb"
+{{< copyable "shell-regular" >}}
+
+```shell
+watch "kubectl get svc -n tidb"
+```
 
 When you see `demo-tidb` appear, you can <kbd>Ctrl</kbd>+<kbd>C</kbd>. The service is ready to connect to!
 
 To connect to TiDB within the Kubernetes cluster, you can establish a tunnel between the TiDB service and your Cloud Shell. This is recommended only for debugging purposes, because the tunnel will not automatically be transferred if your Cloud Shell restarts. To establish a tunnel:
 
-	kubectl -n tidb port-forward svc/demo-tidb 4000:4000 &>/tmp/port-forward.log &
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl -n tidb port-forward svc/demo-tidb 4000:4000 &>/tmp/port-forward.log &
+```
 
 From your Cloud Shell:
 
-	sudo apt-get install -y mysql-client &&
-	mysql -h 127.0.0.1 -u root -P 4000
+{{< copyable "shell-regular" >}}
+
+```shell
+sudo apt-get install -y mysql-client && \
+mysql -h 127.0.0.1 -u root -P 4000
+```
 
 Try out a MySQL command inside your MySQL terminal:
 
-	select tidb_version();
+{{< copyable "sql" >}}
+
+```sql
+select tidb_version();
+```
 
 If you did not specify a password in helm, set one now:
 
-	SET PASSWORD FOR 'root'@'%' = '<change-to-your-password>';
+{{< copyable "sql" >}}
 
-_Note that, this command contains some special characters which cannot be
-auto-populated in the google cloud shell tutorial: you need to copy and paste it into your console manually._
+```sql
+SET PASSWORD FOR 'root'@'%' = '<change-to-your-password>';
+```
+
+> **Note:**
+>
+> This command contains some special characters which cannot be auto-populated in the google cloud shell tutorial, so you might need to copy and paste it into your console manually.
 
 Congratulations, you are now up and running with a distributed TiDB database compatible with MySQL!
 
@@ -159,18 +244,30 @@ Congratulations, you are now up and running with a distributed TiDB database com
 
 With a single command we can easily scale out the TiDB cluster. To scale out TiKV:
 
-	helm upgrade demo pingcap/tidb-cluster --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd,tikv.replicas=5 --version=${chartVersion}
+{{< copyable "shell-regular" >}}
+
+```shell
+helm upgrade demo pingcap/tidb-cluster --set pd.storageClassName=pd-ssd,tikv.storageClassName=pd-ssd,tikv.replicas=5 --version=${chartVersion}
+```
 
 Now the number of TiKV pods is increased from the default 3 to 5. You can check it with:
 
-	kubectl get po -n tidb
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl get po -n tidb
+```
 
 ## Accessing the Grafana dashboard
 
 To access the Grafana dashboards, you can create a tunnel between the Grafana service and your shell.
 To do so, use the following command:
 
-    kubectl -n tidb port-forward svc/demo-grafana 3000:3000 &>/dev/null &
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl -n tidb port-forward svc/demo-grafana 3000:3000 &>/dev/null &
+```
 
 In Cloud Shell, click on the Web Preview button and enter 3000 for the port. This will open a new browser tab pointing to the Grafana dashboards. Alternatively, use the following URL https://ssh.cloud.google.com/devshell/proxy?port=3000 in a new tab or window.
 
@@ -180,21 +277,27 @@ If not using Cloud Shell, point a browser to `localhost:3000`.
 
 When the TiDB cluster is not needed, you can delete it with the following command:
 
-	helm delete demo --purge
+{{< copyable "shell-regular" >}}
+
+```shell
+helm delete demo --purge
+```
 
 The above commands only delete the running pods, the data is persistent. If you do not need the data anymore, you should run the following commands to clean the data and the dynamically created persistent disks:
 
-	kubectl delete pvc -n tidb -l app.kubernetes.io/instance=demo,app.kubernetes.io/managed-by=tidb-operator &&
-	kubectl get pv -l app.kubernetes.io/namespace=tidb,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/instance=demo -o name | xargs -I {} kubectl patch {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl delete pvc -n tidb -l app.kubernetes.io/instance=demo,app.kubernetes.io/managed-by=tidb-operator &&
+kubectl get pv -l app.kubernetes.io/namespace=tidb,app.kubernetes.io/managed-by=tidb-operator,app.kubernetes.io/instance=demo -o name | xargs -I {} kubectl patch {} -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+```
 
 ## Shut down the Kubernetes cluster
 
 Once you have finished experimenting, you can delete the Kubernetes cluster with:
 
-	gcloud container clusters delete tidb
+{{< copyable "shell-regular" >}}
 
-
-## More information
-
-For production deployments, view our [operation guide](./operation-guide.md), and look at the GKE section.
-We also have a simple [terraform based deployment](./gcp-gke-tutorial.md).
+```shell
+gcloud container clusters delete tidb
+```


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

Related PR: https://github.com/pingcap/docs-cn/pull/1467

Preview:
https://github.com/DanielZhangQD/docs/blob/google-migration/tidb-in-kubernetes/gcp-gke-tutorial.md
https://github.com/DanielZhangQD/docs/blob/google-migration/tidb-in-kubernetes/google-kubernetes-tutorial.md