### PR TITLE
v3.0: bumped binlog tutorial to use stable 3.0 packages

### DIFF
--- a/v3.0/how-to/get-started/tidb-binlog.md
+++ b/v3.0/how-to/get-started/tidb-binlog.md
@@ -45,19 +45,19 @@ sudo yum install -y mariadb-server
 Even if you've already started a TiDB cluster, it will be easier to follow along with this tutorial where we will set up a new, simple cluster. We will install from a tarball, using a simplified form of the [Local Deployment](/how-to/get-started/local-cluster/install-from-binary.md) guide. You may also wish to refer to [Testing Deployment from Binary Tarball](/how-to/deploy/from-tarball/testing-environment.md) for best practices of establishing a real testing deployment, but that goes beyond the scope of this tutorial.
 
 ```bash
-curl -L http://download.pingcap.org/tidb-latest-linux-amd64.tar.gz | tar xzf -
-cd tidb-latest-linux-amd64
+curl -L http://download.pingcap.org/tidb-v3.0-linux-amd64.tar.gz | tar xzf -
+cd tidb-v3.0-linux-amd64/
 ```
 
 Expected output:
 
 ```
-[kolbe@localhost ~]$ curl -LO http://download.pingcap.org/tidb-latest-linux-amd64.tar.gz | tar xzf -
+[kolbe@localhost ~]$ curl -LO http://download.pingcap.org/tidb-v3.0-linux-amd64.tar.gz | tar xzf -
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100  368M  100  368M    0     0  8394k      0  0:00:44  0:00:44 --:--:-- 11.1M
-[kolbe@localhost ~]$ cd tidb-latest-linux-amd64
-[kolbe@localhost tidb-latest-linux-amd64]$
+100  279M  100  279M    0     0  4983k      0  0:00:57  0:00:57 --:--:-- 3638k
+[kolbe@localhost ~]$ cd tidb-v3.0-linux-amd64/
+[kolbe@localhost tidb-v3.0-linux-amd64]$
 ```
 
 ## Configuration
@@ -141,21 +141,21 @@ sleep 3
 Expected output:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/pd-server --config=pd.toml &>pd.out &
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/pd-server --config=pd.toml &>pd.out &
 [1] 20935
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/tikv-server --config=tikv.toml &>tikv.out &
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/tikv-server --config=tikv.toml &>tikv.out &
 [2] 20944
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/pump --config=pump.toml &>pump.out &
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/pump --config=pump.toml &>pump.out &
 [3] 21050
-[kolbe@localhost tidb-latest-linux-amd64]$ sleep 3
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/tidb-server --config=tidb.toml &>tidb.out &
+[kolbe@localhost tidb-v3.0-linux-amd64]$ sleep 3
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/tidb-server --config=tidb.toml &>tidb.out &
 [4] 21058
 ```
 
 If you execute `jobs`, you should see a list of running daemons:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ jobs
+[kolbe@localhost tidb-v3.0-linux-amd64]$ jobs
 [1]   Running                 ./bin/pd-server --config=pd.toml &>pd.out &
 [2]   Running                 ./bin/tikv-server --config=tikv.toml &>tikv.out &
 [3]-  Running                 ./bin/pump --config=pump.toml &>pump.out &
@@ -175,12 +175,12 @@ mysql -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
 Expected output:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ mysql -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
+[kolbe@localhost tidb-v3.0-linux-amd64]$ mysql -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
 *************************** 1. row ***************************
-tidb_version(): Release Version: v3.0.0-beta.1-154-gd5afff70c
-Git Commit Hash: d5afff70cdd825d5fab125c8e52e686cc5fb9a6e
-Git Branch: master
-UTC Build Time: 2019-04-24 03:10:00
+tidb_version(): Release Version: v3.0.0
+Git Commit Hash: 60965b006877ca7234adaced7890d7b029ed1306
+Git Branch: HEAD
+UTC Build Time: 2019-06-28 12:14:07
 GoVersion: go version go1.12 linux/amd64
 Race Enabled: false
 TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
@@ -339,10 +339,10 @@ Use `binlogctl` to get a view of the current status of Pumps and Drainers in the
 Expected output:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd drainers
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/binlogctl -cmd drainers
 [2019/04/11 17:44:10.861 -04:00] [INFO] [nodes.go:47] ["query node"] [type=drainer] [node="{NodeID: localhost.localdomain:8249, Addr: 192.168.236.128:8249, State: online, MaxCommitTS: 407638907719778305, UpdateTime: 2019-04-11 17:44:10 -0400 EDT}"]
 
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd pumps
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/binlogctl -cmd pumps
 [2019/04/11 17:44:13.904 -04:00] [INFO] [nodes.go:47] ["query node"] [type=pump] [node="{NodeID: localhost.localdomain:8250, Addr: 192.168.236.128:8250, State: online, MaxCommitTS: 407638914024079361, UpdateTime: 2019-04-11 17:44:13 -0400 EDT}"]
 ```
 
@@ -356,8 +356,8 @@ pkill drainer
 Expected output:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ pkill drainer
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd drainers
+[kolbe@localhost tidb-v3.0-linux-amd64]$ pkill drainer
+[kolbe@localhost tidb-v3.0-linux-amd64]$ ./bin/binlogctl -cmd drainers
 [2019/04/11 17:44:22.640 -04:00] [INFO] [nodes.go:47] ["query node"] [type=drainer] [node="{NodeID: localhost.localdomain:8249, Addr: 192.168.236.128:8249, State: paused, MaxCommitTS: 407638915597467649, UpdateTime: 2019-04-11 17:44:18 -0400 EDT}"]
 ```
 
@@ -390,7 +390,7 @@ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1;
 Expected output:
 
 ```
-kolbe@localhost tidb-latest-linux-amd64]$ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1; done
+kolbe@localhost tidb-v3.0-linux-amd64]$ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1; done
 [4]-  Done                    ./bin/tidb-server --config=tidb.toml &>tidb.out
 [5]+  Done                    ./bin/drainer --config=drainer.toml &>drainer.out
 [3]+  Done                    ./bin/pump --config=pump.toml &>pump.out


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

I bumped the package version for the TiDB-Binlog tutorial to use stable 3.0 releases rather than the "latest" packages.

<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

n/a

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

v3.0

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
