### PR TITLE
dev, v3.0/how-to/get-started: Warn the user not to use tidb-docker-compose in production!

### DIFF
--- a/dev/how-to/get-started/deploy-tidb-from-docker-compose.md
+++ b/dev/how-to/get-started/deploy-tidb-from-docker-compose.md
@@ -10,6 +10,10 @@ This document describes how to quickly deploy a TiDB testing cluster with a sing
 
 With Docker Compose, you can use a YAML file to configure application services in multiple containers. Then, with a single command, you can create and start all the services from your configuration.
 
+> **Warning:**
+>
+> This is for testing only, DO NOT USE in production! Please deploy TiDB with [our ansible solution](/how-to/deploy/orchestrated/ansible.md) or [TiDB Operator in Kubernetes](/tidb-in-kubernetes/deploy/tidb-operator.md) in production.
+
 ## Prerequisites
 
 Make sure you have installed the following items on your machine:

--- a/v3.0/how-to/get-started/deploy-tidb-from-docker-compose.md
+++ b/v3.0/how-to/get-started/deploy-tidb-from-docker-compose.md
@@ -11,6 +11,10 @@ This document describes how to quickly deploy a TiDB testing cluster with a sing
 
 With Docker Compose, you can use a YAML file to configure application services in multiple containers. Then, with a single command, you can create and start all the services from your configuration.
 
+> **Warning:**
+>
+> This is for testing only, DO NOT USE in production! Please deploy TiDB with [our ansible solution](/how-to/deploy/orchestrated/ansible.md) or [TiDB Operator in Kubernetes](/tidb-in-kubernetes/deploy/tidb-operator.md) in production.
+
 ## Prerequisites
 
 Make sure you have installed the following items on your machine:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This tidb-docker-compose repo is for testing only. Users may lose their data when they used it in production. We should warn the user not to use this repo in production.

There is a warning on the Chinese docs site: https://pingcap.com/docs-cn/v3.0/how-to/get-started/deploy-tidb-from-docker-compose/

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

https://github.com/pingcap/tidb-docker-compose/pull/76

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev
v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
