### PR TITLE
dev/v3.0/v2.1: fix wrong binlog links

### DIFF
--- a/dev/TOC.md
+++ b/dev/TOC.md
@@ -83,7 +83,7 @@
     - [Upgrade to Development Series](how-to/upgrade/from-previous-version.md)
     - [Rolling updates with Ansible](how-to/upgrade/rolling-updates-with-ansible.md)
     - [Upgrade TiDB Data Migration](how-to/upgrade/data-migration.md)
-    - [TiDB Binlog Cluster Upgrade](how-to/upgrade/tidb-binlog.md)
+    - [Upgrade TiDB Binlog Cluster](how-to/upgrade/tidb-binlog.md)
   - Troubleshoot
     - [Troubleshoot Cluster Setup](how-to/troubleshoot/cluster-setup.md)
     - [Troubleshoot TiDB Data Migration](how-to/troubleshoot/data-migration.md)

--- a/dev/how-to/deploy/tidb-binlog.md
+++ b/dev/how-to/deploy/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
 category: reference
-
 ---
 
 # TiDB Binlog Cluster Deployment

--- a/dev/how-to/maintain/tidb-binlog.md
+++ b/dev/how-to/maintain/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # TiDB Binlog Cluster Operations

--- a/dev/how-to/monitor/tidb-binlog.md
+++ b/dev/how-to/monitor/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # TiDB Binlog Monitoring

--- a/dev/how-to/upgrade/tidb-binlog.md
+++ b/dev/how-to/upgrade/tidb-binlog.md
@@ -7,7 +7,7 @@ category: reference
 
 # TiDB Binlog Cluster Upgrade
 
-The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
+The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
 The corresponding relationship between TiDB Binlog versions and TiDB versions is shown in the following table:
 

--- a/dev/how-to/upgrade/tidb-binlog.md
+++ b/dev/how-to/upgrade/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # Upgrade TiDB Binlog Cluster

--- a/dev/how-to/upgrade/tidb-binlog.md
+++ b/dev/how-to/upgrade/tidb-binlog.md
@@ -1,11 +1,11 @@
 ---
-title: TiDB Binlog Cluster Upgrade
+title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
 
 ---
 
-# TiDB Binlog Cluster Upgrade
+# Upgrade TiDB Binlog Cluster
 
 The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
@@ -21,7 +21,7 @@ The corresponding relationship between TiDB Binlog versions and TiDB versions is
 
 > **Note:**
 >
-> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog-deploy.md)
+> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog.md).
 
 
 If you want to resume replication from the original checkpoint, perform the following steps to upgrade TiDB Binlog:

--- a/dev/reference/tidb-binlog-overview.md
+++ b/dev/reference/tidb-binlog-overview.md
@@ -63,9 +63,9 @@ The server hardware requirements for development, testing, and the production en
 
 * You need to use TiDB v2.0.8-binlog, v2.1.0-rc.5 or a later version. Older versions of TiDB cluster are not compatible with the cluster version of TiDB Binlog.
 
-* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/binlog/binlog-slave-client.md).
+* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/tidb-binlog/binlog-slave-client.md).
 
-* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/binlog/reparo.md) to recover data incrementally.
+* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/tidb-binlog/reparo.md) to recover data incrementally.
 
     Pay attention to the value of `db-type`:
 

--- a/dev/reference/tidb-binlog-overview.md
+++ b/dev/reference/tidb-binlog-overview.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Overview
 summary: Learn overview of the cluster version of TiDB Binlog.
 category: reference 
-
 ---
 
 # TiDB Binlog Cluster Overview

--- a/v2.1/TOC.md
+++ b/v2.1/TOC.md
@@ -82,7 +82,7 @@
     - [Upgrade to TiDB 2.1](how-to/upgrade/from-previous-version.md)
     - [Rolling updates with Ansible](how-to/upgrade/rolling-updates-with-ansible.md)
     - [Upgrade TiDB Data Migration](how-to/upgrade/data-migration.md)
-    - [TiDB Binlog Cluster Upgrade](how-to/upgrade/tidb-binlog.md)
+    - [Upgrade TiDB Binlog Cluster](how-to/upgrade/tidb-binlog.md)
   - Troubleshoot
     - [Troubleshoot Cluster Setup](how-to/troubleshoot/cluster-setup.md)
     - [Troubleshoot TiDB Data Migration](how-to/troubleshoot/data-migration.md)

--- a/v2.1/how-to/deploy/tidb-binlog.md
+++ b/v2.1/how-to/deploy/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
 category: reference
-
 ---
 
 # TiDB Binlog Cluster Deployment

--- a/v2.1/how-to/maintain/tidb-binlog.md
+++ b/v2.1/how-to/maintain/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # TiDB Binlog Cluster Operations

--- a/v2.1/how-to/monitor/tidb-binlog.md
+++ b/v2.1/how-to/monitor/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # TiDB Binlog Monitoring

--- a/v2.1/how-to/upgrade/tidb-binlog.md
+++ b/v2.1/how-to/upgrade/tidb-binlog.md
@@ -7,7 +7,7 @@ category: reference
 
 # TiDB Binlog Cluster Upgrade
 
-The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
+The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
 The corresponding relationship between TiDB Binlog versions and TiDB versions is shown in the following table:
 

--- a/v2.1/how-to/upgrade/tidb-binlog.md
+++ b/v2.1/how-to/upgrade/tidb-binlog.md
@@ -2,7 +2,6 @@
 title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
-
 ---
 
 # Upgrade TiDB Binlog Cluster

--- a/v2.1/how-to/upgrade/tidb-binlog.md
+++ b/v2.1/how-to/upgrade/tidb-binlog.md
@@ -1,11 +1,11 @@
 ---
-title: TiDB Binlog Cluster Upgrade
+title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
 
 ---
 
-# TiDB Binlog Cluster Upgrade
+# Upgrade TiDB Binlog Cluster
 
 The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
@@ -21,7 +21,7 @@ The corresponding relationship between TiDB Binlog versions and TiDB versions is
 
 > **Note:**
 >
-> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog-deploy.md)
+> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog.md).
 
 
 If you want to resume replication from the original checkpoint, perform the following steps to upgrade TiDB Binlog:

--- a/v2.1/reference/tidb-binlog-overview.md
+++ b/v2.1/reference/tidb-binlog-overview.md
@@ -63,9 +63,9 @@ The server hardware requirements for development, testing, and the production en
 
 * You need to use TiDB v2.0.8-binlog, v2.1.0-rc.5 or a later version. Older versions of TiDB cluster are not compatible with the cluster version of TiDB Binlog.
 
-* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/binlog/binlog-slave-client.md).
+* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/tidb-binlog/binlog-slave-client.md).
 
-* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/binlog/reparo.md) to recover data incrementally.
+* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/tidb-binlog/reparo.md) to recover data incrementally.
 
     Pay attention to the value of `db-type`:
 

--- a/v3.0/TOC.md
+++ b/v3.0/TOC.md
@@ -83,7 +83,7 @@
     - [Upgrade to TiDB 3.0](how-to/upgrade/from-previous-version.md)
     - [Rolling updates with Ansible](how-to/upgrade/rolling-updates-with-ansible.md)
     - [Upgrade TiDB Data Migration](how-to/upgrade/data-migration.md)
-    - [TiDB Binlog Cluster Upgrade](how-to/upgrade/tidb-binlog.md)
+    - [Upgrade TiDB Binlog Cluster](how-to/upgrade/tidb-binlog.md)
   - Troubleshoot
     - [Troubleshoot Cluster Setup](how-to/troubleshoot/cluster-setup.md)
     - [Troubleshoot TiDB Data Migration](how-to/troubleshoot/data-migration.md)

--- a/v3.0/how-to/deploy/tidb-binlog.md
+++ b/v3.0/how-to/deploy/tidb-binlog.md
@@ -3,7 +3,6 @@ title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
 category: reference
 aliases: ['/docs/tools/binlog/deploy/','/docs/dev/reference/tools/tidb-binlog/deploy/']
-
 ---
 
 # TiDB Binlog Cluster Deployment

--- a/v3.0/how-to/maintain/tidb-binlog.md
+++ b/v3.0/how-to/maintain/tidb-binlog.md
@@ -3,7 +3,6 @@ title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
 category: reference
 aliases: ['/docs/tools/binlog/operation/','/docs/dev/reference/tools/tidb-binlog/operation/']
-
 ---
 
 # TiDB Binlog Cluster Operations

--- a/v3.0/how-to/monitor/tidb-binlog.md
+++ b/v3.0/how-to/monitor/tidb-binlog.md
@@ -3,7 +3,6 @@ title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
 category: reference
 aliases: ['/docs/tools/binlog/monitor/','/docs/dev/reference/tools/tidb-binlog/monitor/']
-
 ---
 
 # TiDB Binlog Monitoring

--- a/v3.0/how-to/upgrade/tidb-binlog.md
+++ b/v3.0/how-to/upgrade/tidb-binlog.md
@@ -3,7 +3,6 @@ title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
 aliases: ['/docs/tools/binlog/upgrade/','/docs/dev/reference/tools/tidb-binlog/upgrade/']
-
 ---
 
 # Upgrade TiDB Binlog Cluster

--- a/v3.0/how-to/upgrade/tidb-binlog.md
+++ b/v3.0/how-to/upgrade/tidb-binlog.md
@@ -1,12 +1,12 @@
 ---
-title: TiDB Binlog Cluster Upgrade
+title: Upgrade TiDB Binlog Cluster
 summary: Learn how to upgrade the cluster version of TiDB Binlog.
 category: reference
 aliases: ['/docs/tools/binlog/upgrade/','/docs/dev/reference/tools/tidb-binlog/upgrade/']
 
 ---
 
-# TiDB Binlog Cluster Upgrade
+# Upgrade TiDB Binlog Cluster
 
 The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
@@ -22,7 +22,7 @@ The corresponding relationship between TiDB Binlog versions and TiDB versions is
 
 > **Note:**
 >
-> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog.md)
+> If importing the full data is acceptable, you can abandon the old version and deploy TiDB Binlog following [TiDB Binlog Cluster Deployment](/how-to/deploy/tidb-binlog.md).
 
 
 If you want to resume replication from the original checkpoint, perform the following steps to upgrade TiDB Binlog:

--- a/v3.0/how-to/upgrade/tidb-binlog.md
+++ b/v3.0/how-to/upgrade/tidb-binlog.md
@@ -8,7 +8,7 @@ aliases: ['/docs/tools/binlog/upgrade/','/docs/dev/reference/tools/tidb-binlog/u
 
 # TiDB Binlog Cluster Upgrade
 
-The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
+The new TiDB versions (v2.0.8-binlog, v2.1.0-rc.5 or later) are not compatible with the [Kafka version](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) or [Local version](/reference/tools/tidb-binlog/tidb-binlog-local.md) of TiDB Binlog. If TiDB is upgraded to one of the new versions, it is required to use the cluster version of TiDB Binlog. If the Kafka or local version of TiDB Binlog is used before upgrading, you need to upgrade your TiDB Binlog to the cluster version.
 
 The corresponding relationship between TiDB Binlog versions and TiDB versions is shown in the following table:
 

--- a/v3.0/reference/tidb-binlog-overview.md
+++ b/v3.0/reference/tidb-binlog-overview.md
@@ -63,9 +63,9 @@ The server hardware requirements for development, testing, and the production en
 
 * You need to use TiDB v2.0.8-binlog, v2.1.0-rc.5 or a later version. Older versions of TiDB cluster are not compatible with the cluster version of TiDB Binlog.
 
-* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/binlog/binlog-slave-client.md).
+* Drainer supports replicating binlogs to MySQL, TiDB, Kafka or local files. If you need to replicate binlogs to other Drainer unsuppored destinations, you can set Drainer to replicate the binlog to Kafka and read the data in Kafka for customized processing according to binlog slave protocol. See [Binlog Slave Client User Guide](/reference/tools/tidb-binlog/binlog-slave-client.md).
 
-* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/binlog/reparo.md) to recover data incrementally.
+* To use TiDB Binlog for recovering incremental data, set the config `db-type` to `file` (local files in the proto buffer format). Drainer converts the binlog to data in the specified [proto buffer format](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto) and writes the data to local files. In this way, you can use [Reparo](/reference/tools/tidb-binlog/reparo.md) to recover data incrementally.
 
     Pay attention to the value of `db-type`:
 

--- a/v3.0/reference/tidb-binlog-overview.md
+++ b/v3.0/reference/tidb-binlog-overview.md
@@ -3,8 +3,8 @@ title: TiDB Binlog Overview
 summary: Learn overview of the cluster version of TiDB Binlog.
 category: reference 
 aliases: ['/docs/tools/binlog/overview/','docs/tools/tidb-binlog-cluster/','/docs/dev/reference/tools/tidb-binlog/overview/']
-
 ---
+
 # TiDB Binlog Cluster Overview
 
 This document introduces the architecture and the deployment of the cluster version of TiDB Binlog.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->

* In **/reference/tidb-binlog-overview.md**, the `reparo` link is wrong and should be correct to **/reference/tools/tidb-binlog/reparo.md**; also  the `Binlog Slave Client User Guide` link is wrong and should be correct to **/reference/tools/tidb-binlog/binlog-slave-client.md**
* In **how-to/upgrade/tidb-binlog.md**， the `Kafka version` link should be correct to **/reference/tools/tidb-binlog/tidb-binlog-kafka.md** and `Local version` should be correct to **/reference/tools/tidb-binlog/tidb-binlog-local.md**

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->
PTAL https://github.com/pingcap/docs-cn/pull/1522

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

apply in dev/v3.0/v2.1
