### PR TITLE
dev, 3.0: Refine document of GC

### DIFF
--- a/dev/reference/garbage-collection/configuration.md
+++ b/dev/reference/garbage-collection/configuration.md
@@ -6,15 +6,39 @@ category: reference
 
 # GC Configuration
 
-The GC (Garbage Collection) configuration and operational status are recorded in the `mysql.tidb` system table. This document lists these parameters with their descriptions. You can use SQL statements to query or modify them. For example, the following statement adjusts the GC interval to 30 minutes:
+The GC (Garbage Collection) configuration and operational status are recorded in the `mysql.tidb` system table. You can use SQL statements to query or modify them:
+
+```plain
+mysql> select VARIABLE_NAME, VARIABLE_VALUE from mysql.tidb;
++--------------------------+----------------------------------------------------------------------------------------------------+
+| VARIABLE_NAME            | VARIABLE_VALUE                                                                                     |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| bootstrapped             | True                                                                                               |
+| tidb_server_version      | 33                                                                                                 |
+| system_tz                | UTC                                                                                                |
+| tikv_gc_leader_uuid      | 5afd54a0ea40005                                                                                    |
+| tikv_gc_leader_desc      | host:tidb-cluster-tidb-0, pid:215, start at 2019-07-15 11:09:14.029668932 +0000 UTC m=+0.463731223 |
+| tikv_gc_leader_lease     | 20190715-12:12:14 +0000                                                                            |
+| tikv_gc_enable           | true                                                                                               |
+| tikv_gc_run_interval     | 10m0s                                                                                              |
+| tikv_gc_life_time        | 10m0s                                                                                              |
+| tikv_gc_last_run_time    | 20190715-12:09:14 +0000                                                                            |
+| tikv_gc_safe_point       | 20190715-11:59:14 +0000                                                                            |
+| tikv_gc_auto_concurrency | true                                                                                               |
+| tikv_gc_mode             | distributed                                                                                        |
++--------------------------+----------------------------------------------------------------------------------------------------+
+13 rows in set (0.00 sec)
+```
+
+For example, the following statement makes GC keeps history data in the recent one day:
 
 ```sql
-update mysql.tidb set VARIABLE_VALUE="30m" where VARIABLE_NAME="tikv_gc_run_interval";
+update mysql.tidb set VARIABLE_VALUE="24h" where VARIABLE_NAME="tikv_gc_life_time";
 ```
 
 > **Note:**
 >
-> In addition to GC configuration parameters, the `mysql.tidb` system table also contains records that store the status of the storage components in a TiDB cluster, among which GC related ones are included, as listed below:
+> In addition to the following GC configuration parameters, the `mysql.tidb` system table also contains records that store the status of the storage components in a TiDB cluster, among which GC related ones are included, as listed below:
 >
 > - `tikv_gc_leader_uuid`, `tikv_gc_leader_desc` and `tikv_gc_leader_lease`: Records the information of the GC leader
 > - `tikv_gc_last_run_time`: The duration of the previous GC

--- a/dev/reference/garbage-collection/configuration.md
+++ b/dev/reference/garbage-collection/configuration.md
@@ -30,7 +30,7 @@ mysql> select VARIABLE_NAME, VARIABLE_VALUE from mysql.tidb;
 13 rows in set (0.00 sec)
 ```
 
-For example, the following statement makes GC keeps history data in the recent one day:
+For example, the following statement makes GC keep history data for the most recent 24 hours:
 
 ```sql
 update mysql.tidb set VARIABLE_VALUE="24h" where VARIABLE_NAME="tikv_gc_life_time";

--- a/v3.0/reference/garbage-collection/configuration.md
+++ b/v3.0/reference/garbage-collection/configuration.md
@@ -6,10 +6,34 @@ category: reference
 
 # GC Configuration
 
-The GC (Garbage Collection) configuration and operational status are recorded in the `mysql.tidb` system table. This documents lists these parameters with their descriptions. You can use SQL statements to query or modify them. For example, the following statement adjusts the GC interval to 30 minutes:
+The GC (Garbage Collection) configuration and operational status are recorded in the `mysql.tidb` system table. You can use SQL statements to query or modify them:
+
+```plain
+mysql> select VARIABLE_NAME, VARIABLE_VALUE from mysql.tidb;
++--------------------------+----------------------------------------------------------------------------------------------------+
+| VARIABLE_NAME            | VARIABLE_VALUE                                                                                     |
++--------------------------+----------------------------------------------------------------------------------------------------+
+| bootstrapped             | True                                                                                               |
+| tidb_server_version      | 33                                                                                                 |
+| system_tz                | UTC                                                                                                |
+| tikv_gc_leader_uuid      | 5afd54a0ea40005                                                                                    |
+| tikv_gc_leader_desc      | host:tidb-cluster-tidb-0, pid:215, start at 2019-07-15 11:09:14.029668932 +0000 UTC m=+0.463731223 |
+| tikv_gc_leader_lease     | 20190715-12:12:14 +0000                                                                            |
+| tikv_gc_enable           | true                                                                                               |
+| tikv_gc_run_interval     | 10m0s                                                                                              |
+| tikv_gc_life_time        | 10m0s                                                                                              |
+| tikv_gc_last_run_time    | 20190715-12:09:14 +0000                                                                            |
+| tikv_gc_safe_point       | 20190715-11:59:14 +0000                                                                            |
+| tikv_gc_auto_concurrency | true                                                                                               |
+| tikv_gc_mode             | distributed                                                                                        |
++--------------------------+----------------------------------------------------------------------------------------------------+
+13 rows in set (0.00 sec)
+```
+
+For example, the following statement makes GC keeps history data in the recent one day:
 
 ```sql
-update mysql.tidb set VARIABLE_VALUE="30m" where VARIABLE_NAME="tikv_gc_run_interval";
+update mysql.tidb set VARIABLE_VALUE="24h" where VARIABLE_NAME="tikv_gc_life_time";
 ```
 
 > **Note:**

--- a/v3.0/reference/garbage-collection/configuration.md
+++ b/v3.0/reference/garbage-collection/configuration.md
@@ -30,7 +30,7 @@ mysql> select VARIABLE_NAME, VARIABLE_VALUE from mysql.tidb;
 13 rows in set (0.00 sec)
 ```
 
-For example, the following statement makes GC keeps history data in the recent one day:
+For example, the following statement makes GC keep history data for the most recent 24 hours:
 
 ```sql
 update mysql.tidb set VARIABLE_VALUE="24h" where VARIABLE_NAME="tikv_gc_life_time";


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

* This PR is corresponding with https://github.com/pingcap/docs-cn/pull/1634 :
  * Add the example of mysql.tidb's content back to make it easier for reader to understand how the configurations are represented.
  * Use tikv_gc_life_time as the example of updating configurations, which is more frequently used.
* Additionally, this PR fixed an inconstancy of dev and 3.0, at configuration.md L41

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

* Chinese version: https://github.com/pingcap/docs-cn/pull/1634

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev, v3.0

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
