### PR TITLE
reference/security: update 2.1 advice

### DIFF
--- a/dev/reference/security/privilege-system.md
+++ b/dev/reference/security/privilege-system.md
@@ -338,9 +338,7 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 > **Note:**
 >
-> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
-> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
-> behavior until `FLUSH PRIVILEGES` is executed.
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`. Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 

--- a/dev/reference/security/privilege-system.md
+++ b/dev/reference/security/privilege-system.md
@@ -336,19 +336,11 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 `Host` and `User` in `mysql.db` determine which databases users can access. The effective range is the database.
 
-In theory, all privilege-related operations can be done directly by the CRUD operations on the grant table.
-
-On the implementation level, only a layer of syntactic sugar is added. For example, you can use the following command to remove a user:
-
-```sql
-DELETE FROM mysql.user WHERE user='test';
-```
-
-However, the recommended usage is with `DROP USER`:
-
-```sql
-DROP USER 'test';
-```
+> **Note:**
+>
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
+> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
+> behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 

--- a/v2.1/reference/security/privilege-system.md
+++ b/v2.1/reference/security/privilege-system.md
@@ -14,39 +14,23 @@ This document introduces privilege-related TiDB operations, privileges required 
 
 ### Grant privileges
 
-The `GRANT` statement grants privileges to the user accounts.
-
-For example, use the following statement to grant the `xxx` user the privilege to read the `test` database.
+The `GRANT` statement grants privileges to user accounts. It is recommended to first create a user, and then grant privileges. For example, use the following statement to grant the `developer` user the privilege to read the `test` database:
 
 ```sql
-GRANT SELECT ON test.* TO 'xxx'@'%';
+CREATE USER developer IDENTIFIED BY 'mypassword';
+GRANT SELECT ON test.* TO 'developer';
 ```
 
-Use the following statement to grant the `xxx` user all privileges on all databases:
+Use the following statement to grant the `developer` user all privileges on all databases:
 
 ```sql
-GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'developer';
 ```
 
-If the granted user does not exist, TiDB will automatically create a user.
-
-```sql
-mysql> SELECT * FROM mysql.user WHERE user='xxxx';
-Empty set (0.00 sec)
-
-mysql> GRANT ALL PRIVILEGES ON test.* TO 'xxxx'@'%' IDENTIFIED BY 'yyyyy';
-Query OK, 0 rows affected (0.00 sec)
-
-mysql> SELECT user,host FROM mysql.user WHERE user='xxxx';
-+------|------+
-| user | host |
-+------|------+
-| xxxx | %    |
-+------|------+
-1 row in set (0.00 sec)
-```
-
-In this example, `xxxx@%` is the user that is automatically created.
+> **Warning：**
+>
+> TiDB 2.1 does not support the `NO_AUTO_CREATE_USER` SQL Mode. This means that TiDB will automatically create a new user if one does not already exist.
+> This is particularly risky, since typos can lead to users created with an empty password. While this behavior is compatible with earlier releases of MySQL, it is recommended to upgrade to TiDB 3.0 to prevent this issue.
 
 > **Note:**
 >
@@ -303,19 +287,11 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 `Host` and `User` in `mysql.db` determine which databases users can access. The effective range is the database.
 
-In theory, all privilege-related operations can be done directly by the CRUD operations on the grant table.
-
-On the implementation level, only a layer of syntactic sugar is added. For example, you can use the following command to remove a user:
-
-```sql
-DELETE FROM mysql.user WHERE user='test';
-```
-
-However, the recommended usage is with `DROP USER`:
-
-```sql
-DROP USER 'test';
-```
+> **Note:**
+>
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
+> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
+> behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 

--- a/v2.1/reference/security/privilege-system.md
+++ b/v2.1/reference/security/privilege-system.md
@@ -289,9 +289,7 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 > **Note:**
 >
-> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
-> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
-> behavior until `FLUSH PRIVILEGES` is executed.
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`. Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 

--- a/v3.0/reference/security/privilege-system.md
+++ b/v3.0/reference/security/privilege-system.md
@@ -339,9 +339,7 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 > **Note:**
 >
-> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
-> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
-> behavior until `FLUSH PRIVILEGES` is executed.
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`. Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 

--- a/v3.0/reference/security/privilege-system.md
+++ b/v3.0/reference/security/privilege-system.md
@@ -29,25 +29,58 @@ Use the following statement to grant the `xxx` user all privileges on all databa
 GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
 ```
 
-If the granted user does not exist, TiDB will automatically create a user.
+By default, `GRANT` statements will return an error if the user specified does not exist. This behavior depends on if the SQL Mode `NO_AUTO_CREATE_USER` is specified:
 
 ```sql
-mysql> SELECT * FROM mysql.user WHERE user='xxxx';
-Empty set (0.00 sec)
-
-mysql> GRANT ALL PRIVILEGES ON test.* TO 'xxxx'@'%' IDENTIFIED BY 'yyyyy';
+mysql> SET sql_mode=DEFAULT;
 Query OK, 0 rows affected (0.00 sec)
 
-mysql> SELECT user,host FROM mysql.user WHERE user='xxxx';
-+------|------+
-| user | host |
-+------|------+
-| xxxx | %    |
-+------|------+
+mysql> SELECT @@sql_mode;
++-------------------------------------------------------------------------------------------------------------------------------------------+
+| @@sql_mode                                                                                                                                |
++-------------------------------------------------------------------------------------------------------------------------------------------+
+| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION |
++-------------------------------------------------------------------------------------------------------------------------------------------+
 1 row in set (0.00 sec)
+
+mysql> SELECT * FROM mysql.user WHERE user='idontexist';
+Empty set (0.00 sec)
+
+mysql> GRANT ALL PRIVILEGES ON test.* TO 'idontexist';
+ERROR 1105 (HY000): You are not allowed to create a user with GRANT
+
+mysql> SELECT user,host,password FROM mysql.user WHERE user='idontexist';
+Empty set (0.00 sec)
 ```
 
-In this example, `xxxx@%` is the user that is automatically created.
+In the following example, the user `idontexist` is automatically created with an empty password because the SQL Mode `NO_AUTO_CREATE_USER` was not set. This is **not recommended** since it presents a security risk: miss-spelling a username will result in a new user created with an empty password:
+
+```sql
+mysql> SET @@sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
+Query OK, 0 rows affected (0.00 sec)
+
+mysql> SELECT @@sql_mode;
++-----------------------------------------------------------------------------------------------------------------------+
+| @@sql_mode                                                                                                            |
++-----------------------------------------------------------------------------------------------------------------------+
+| ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION |
++-----------------------------------------------------------------------------------------------------------------------+
+1 row in set (0.00 sec)
+
+mysql> SELECT * FROM mysql.user WHERE user='idontexist';
+Empty set (0.00 sec)
+
+mysql> GRANT ALL PRIVILEGES ON test.* TO 'idontexist';
+Query OK, 1 row affected (0.05 sec)
+
+mysql> SELECT user,host,password FROM mysql.user WHERE user='idontexist';
++------------+------+----------+
+| user       | host | password |
++------------+------+----------+
+| idontexist | %    |          |
++------------+------+----------+
+1 row in set (0.00 sec)
+```
 
 > **Note:**
 >
@@ -283,10 +316,10 @@ Requires the `SUPER` privilege.
 
 The following system tables are special because all the privilege-related data is stored in them:
 
-- mysql.user (user account, global privilege)
-- mysql.db (database-level privilege)
-- mysql.tables_priv (table-level privilege)
-- mysql.columns_priv (column-level privilege; not currently supported)
+- `mysql.user` (user account, global privilege)
+- `mysql.db` (database-level privilege)
+- `mysql.tables_priv` (table-level privilege)
+- `mysql.columns_priv` (column-level privilege; not currently supported)
 
 These tables contain the effective range and privilege information of the data. For example, in the `mysql.user` table:
 
@@ -304,19 +337,11 @@ In this record, `Host` and `User` determine that the connection request sent by 
 
 `Host` and `User` in `mysql.db` determine which databases users can access. The effective range is the database.
 
-In theory, all privilege-related operations can be done directly by the CRUD operations on the grant table.
-
-On the implementation level, only a layer of syntactic sugar is added. For example, you can use the following command to remove a user:
-
-```sql
-DELETE FROM mysql.user WHERE user='test';
-```
-
-However, the recommended usage is with `DROP USER`:
-
-```sql
-DROP USER 'test';
-```
+> **Note:**
+>
+> It is recommended to only update the privilege tables via the supplied syntax such as `GRANT`, `CREATE USER` and `DROP USER`.
+> Making direct edits to the underlying privilege tables will not automatially update the privilege cache, leading to unpredictable
+> behavior until `FLUSH PRIVILEGES` is executed.
 
 ### Connection verification
 
@@ -334,7 +359,7 @@ For database-related requests (`INSERT`, `UPDATE`), the request verification pro
 
 The `user` table has global privileges regardless of the default database. For example, the `DELETE` privilege in `user` can apply to any row, table, or database.
 
-In the `Db` table, an empty user is to match the anonymous user name. Wildcards are not allowed in the `User` column. The value for the `Host` and `Db` columns can use `%` and `_`, which can use pattern matching.
+In the `db` table, an empty user is to match the anonymous user name. Wildcards are not allowed in the `User` column. The value for the `Host` and `Db` columns can use `%` and `_`, which can use pattern matching.
 
 Data in the `user` and `db` tables is also sorted when loaded into memory.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

2.1 Does not support ONLY_FULL_GROUP_BY.
2.1: Remove an example that shows bad practice.
2.1/3.0/dev: Remove advice about direct edits to privilege tables.

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

This is a followup PR to https://github.com/pingcap/docs/pull/1229

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

Mainly 2.1, but some 3.0/dev changes.

### Check list <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
