### PR TITLE
dev, v3.0: fix incorrect links

### DIFF
--- a/dev/reference/mysql-compatibility.md
+++ b/dev/reference/mysql-compatibility.md
@@ -170,7 +170,7 @@ It is recommended to use the historical reads feature of `tidb_snapshot` to prod
 - Default collation:
     - The default collation of `utf8mb4` in TiDB is `utf8mb4_bin`.
     - The default collation of `utf8mb4` in MySQL 5.7 is `utf8mb4_general_ci`, but changes to `utf8mb4_0900_ai_ci` in MySQL 8.0.
-    - You can use the [`SHOW CHARACTER SET`](/dev/reference/sql/statements/show-character-set.md) statement to check the default collations of all character sets.
+    - You can use the [`SHOW CHARACTER SET`](/reference/sql/statements/show-character-set.md) statement to check the default collations of all character sets.
 - Default value of `foreign_key_checks`:
     - The default value in TiDB is `OFF` and currently TiDB only supports `OFF`.
     - The default value in MySQL 5.7 is `ON`.

--- a/v3.0/reference/mysql-compatibility.md
+++ b/v3.0/reference/mysql-compatibility.md
@@ -166,7 +166,7 @@ tidb> SELECT /*!90000 "I should not run", */ "I should run" FROM dual;
 - Default collation:
     - The default collation of `utf8mb4` in TiDB is `utf8mb4_bin`.
     - The default collation of `utf8mb4` in MySQL 5.7 is `utf8mb4_general_ci`, but changes to `utf8mb4_0900_ai_ci` in MySQL 8.0.
-    - You can use the [`SHOW CHARACTER SET`](/dev/reference/sql/statements/show-character-set.md) statement to check the default collations of all character sets.
+    - You can use the [`SHOW CHARACTER SET`](/reference/sql/statements/show-character-set.md) statement to check the default collations of all character sets.
 - Default value of `foreign_key_checks`:
     - The default value in TiDB is `OFF` and currently TiDB only supports `OFF`.
     - The default value in MySQL 5.7 is `ON`.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

fix incorrect links in dev and v3.0 folders @CaitinChen  PTAL

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->
dev and v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`