### PR TITLE
v3.0,dev/how-to/configure: initialize cluster managed by tidb-operator 

### DIFF
--- a/dev/TOC.md
+++ b/dev/TOC.md
@@ -61,6 +61,7 @@
   + Configure
     - [Time Zone](how-to/configure/time-zone.md)
     - [Memory Control](how-to/configure/memory-control.md)
+    - [Cluster Initialization](how-to/configure/initialize-cluster.md)
   + Secure
     + Transport Layer Security (TLS)
       - [Enable TLS For MySQL Clients](how-to/secure/enable-tls-clients.md)

--- a/dev/how-to/configure/initialize-cluster.md
+++ b/dev/how-to/configure/initialize-cluster.md
@@ -1,0 +1,79 @@
+---
+title: Cluster Initialization in Kubernetes
+summary: Learn how to initiate a TiDB cluster in K8s.
+category: how-to
+---
+
+# Cluster Initialization in Kubernetes
+
+This document describes how to initialize a cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by batch executing SQL statements automatically.
+
+> **Note:**
+>
+> The following steps only apply when you create a cluster for the first time. Further configuration or modification after the initial cluster creation is not valid.
+
+## Set initial account and password
+
+When a cluster is created, a default account `root` is created with no password. This might cause security issues. You can set a password for the `root` account in the following steps:
+
+1. Create a `secret` object.
+
+    Before creating a cluster, create a [`secret`](https://kubernetes.io/docs/concepts/configuration/secret/) to specify the password for `root`:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    kubectl create secret generic tidb-secret --from-literal=root=<root-password> --namespace=<namespace>
+    ```
+
+    If you also want to create users automatically, append the desired user name and the password, for example:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    kubectl create secret generic tidb-secret --from-literal=root=<root-password> --from-literal=developer=<developer-passowrd> --namespace=<namespace>
+    ```
+
+    This command creates users `root` and `developer` with their passwords, which are saved in the `tidb-secret` object.
+
+2. Deploy the cluster.
+
+    After creating the `secret`, deploy the cluster using the following command:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    helm install pingcap/tidb-cluster --name=<release-name> --namespace=<namespace> --version=v1.0.0-beta.3 --set tidb.passwordSecretName=tidb-secret
+    ```
+
+    After specifying `tidb.passwordSecretName`, the above command sets up a cluster with an initialization job created automatically. Using the available `secret`, this job creates the password for the `root` account, and creates other user accounts and passwords if specified. The password specified here is required when you login to the MySQL client.
+
+    > **Note:**
+    > 
+    > When the initialization job is created, the pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and pod state becomes Completed.
+
+## Batch execute initialization SQL statements
+
+You can also batch execute the SQL statements in  `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
+
+{{< copyable "yaml" >}}
+
+```yaml
+tidb:
+  passwordSecretName: tidb-secret
+  initSql: |-
+    CREATE DATABASE app;
+    GRANT ALL PRIVILEGES ON app.* TO 'developer'@'%';
+```
+
+Save the above configuration to `values.yaml` file and run the following command to deploy the cluster:
+
+{{< copyable "shell-regular" >}}
+
+```bash
+helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespace=<namespace> --version=v1.0.0-beta.3
+```
+
+> **Note:**
+>
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, it's not recommended because passwords created this way are saved as plaintext in the initializer job object.

--- a/dev/how-to/configure/initialize-cluster.md
+++ b/dev/how-to/configure/initialize-cluster.md
@@ -50,7 +50,7 @@ When a cluster is created, a default account `root` is created with no password.
 
     > **Note:**
     > 
-    > When the initialization job is created, the pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and pod state becomes Completed.
+    > When the initialization job is created, the Pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and Pod state becomes Completed.
 
 ## Batch execute initialization SQL statements
 

--- a/dev/how-to/configure/initialize-cluster.md
+++ b/dev/how-to/configure/initialize-cluster.md
@@ -76,4 +76,4 @@ helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespa
 
 > **Note:**
 >
-> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, it's not recommended because passwords created this way are saved as plaintext in the initializer job object.
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it's not recommended because passwords created this way are saved as plaintext in the initializer job object.

--- a/dev/how-to/configure/initialize-cluster.md
+++ b/dev/how-to/configure/initialize-cluster.md
@@ -1,12 +1,12 @@
 ---
-title: Cluster Initialization in Kubernetes
-summary: Learn how to initiate a TiDB cluster in K8s.
+title: Initialize a TiDB Cluster in Kubernetes
+summary: Learn how to initialize a TiDB cluster in K8s.
 category: how-to
 ---
 
-# Cluster Initialization in Kubernetes
+# Initialize a TiDB Cluster in Kubernetes
 
-This document describes how to initialize a cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by batch executing SQL statements automatically.
+This document describes how to initialize a TiDB cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by executing SQL statements automatically in batch.
 
 > **Note:**
 >
@@ -52,9 +52,9 @@ When a cluster is created, a default account `root` is created with no password.
     > 
     > When the initialization job is created, the Pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and Pod state becomes Completed.
 
-## Batch execute initialization SQL statements
+## Initialize SQL statements in batch
 
-You can also batch execute the SQL statements in  `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
+You can also execute the SQL statements in batch in `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
 
 {{< copyable "yaml" >}}
 
@@ -66,7 +66,7 @@ tidb:
     GRANT ALL PRIVILEGES ON app.* TO 'developer'@'%';
 ```
 
-Save the above configuration to `values.yaml` file and run the following command to deploy the cluster:
+Save the above configuration to the `values.yaml` file and run the following command to deploy the cluster:
 
 {{< copyable "shell-regular" >}}
 
@@ -76,4 +76,4 @@ helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespa
 
 > **Note:**
 >
-> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it's not recommended because passwords created this way are saved as plaintext in the initializer job object.
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it is not recommended because passwords created this way are saved as plaintext in the initializer job object.

--- a/v3.0/TOC.md
+++ b/v3.0/TOC.md
@@ -61,6 +61,7 @@
   + Configure
     - [Time Zone](how-to/configure/time-zone.md)
     - [Memory Control](how-to/configure/memory-control.md)
+    - [Cluster Initialization](how-to/configure/initialize-cluster.md)
   + Secure
     + Transport Layer Security (TLS)
       - [Enable TLS For MySQL Clients](how-to/secure/enable-tls-clients.md)

--- a/v3.0/how-to/configure/initialize-cluster.md
+++ b/v3.0/how-to/configure/initialize-cluster.md
@@ -1,0 +1,79 @@
+---
+title: Cluster Initialization in Kubernetes
+summary: Learn how to initiate a TiDB cluster in K8s.
+category: how-to
+---
+
+# Cluster Initialization in Kubernetes
+
+This document describes how to initialize a cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by batch executing SQL statements automatically.
+
+> **Note:**
+>
+> The following steps only apply when you create a cluster for the first time. Further configuration or modification after the initial cluster creation is not valid.
+
+## Set initial account and password
+
+When a cluster is created, a default account `root` is created with no password. This might cause security issues. You can set a password for the `root` account in the following steps:
+
+1. Create a `secret` object.
+
+    Before creating a cluster, create a [`secret`](https://kubernetes.io/docs/concepts/configuration/secret/) to specify the password for `root`:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    kubectl create secret generic tidb-secret --from-literal=root=<root-password> --namespace=<namespace>
+    ```
+
+    If you also want to create users automatically, append the desired user name and the password, for example:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    kubectl create secret generic tidb-secret --from-literal=root=<root-password> --from-literal=developer=<developer-passowrd> --namespace=<namespace>
+    ```
+
+    This command creates users `root` and `developer` with their passwords, which are saved in the `tidb-secret` object.
+
+2. Deploy the cluster.
+
+    After creating the `secret`, deploy the cluster using the following command:
+
+    {{< copyable "shell-regular" >}}
+
+    ```shell
+    helm install pingcap/tidb-cluster --name=<release-name> --namespace=<namespace> --version=v1.0.0-beta.3 --set tidb.passwordSecretName=tidb-secret
+    ```
+
+    After specifying `tidb.passwordSecretName`, the above command sets up a cluster with an initialization job created automatically. Using the available `secret`, this job creates the password for the `root` account, and creates other user accounts and passwords if specified. The password specified here is required when you login to the MySQL client.
+
+    > **Note:**
+    > 
+    > When the initialization job is created, the pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and pod state becomes Completed.
+
+## Batch execute initialization SQL statements
+
+You can also batch execute the SQL statements in  `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
+
+{{< copyable "yaml" >}}
+
+```yaml
+tidb:
+  passwordSecretName: tidb-secret
+  initSql: |-
+    CREATE DATABASE app;
+    GRANT ALL PRIVILEGES ON app.* TO 'developer'@'%';
+```
+
+Save the above configuration to `values.yaml` file and run the following command to deploy the cluster:
+
+{{< copyable "shell-regular" >}}
+
+```bash
+helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespace=<namespace> --version=v1.0.0-beta.3
+```
+
+> **Note:**
+>
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, it's not recommended because passwords created this way are saved as plaintext in the initializer job object.

--- a/v3.0/how-to/configure/initialize-cluster.md
+++ b/v3.0/how-to/configure/initialize-cluster.md
@@ -50,7 +50,7 @@ When a cluster is created, a default account `root` is created with no password.
 
     > **Note:**
     > 
-    > When the initialization job is created, the pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and pod state becomes Completed.
+    > When the initialization job is created, the Pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and Pod state becomes Completed.
 
 ## Batch execute initialization SQL statements
 

--- a/v3.0/how-to/configure/initialize-cluster.md
+++ b/v3.0/how-to/configure/initialize-cluster.md
@@ -76,4 +76,4 @@ helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespa
 
 > **Note:**
 >
-> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, it's not recommended because passwords created this way are saved as plaintext in the initializer job object.
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it's not recommended because passwords created this way are saved as plaintext in the initializer job object.

--- a/v3.0/how-to/configure/initialize-cluster.md
+++ b/v3.0/how-to/configure/initialize-cluster.md
@@ -1,12 +1,12 @@
 ---
-title: Cluster Initialization in Kubernetes
-summary: Learn how to initiate a TiDB cluster in K8s.
+title: Initialize a TiDB Cluster in Kubernetes
+summary: Learn how to initialize a TiDB cluster in K8s.
 category: how-to
 ---
 
-# Cluster Initialization in Kubernetes
+# Initialize a TiDB Cluster in Kubernetes
 
-This document describes how to initialize a cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by batch executing SQL statements automatically.
+This document describes how to initialize a TiDB cluster in Kubernetes (K8s), specifically, how to configure the initial account and password and how to initialize the database by executing SQL statements automatically in batch.
 
 > **Note:**
 >
@@ -52,9 +52,9 @@ When a cluster is created, a default account `root` is created with no password.
     > 
     > When the initialization job is created, the Pod for the TiDB cluster has not been created fully. There might be a few errors before initialization completes and Pod state becomes Completed.
 
-## Batch execute initialization SQL statements
+## Initialize SQL statements in batch
 
-You can also batch execute the SQL statements in  `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
+You can also execute the SQL statements in batch in `tidb.initSql` for initialization. This function by default creates some databases or tables for the cluster and performs user privilege management operations. For example, the following configuration automatically creates a database named `app` after the cluster creation, and grants the `developer` account full management privileges on `app`.
 
 {{< copyable "yaml" >}}
 
@@ -66,7 +66,7 @@ tidb:
     GRANT ALL PRIVILEGES ON app.* TO 'developer'@'%';
 ```
 
-Save the above configuration to `values.yaml` file and run the following command to deploy the cluster:
+Save the above configuration to the `values.yaml` file and run the following command to deploy the cluster:
 
 {{< copyable "shell-regular" >}}
 
@@ -76,4 +76,4 @@ helm install pingcap/tidb-cluster -f values.yaml --name=<release-name> --namespa
 
 > **Note:**
 >
-> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it's not recommended because passwords created this way are saved as plaintext in the initializer job object.
+> Currently no verification has been implemented for `initSql`. You can create accounts and set passwords in `initSql`, but it is not recommended because passwords created this way are saved as plaintext in the initializer job object.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
Adding a document about how to initialize TiDB cluster on Kubernetes deployment.

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1591

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev and v3.0

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`


