### PR TITLE
dev, v3.0/tidb-in-kubernetes: fix broken links in the K8s docs

### DIFF
--- a/dev/tidb-in-kubernetes/deploy/general-kubernetes.md
+++ b/dev/tidb-in-kubernetes/deploy/general-kubernetes.md
@@ -11,7 +11,7 @@ This document describes how to deploy a TiDB cluster on general Kubernetes.
 ## Prerequisites
 
 - [Deploy TiDB Operator](tidb-in-kubernetes/deploy/tidb-operator.md);
-- [Install Helm](tidb-in-kubernetes/reference/tools/tools-in-kubernetes.md)  and configure it with the official PingCAP chart.
+- [Install Helm](tidb-in-kubernetes/reference/tools/in-kubernetes.md) and configure it with the official PingCAP chart.
 
 ## Configure TiDB cluster
 
@@ -28,7 +28,7 @@ helm inspect values pingcap/tidb-cluster --version=<chartVersion> > /home/tidb/<
 >
 > You can replace `/home/tidb` with any directory as you like. In the rest of this document, `values.yaml` is used to refer to `/home/tidb/<releaseName>/values-<releaseName>.yaml`.
 
-Modify the configuratiuon above according to your needs. For more configuration details, refer to the [TiDB Cluster Configuration Document](/tidb-in-kubernetes/reference/configuration/tidb-cluster.md)。
+Modify the configuratiuon above according to your needs. For more configuration details, refer to the [TiDB Cluster Configuration Document](/tidb-in-kubernetes/reference/configuration/tidb-cluster.md).
 
 ## Deploy TiDB Cluster
 

--- a/dev/tidb-in-kubernetes/deploy/tidb-operator.md
+++ b/dev/tidb-in-kubernetes/deploy/tidb-operator.md
@@ -50,7 +50,7 @@ Set `LimitNOFILE` to `1048576` or bigger.
 
 ## Install Helm
 
-Refer to [Use Helm](/tidb-in-kubernetes/reference/tools-in-kubernetes.md#use-helm) to install Helm and configre it with the official PingCAP chart Repo.
+Refer to [Use Helm](/tidb-in-kubernetes/reference/tools/in-kubernetes.md#use-helm) to install Helm and configre it with the official PingCAP chart Repo.
 
 ## Configure Local Persistent Volume
 

--- a/dev/tidb-in-kubernetes/tidb-operator-overview.md
+++ b/dev/tidb-in-kubernetes/tidb-operator-overview.md
@@ -47,7 +47,7 @@ Before deploying TiDB on any of the above two environments, you can always refer
 
 After the deployment is complete, see the following documents to use, operate, and maintain TiDB clusters in Kubernetes:
 
-+ [Manage the TiDB Cluster](tidb-in-kubernetes/maintain/tidb-cluster.md)
++ [Manage the TiDB Cluster](tidb-in-kubernetes/maintain/kubernetes-node.md)
 + [Access the TiDB Cluster](tidb-in-kubernetes/deploy/access-tidb.md)
 + [Scale TiDB Cluster](tidb-in-kubernetes/scale-in-kubernetes.md)
 + [Upgrade TiDB Cluster](tidb-in-kubernetes/upgrade/tidb-cluster.md#upgrade-the-version-of-tidb-cluster)

--- a/v3.0/tidb-in-kubernetes/deploy/general-kubernetes.md
+++ b/v3.0/tidb-in-kubernetes/deploy/general-kubernetes.md
@@ -11,7 +11,7 @@ This document describes how to deploy a TiDB cluster on general Kubernetes.
 ## Prerequisites
 
 - [Deploy TiDB Operator](tidb-in-kubernetes/deploy/tidb-operator.md);
-- [Install Helm](tidb-in-kubernetes/reference/tools/tools-in-kubernetes.md)  and configure it with the official PingCAP chart.
+- [Install Helm](tidb-in-kubernetes/reference/tools/in-kubernetes.md) and configure it with the official PingCAP chart.
 
 ## Configure TiDB cluster
 
@@ -28,7 +28,7 @@ helm inspect values pingcap/tidb-cluster --version=<chartVersion> > /home/tidb/<
 >
 > You can replace `/home/tidb` with any directory as you like. In the rest of this document, `values.yaml` is used to refer to `/home/tidb/<releaseName>/values-<releaseName>.yaml`.
 
-Modify the configuratiuon above according to your needs. For more configuration details, refer to the [TiDB Cluster Configuration Document](/tidb-in-kubernetes/reference/configuration/tidb-cluster.md)。
+Modify the configuratiuon above according to your needs. For more configuration details, refer to the [TiDB Cluster Configuration Document](/tidb-in-kubernetes/reference/configuration/tidb-cluster.md).
 
 ## Deploy TiDB Cluster
 

--- a/v3.0/tidb-in-kubernetes/deploy/tidb-operator.md
+++ b/v3.0/tidb-in-kubernetes/deploy/tidb-operator.md
@@ -50,7 +50,7 @@ Set `LimitNOFILE` to `1048576` or bigger.
 
 ## Install Helm
 
-Refer to [Use Helm](/tidb-in-kubernetes/reference/tools-in-kubernetes.md#use-helm) to install Helm and configre it with the official PingCAP chart Repo.
+Refer to [Use Helm](/tidb-in-kubernetes/reference/tools/in-kubernetes.md#use-helm) to install Helm and configre it with the official PingCAP chart Repo.
 
 ## Configure Local Persistent Volume
 

--- a/v3.0/tidb-in-kubernetes/tidb-operator-overview.md
+++ b/v3.0/tidb-in-kubernetes/tidb-operator-overview.md
@@ -47,7 +47,7 @@ Before deploying TiDB on any of the above two environments, you can always refer
 
 After the deployment is complete, see the following documents to use, operate, and maintain TiDB clusters in Kubernetes:
 
-+ [Manage the TiDB Cluster](tidb-in-kubernetes/maintain/tidb-cluster.md)
++ [Manage the TiDB Cluster](tidb-in-kubernetes/maintain/kubernetes-node.md)
 + [Access the TiDB Cluster](tidb-in-kubernetes/deploy/access-tidb.md)
 + [Scale TiDB Cluster](tidb-in-kubernetes/scale-in-kubernetes.md)
 + [Upgrade TiDB Cluster](tidb-in-kubernetes/upgrade/tidb-cluster.md#upgrade-the-version-of-tidb-cluster)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR fixes 3 broken links found in the `TiDB Operator Overview` document, the `Get-Started` and the `Deploy` directories.

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

`dev`  `v3.0`

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
