### PR TITLE
Fix TiDB 3.0 sysbench test's machine information

### DIFF
--- a/dev/benchmark/sysbench-v4.md
+++ b/dev/benchmark/sysbench-v4.md
@@ -24,8 +24,8 @@ This test runs on AWS EC2 and uses the CentOS-7.6.1810-Nitro (ami-028946f4cffc8b
 | Component  |  Instance type  |
 | :--- | :-------- |
 |  PD   | r5d.xlarge |
-| TiKV  | c5d.xlarge |
-| TiDB  | c5.xlarge |
+| TiKV  | c5d.4xlarge |
+| TiDB  | c5.4xlarge |
 
 Sysbench version: 1.0.17
 

--- a/v3.0/benchmark/sysbench-v4.md
+++ b/v3.0/benchmark/sysbench-v4.md
@@ -24,8 +24,8 @@ This test runs on AWS EC2 and uses the CentOS-7.6.1810-Nitro (ami-028946f4cffc8b
 | Component  |  Instance type  |
 | :--- | :-------- |
 |  PD   | r5d.xlarge |
-| TiKV  | c5d.xlarge |
-| TiDB  | c5.xlarge |
+| TiKV  | c5d.4xlarge |
+| TiDB  | c5.4xlarge |
 
 Sysbench version: 1.0.17
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
modify: simple bug fix

<!--Tell us what you did and why.-->
wrong VM info in TiDB 3.0's sysbench doc.

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [] Use *four* spaces for each level of indentation except that in `TOC.md`
