### PR TITLE
dev/how-to/deploy: add access-tidb-clusters-on-kubernetes

### DIFF
--- a/dev/TOC.md
+++ b/dev/TOC.md
@@ -43,8 +43,6 @@
       - [For Testing Environments](how-to/deploy/from-tarball/testing-environment.md)
       - [For Production Environments](how-to/deploy/from-tarball/production-environment.md)
     + Orchestrated Deployment
-      + tidb-in-kubernetes
-        - [Access TiDB](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
       - [Ansible Deployment (Recommended)](how-to/deploy/orchestrated/ansible.md)
       - [Ansible Offline Deployment](how-to/deploy/orchestrated/offline-ansible.md)
       - [Docker Deployment](how-to/deploy/orchestrated/docker.md)
@@ -54,6 +52,7 @@
       - [Configure Location Awareness](how-to/deploy/geographic-redundancy/location-awareness.md)
     - [Data Migration with Ansible](how-to/deploy/data-migration-with-ansible.md)
     - [TiDB Binlog Cluster Deployment](how-to/deploy/tidb-binlog.md)
+    - [Access the TiDB Cluster in Kubernetes](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
   + Configure
     - [Time Zone](how-to/configure/time-zone.md)
     - [Memory Control](how-to/configure/memory-control.md)

--- a/dev/TOC.md
+++ b/dev/TOC.md
@@ -43,6 +43,8 @@
       - [For Testing Environments](how-to/deploy/from-tarball/testing-environment.md)
       - [For Production Environments](how-to/deploy/from-tarball/production-environment.md)
     + Orchestrated Deployment
+      + tidb-in-kubernetes
+        - [Access TiDB](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
       - [Ansible Deployment (Recommended)](how-to/deploy/orchestrated/ansible.md)
       - [Ansible Offline Deployment](how-to/deploy/orchestrated/offline-ansible.md)
       - [Docker Deployment](how-to/deploy/orchestrated/docker.md)

--- a/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
+++ b/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
@@ -1,37 +1,39 @@
 ---
-title: Access TiDB Clusters on Kubernetes
+title: Access the TiDB Cluster in Kubernetes
+summary: Learn how to access the TiDB cluster in Kubernetes.
 category: how-to
 ---
 
-# Access TiDB Clusters on Kubernetes
+# Access the TiDB Cluster in Kubernetes
 
-To access TiDB within a Kubernetes cluster, use the TiDB service domain name `<tidbcluster-name>-tidb.<namespace>`.
+This document describes how to access the TiDB cluster in Kubernetes.
 
-To access TiDB outside a Kubernetes cluster, you need to expose TiDB service port. To do that, make the following configuration via the `tidb.service` field in the `values.yaml` file in the tidb-cluster Helm chart.
++ To access the TiDB cluster within a Kubernetes cluster, use the TiDB service domain name `<tidbcluster-name>-tidb.<namespace>`.
++ To access the TiDB cluster outside a Kubernetes cluster, expose the TiDB service port by editing the `tidb.service` field configuration in the `values.yaml` file of the `tidb-cluster` Helm chart.
 
-{{< copyable "" >}}
+    {{< copyable "" >}}
 
-```yaml
-tidb:
-  service:
-    type: NodePort
-    # externalTrafficPolicy: Cluster
-    # annotations:
-    # cloud.google.com/load-balancer-type: Internal
-```
+    ```yaml
+    tidb:
+    service:
+        type: NodePort
+        # externalTrafficPolicy: Cluster
+        # annotations:
+        # cloud.google.com/load-balancer-type: Internal
+    ```
 
 ## NodePort
 
-Without LoadBalancer, expose the TiDB service port in the following two modes of NodePort:
+If there is no LoadBalancer, expose the TiDB service port in the following two modes of NodePort:
 
 - `externalTrafficPolicy=Cluster`: All machines in the Kubernetes cluster assign a NodePort to TiDB Pod, which is the default mode.
 - `externalTrafficPolicy=Local`: Only those machines that runs TiDB assign NodePort to TiDB Pod so that you can access local TiDB instances.
 
-    When the `Local` mode is in use, it is recommended to enable the `StableScheduling` feature of tidb-scheduler. Tidb-scheduler tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
+    When you use the `Local` mode, it is recommended to enable the `StableScheduling` feature of `tidb-scheduler`. `tidb-scheduler` tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside the Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
 
-### See the IP/PORT exposed in NodePort mode
+### View the IP/PORT exposed in NodePort mode
 
-To see the Node Port assigned by Service, use the following commands to obtain the Service object of TiDB:
+To view the Node Port assigned by Service, run the following commands to obtain the Service object of TiDB:
 
 {{< copyable "shell-regular" >}}
 
@@ -51,10 +53,10 @@ release=<your-tidb-release-name>
 kubectl -n ${namespace} get svc ${release}-tidb -ojsonpath="{.spec.ports[?(@.name=='mysql-client')].nodePort}{'\n'}"
 ```
 
-You might encounter the following two situations when seeing which nodes' IP can access TiDB service:
+To check you can access TiDB services by using the IP of what nodes, see the following two cases:
 
-- When `externalTrafficPolicy` is configured as `Cluster`, IPs of all nodes can access TiDB.
-- When `externalTrafficPolicy` is configured as `Local`, use the following commands to obtain the nodes on which the TiDB instance of the specified cluster is located:
+- When `externalTrafficPolicy` is configured as `Cluster`, you can use the IP of any node to access TiDB services.
+- When `externalTrafficPolicy` is configured as `Local`, use the following commands to get the nodes where the TiDB instance of a specified cluster is located:
 
     {{< copyable "shell-regular" >}}
 

--- a/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
+++ b/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
@@ -70,6 +70,6 @@ You might encounter the following two situations when seeing which nodes' IP can
 
 ## LoadBalancer
 
-If Kubernetes is run in an environment with LoadBalancer, such as GCP/AWS platform, it is recommended to enable the LoadBalancer feature of these cloud platforms.
+If Kubernetes is run in an environment with LoadBalancer, such as GCP/AWS platform, it is recommended to use the LoadBalancer feature of these cloud platforms by setting `tidb.service.type=LoadBalancer`.
 
 See [Kubernetes Service Documentation](https://kubernetes.io/docs/concepts/services-networking/service/) to know more about the features of Service and what LoadBalancer in the cloud platform supports.

--- a/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
+++ b/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
@@ -1,0 +1,75 @@
+---
+title: Access TiDB Clusters on Kubernetes
+category: how-to
+---
+
+# Access TiDB Clusters on Kubernetes
+
+To access TiDB within a Kubernetes cluster, use the TiDB service domain name `<tidbcluster-name>-tidb.<namespace>`.
+
+To access TiDB outside a Kubernetes cluster, you need to expose TiDB service port. To do that, make the following configuration via the `tidb.service` field in the `values.yaml` file in the tidb-cluster Helm chart.
+
+{{< copyable "" >}}
+
+```yaml
+tidb:
+  service:
+    type: NodePort
+    # externalTrafficPolicy: Cluster
+    # annotations:
+    # cloud.google.com/load-balancer-type: Internal
+```
+
+## NodePort
+
+Without LoadBalancer, you could expose TiDB service port in the following 2 modes of NodePort:
+
+- `externalTrafficPolicy=Cluster`: All machines in the Kubernetes cluster assign a NodePort to TiDB Pod, which is the default mode.
+- `externalTrafficPolicy=Local`: Only those machines running TiDB assign NodePort to TiDB Pod so that you could access local TiDB instances.
+
+    When the `Local` mode is in use, it is recommended to enable the `StableScheduling` feature of tidb-scheduler. Tidb-scheduler tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
+
+### See the IP/PORT exposed in NodePort mode
+
+To see the Node Port assigned by Service, use the following commands to obtain the Service object of TiDB:
+
+{{< copyable "shell-regular" >}}
+
+```shell
+namespace=<your-tidb-namesapce>
+```
+
+{{< copyable "shell-regular" >}}
+
+```shell
+release=<your-tidb-release-name>
+```
+
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl -n ${namespace} get svc ${release}-tidb -ojsonpath="{.spec.ports[?(@.name=='mysql-client')].nodePort}{'\n'}"
+```
+
+You might encounter the following two situations when seeing which nodes' IP can access TiDB service:
+
+- When `externalTrafficPolicy` is configured as `Cluster`, IPs of all nodes can access TiDB.
+- When `externalTrafficPolicy` is configured as `Local`, use the following commands to obtain the nodes on which the TiDB instance of the specified cluster is located:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    release=<your-tidb-release-name>
+    ```
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    kubectl -n stability-cluster1 get pods -l "app.kubernetes.io/component=tidb,app.kubernetes.io/instance=${release}" -ojsonpath="{range .items[*]}{.spec.nodeName}{'\n'}{end}"
+    ```
+
+## LoadBalancer
+
+If Kubernetes is run in an environment with LoadBalancer, such as GCP/AWS platform, it is recommended to enable the LoadBalancer feature of these cloud platforms.
+
+See [Kubernetes Service Documentation](https://kubernetes.io/docs/concepts/services-networking/service/) to know more about the features of Service and what LoadBalancer in the cloud platform supports.

--- a/v3.0/TOC.md
+++ b/v3.0/TOC.md
@@ -43,8 +43,6 @@
       - [For Testing Environments](how-to/deploy/from-tarball/testing-environment.md)
       - [For Production Environments](how-to/deploy/from-tarball/production-environment.md)
     + Orchestrated Deployment
-      + tidb-in-kubernetes
-        - [Access TiDB](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
       - [Ansible Deployment (Recommended)](how-to/deploy/orchestrated/ansible.md)
       - [Ansible Offline Deployment](how-to/deploy/orchestrated/offline-ansible.md)
       - [Docker Deployment](how-to/deploy/orchestrated/docker.md)
@@ -54,6 +52,7 @@
       - [Configure Location Awareness](how-to/deploy/geographic-redundancy/location-awareness.md)
     - [Data Migration with Ansible](how-to/deploy/data-migration-with-ansible.md)
     - [TiDB Binlog Cluster Deployment](how-to/deploy/tidb-binlog.md)
+    - [Access the TiDB Cluster in Kubernetes](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
   + Configure
     - [Time Zone](how-to/configure/time-zone.md)
     - [Memory Control](how-to/configure/memory-control.md)

--- a/v3.0/TOC.md
+++ b/v3.0/TOC.md
@@ -43,6 +43,8 @@
       - [For Testing Environments](how-to/deploy/from-tarball/testing-environment.md)
       - [For Production Environments](how-to/deploy/from-tarball/production-environment.md)
     + Orchestrated Deployment
+      + tidb-in-kubernetes
+        - [Access TiDB](how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)
       - [Ansible Deployment (Recommended)](how-to/deploy/orchestrated/ansible.md)
       - [Ansible Offline Deployment](how-to/deploy/orchestrated/offline-ansible.md)
       - [Docker Deployment](how-to/deploy/orchestrated/docker.md)

--- a/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
+++ b/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
@@ -22,10 +22,10 @@ tidb:
 
 ## NodePort
 
-Without LoadBalancer, expose the TiDB service port in the following two modes of NodePort:
+Without LoadBalancer, expose TiDB service port in the following two modes of NodePort:
 
 - `externalTrafficPolicy=Cluster`: All machines in the Kubernetes cluster assign a NodePort to TiDB Pod, which is the default mode.
-- `externalTrafficPolicy=Local`: Only those machines that runs TiDB assign NodePort to TiDB Pod so that you can access local TiDB instances.
+- `externalTrafficPolicy=Local`: Only those machines running TiDB assign NodePort to TiDB Pod so that you can access local TiDB instances.
 
     When the `Local` mode is in use, it is recommended to enable the `StableScheduling` feature of tidb-scheduler. Tidb-scheduler tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
 

--- a/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
+++ b/v3.0/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md
@@ -1,37 +1,39 @@
 ---
-title: Access TiDB Clusters on Kubernetes
+title: Access the TiDB Cluster in Kubernetes
+summary: Learn how to access the TiDB cluster in Kubernetes.
 category: how-to
 ---
 
-# Access TiDB Clusters on Kubernetes
+# Access the TiDB Cluster in Kubernetes
 
-To access TiDB within a Kubernetes cluster, use the TiDB service domain name `<tidbcluster-name>-tidb.<namespace>`.
+This document describes how to access the TiDB cluster in Kubernetes.
 
-To access TiDB outside a Kubernetes cluster, you need to expose TiDB service port. To do that, make the following configuration via the `tidb.service` field in the `values.yaml` file in the tidb-cluster Helm chart.
++ To access the TiDB cluster within a Kubernetes cluster, use the TiDB service domain name `<tidbcluster-name>-tidb.<namespace>`.
++ To access the TiDB cluster outside a Kubernetes cluster, expose the TiDB service port by editing the `tidb.service` field configuration in the `values.yaml` file of the `tidb-cluster` Helm chart.
 
-{{< copyable "" >}}
+    {{< copyable "" >}}
 
-```yaml
-tidb:
-  service:
-    type: NodePort
-    # externalTrafficPolicy: Cluster
-    # annotations:
-    # cloud.google.com/load-balancer-type: Internal
-```
+    ```yaml
+    tidb:
+    service:
+        type: NodePort
+        # externalTrafficPolicy: Cluster
+        # annotations:
+        # cloud.google.com/load-balancer-type: Internal
+    ```
 
 ## NodePort
 
-Without LoadBalancer, expose TiDB service port in the following two modes of NodePort:
+If there is no LoadBalancer, expose the TiDB service port in the following two modes of NodePort:
 
 - `externalTrafficPolicy=Cluster`: All machines in the Kubernetes cluster assign a NodePort to TiDB Pod, which is the default mode.
-- `externalTrafficPolicy=Local`: Only those machines running TiDB assign NodePort to TiDB Pod so that you can access local TiDB instances.
+- `externalTrafficPolicy=Local`: Only those machines that runs TiDB assign NodePort to TiDB Pod so that you can access local TiDB instances.
 
-    When the `Local` mode is in use, it is recommended to enable the `StableScheduling` feature of tidb-scheduler. Tidb-scheduler tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
+    When you use the `Local` mode, it is recommended to enable the `StableScheduling` feature of `tidb-scheduler`. `tidb-scheduler` tries to schedule the newly added TiDB instances to the existing machines during the upgrade process. With such scheduling, client outside the Kubernetes cluster does not need to upgrade configuration after TiDB is restarted.
 
-### See the IP/PORT exposed in NodePort mode
+### View the IP/PORT exposed in NodePort mode
 
-To see the Node Port assigned by Service, use the following commands to obtain the Service object of TiDB:
+To view the Node Port assigned by Service, run the following commands to obtain the Service object of TiDB:
 
 {{< copyable "shell-regular" >}}
 
@@ -51,10 +53,10 @@ release=<your-tidb-release-name>
 kubectl -n ${namespace} get svc ${release}-tidb -ojsonpath="{.spec.ports[?(@.name=='mysql-client')].nodePort}{'\n'}"
 ```
 
-You might encounter the following two situations when seeing which nodes' IP can access TiDB service:
+To check you can access TiDB services by using the IP of what nodes, see the following two cases:
 
-- When `externalTrafficPolicy` is configured as `Cluster`, IPs of all nodes can access TiDB.
-- When `externalTrafficPolicy` is configured as `Local`, use the following commands to obtain the nodes on which the TiDB instance of the specified cluster is located:
+- When `externalTrafficPolicy` is configured as `Cluster`, you can use the IP of any node to access TiDB services.
+- When `externalTrafficPolicy` is configured as `Local`, use the following commands to get the nodes where the TiDB instance of a specified cluster is located:
 
     {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
Via: https://github.com/pingcap/docs-cn/pull/1428

The document `tidb-in-kubernetes/expose-servics.md` added in #1428 had been changed in title, description, and place by the time when I did the translation. Therefore, this is not a literal translation. 
(the new address: https://github.com/pingcap/docs-cn/blob/master/dev/how-to/deploy/orchestrated/tidb-in-kubernetes/access-tidb.md)

The `## NodePort` section might be a little different from the original Chinese version. @weekface has given me some technical details to change the description of NodePort to make it more understandable.

Anyway, PTAL, thanks!