### PR TITLE
generate_pdf.sh: stop generating PDFs for v3.0 and v2.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,19 +30,15 @@ jobs:
           command: |
             sudo bash -c 'echo "222.222.95.49 uc.qbox.me" >> /etc/hosts';
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              python3 scripts/upload.py dev/output.pdf tidb-manual-dev.pdf;
-              python3 scripts/upload.py v3.0/output.pdf tidb-manual-v3.0.pdf;
-              python3 scripts/upload.py v2.1/output.pdf tidb-manual-v2.1.pdf;
+              python3 scripts/upload.py dev/output.pdf tidb-manual.pdf;
             fi
             if [ "${CIRCLE_BRANCH}" == "website-preview" ]; then
-              python3 scripts/upload.py dev/output.pdf tidb-manual-dev-preview.pdf;
-              python3 scripts/upload.py v3.0/output.pdf tidb-manual-v3.0-preview.pdf;
-              python3 scripts/upload.py v2.1/output.pdf tidb-manual-v2.1-preview.pdf;
+              python3 scripts/upload.py dev/output.pdf tidb-manual-preview.pdf;
             fi
 
       - run:
           name: "Copy Generated PDF"
-          command: mkdir /tmp/artifacts && cp dev/output.pdf dev/doc.md v3.0/output.pdf v3.0/doc.md v2.1/output.pdf v2.1/doc.md /tmp/artifacts
+          command: mkdir /tmp/artifacts && cp dev/output.pdf dev/doc.md /tmp/artifacts
 
       - store_artifacts:
           path: /tmp/artifacts

--- a/scripts/generate_pdf.sh
+++ b/scripts/generate_pdf.sh
@@ -16,7 +16,7 @@ _version_tag="$(date '+%Y%m%d')"
 # used to debug template setting error
 
 
-docs_versions=(dev v3.0 v2.1)
+docs_versions=(dev)
 
 for i in "${docs_versions[@]}"
 do


### PR DESCRIPTION
### What is changed, added or deleted?

CI failed at generating PDF for v2.1 and v3.0, so remove v2.1 and v3.0 from generate_pdf.sh

### Check list <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
