### PR TITLE
reference/transactions: improve version diffs

### DIFF
--- a/dev/reference/mysql-compatibility.md
+++ b/dev/reference/mysql-compatibility.md
@@ -36,9 +36,9 @@ Currently TiDB Server advertises itself as MySQL 5.7 and works with most MySQL d
 + `CREATE TABLE tblName AS SELECT stmt` syntax
 + `CREATE TEMPORARY TABLE` syntax
 + `XA` syntax (TiDB uses a two-phase commit internally, but this is not exposed via an SQL interface)
-+ `LOCK TABLE` syntax (TiDB uses `tidb_snapshot` to [produce backups](/reference/tools/mydumper.md))
 + `CHECK TABLE` syntax
 + `CHECKSUM TABLE` syntax
++ `GET_LOCK` and `RELEASE_LOCK` functions
 
 ## Features that are different from MySQL
 
@@ -153,6 +153,12 @@ tidb> SELECT /*!90000 "I should not run", */ "I should run" FROM dual;
 +------------------+--------------+
 1 row in set (0.00 sec)
 ```
+
+### Lock tables
+
+Support for `LOCK TABLE` syntax is currently experimental, and must be explicitly enabled ([TiDB #10343](https://github.com/pingcap/tidb/pull/10343)).
+
+It is recommended to use the historical reads feature of `tidb_snapshot` to produce consistent reads, instead of `FLUSH TABLES WITH READ LOCK`. Support for `tidb_snapshot` is available in [mydumper](/reference/tools/mydumper.md)).
 
 ### Default differences
 

--- a/dev/reference/transactions/transaction-model.md
+++ b/dev/reference/transactions/transaction-model.md
@@ -6,13 +6,13 @@ category: reference
 
 # Transaction Model
 
-TiDB implements an optimistic transaction model. Unlike MySQL, which uses row-level locking to avoid write conflict, in TiDB, the write conflict is checked only in the `commit` process during the execution of the statements like `Update`, `Insert`, `Delete`, and so on.
+TiDB defaults to an optimistic transaction model. This means that unlike MySQL where statements may block waiting to acquire row-locks, TiDB will allow modifications to occur and detect the conflict at the transaction attempts to commit.
 
-Similarly, functions such as `GET_LOCK()` and `RELEASE_LOCK()` and statements such as `SELECT .. FOR UPDATE` do not work in the same way as in MySQL.
+Similarly, statements such as `SELECT .. FOR UPDATE` do not work in the same way as in MySQL.
 
 > **Note:**
 >
-> On the application side, remember to check the returned results of `COMMIT` because even there is no error in the execution, there might be errors in the `COMMIT` process.
+> Experimental support for [pessimistic locking](/reference/transactions/transaction-pessimistic.md) is now available. When enabled, TiDB will behave behave similar to the InnoDB storage engine.
 
 ## Differences from MySQL
 
@@ -46,6 +46,10 @@ UPDATE my_table SET a='newer_value' WHERE id = 2;
 UPDATE my_table SET a='newest_value' WHERE id = 3;
 COMMIT;
 ```
+
+### SELECT .. FOR UPDATE
+
+Due to optimistic locking, `SELECT .. FOR UPDATE` statements do not block other sessions from modifying data. Instead, the `SELECT .. FOR UPDATE` statement will cause the transaction to fail if rows have been modified by another transaction. Similarly, the `SELECT .. FOR UPDATE` statement disables any transaction retry.
 
 ### Single-threaded or latency-sensitive workloads
 

--- a/v2.1/reference/mysql-compatibility.md
+++ b/v2.1/reference/mysql-compatibility.md
@@ -40,6 +40,7 @@ Currently TiDB Server advertises itself as MySQL 5.7 and works with most MySQL d
 + `LOCK TABLE` syntax (TiDB uses `tidb_snapshot` to [produce backups](/reference/tools/mydumper.md))
 + `CHECK TABLE` syntax
 + `CHECKSUM TABLE` syntax
++ `GET_LOCK` and `RELEASE_LOCK` functions
 
 ## Features that are different from MySQL
 

--- a/v2.1/reference/transactions/transaction-model.md
+++ b/v2.1/reference/transactions/transaction-model.md
@@ -8,17 +8,17 @@ category: reference
 
 TiDB implements an optimistic transaction model. Unlike MySQL, which uses row-level locking to avoid write conflict, in TiDB, the write conflict is checked only in the `commit` process during the execution of the statements like `Update`, `Insert`, `Delete`, and so on.
 
-Similarly, functions such as `GET_LOCK()` and `RELEASE_LOCK()` and statements such as `SELECT .. FOR UPDATE` do not work in the same way as in MySQL.
-
-> **Note:**
->
-> On the application side, remember to check the returned results of `COMMIT` because even there is no error in the execution, there might be errors in the `COMMIT` process.
+Similarly, statements such as `SELECT .. FOR UPDATE` do not work in the same way as in MySQL.
 
 ## Differences from MySQL
 
 ### Transaction retry
 
-While the transaction retry is not enabled by default, TiDB can automatically retry failed transactions when `tidb_disable_txn_auto_retry = off`. This feature is disabled by default because retry might lead to lost updates.
+TiDB will automatically retry failed transactions by default. It is recommended that you disable this feature by setting `tidb_disable_txn_auto_retry = ON`, since retry might lead to lost updates.
+
+> **Warning:**
+>
+> TiDB 2.1 will retry transactions by default, leading to potentially lost updates. TiDB 3.0 switches to transaction retry being disabled by default.  This means it is important to remember to check the returned results of commit statements, because even if there is no error in execution, there might be errors during the `COMMIT` process.
 
 ### Large transactions
 
@@ -46,6 +46,10 @@ UPDATE my_table SET a='newer_value' WHERE id = 2;
 UPDATE my_table SET a='newest_value' WHERE id = 3;
 COMMIT;
 ```
+
+### SELECT .. FOR UPDATE
+
+Due to optimistic locking, `SELECT .. FOR UPDATE` statements do not block other sessions from modifying data. Instead, the `SELECT .. FOR UPDATE` statement will cause the transaction to fail if rows have been modified by another transaction. Similarly, the `SELECT .. FOR UPDATE` statement disables any transaction retry.
 
 ### Single-threaded or latency-sensitive workloads
 

--- a/v3.0/reference/mysql-compatibility.md
+++ b/v3.0/reference/mysql-compatibility.md
@@ -40,6 +40,7 @@ Currently TiDB Server advertises itself as MySQL 5.7 and works with most MySQL d
 + `LOCK TABLE` syntax (TiDB uses `tidb_snapshot` to [produce backups](/reference/tools/mydumper.md))
 + `CHECK TABLE` syntax
 + `CHECKSUM TABLE` syntax
++ `GET_LOCK` and `RELEASE_LOCK` functions
 
 ## Features that are different from MySQL
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

- Do not explain "get_lock" as different from MySQL: it doesn't work and should be on incompatibility.
- Explain in dev/ that optimistic is only the default.
- Better clarify that retry differs between 2.1 and 3.0 and could cause upgrade issues (document on both sides).
- Change dev/ mysql-compatibility for LOCK TABLES from incompatible to having an explanation.
- Document SELECT FOR UPDATE as a transaction model behavior difference

Also fixes https://github.com/pingcap/docs/issues/807

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

All

### Check list <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
