### PR TITLE
v2.1/reference/sql: add alter-database doc in v2.1

### DIFF
--- a/v2.1/TOC.md
+++ b/v2.1/TOC.md
@@ -151,6 +151,7 @@
       - [`ADD COLUMN`](reference/sql/statements/add-column.md)
       - [`ADD INDEX`](reference/sql/statements/add-index.md)
       - [`ADMIN`](reference/sql/statements/admin.md)
+      - [`ALTER DATABASE`](reference/sql/statements/alter-database.md)
       - [`ALTER TABLE`](reference/sql/statements/alter-table.md)
       - [`ALTER USER`](reference/sql/statements/alter-user.md)
       - [`ANALYZE TABLE`](reference/sql/statements/analyze-table.md)

--- a/v2.1/reference/sql/statements/alter-database.md
+++ b/v2.1/reference/sql/statements/alter-database.md
@@ -1,0 +1,26 @@
+---
+title: ALTER DATABASE | TiDB SQL Statement Reference 
+summary: An overview of the usage of ALTER DATABASE for the TiDB database.
+category: reference
+---
+
+# ALTER DATABASE
+
+`ALTER DATABASE` is used to specify or modify the default character set and collation of the current database. `ALTER SCHEMA` has the same effect as `ALTER DATABASE`.
+
+## Examples
+
+```sql
+ALTER {DATABASE | SCHEMA} [db_name]
+    alter_specification ...
+alter_specification:
+    [DEFAULT] CHARACTER SET [=] charset_name
+  | [DEFAULT] COLLATE [=] collation_name
+```
+
+The `alter_specification` option specifies the `CHARACTER SET` and `COLLATE` of a specified database. Currently, TiDB only supports some character sets and collations. See [Character Set Support](/reference/sql/character-set.md) for details.
+
+## See also
+
+* [CREATE DATABASE](/reference/sql/statements/create-database.md)
+* [SHOW DATABASES](/reference/sql/statements/show-databases.md)


### PR DESCRIPTION
### What is changed, added or deleted? <!--Required-->

This PR adds the alter-database document to the v2.1 directory.

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1610

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

v2.1

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
