### PR TITLE
v.3.0, V2.1/how-to/deploy, */faq: recover the docker-compose link

### DIFF
--- a/v2.1/faq/tidb.md
+++ b/v2.1/faq/tidb.md
@@ -249,7 +249,7 @@ It is not recommended to deploy TiDB offline using Ansible. If the Control Machi
 
 #### How to deploy TiDB quickly using Docker Compose on a single machine?
 
-You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md).
+You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://pingcap.com/docs/dev/how-to/get-started/deploy-tidb-from-docker-compose/).
 
 #### How to separately record the slow query log in TiDB? How to locate the slow query SQL statement?
 

--- a/v2.1/faq/tidb.md
+++ b/v2.1/faq/tidb.md
@@ -249,7 +249,7 @@ It is not recommended to deploy TiDB offline using Ansible. If the Control Machi
 
 #### How to deploy TiDB quickly using Docker Compose on a single machine?
 
-You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment.
+You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md).
 
 #### How to separately record the slow query log in TiDB? How to locate the slow query SQL statement?
 

--- a/v2.1/how-to/deploy/orchestrated/ansible.md
+++ b/v2.1/how-to/deploy/orchestrated/ansible.md
@@ -42,7 +42,7 @@ Before you start, make sure you have:
 
     > **Note:**
     >
-    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check.
+    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md) on a single machine.
 
 2. A Control Machine that meets the following requirements:
 

--- a/v2.1/how-to/deploy/orchestrated/ansible.md
+++ b/v2.1/how-to/deploy/orchestrated/ansible.md
@@ -42,7 +42,7 @@ Before you start, make sure you have:
 
     > **Note:**
     >
-    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md) on a single machine.
+    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://pingcap.com/docs/dev/how-to/get-started/deploy-tidb-from-docker-compose/) on a single machine.
 
 2. A Control Machine that meets the following requirements:
 

--- a/v3.0/faq/tidb.md
+++ b/v3.0/faq/tidb.md
@@ -250,7 +250,7 @@ It is not recommended to deploy TiDB offline using Ansible. If the Control Machi
 
 #### How to deploy TiDB quickly using Docker Compose on a single machine?
 
-You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment.
+You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md).
 
 #### How to separately record the slow query log in TiDB? How to locate the slow query SQL statement?
 

--- a/v3.0/faq/tidb.md
+++ b/v3.0/faq/tidb.md
@@ -250,7 +250,7 @@ It is not recommended to deploy TiDB offline using Ansible. If the Control Machi
 
 #### How to deploy TiDB quickly using Docker Compose on a single machine?
 
-You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md).
+You can use Docker Compose to build a TiDB cluster locally, including the cluster monitoring components. You can also customize the version and number of instances for each component. The configuration file can also be customized. You can only use this deployment method for testing and development environment. For details, see [Building the Cluster Using Docker Compose](https://pingcap.com/docs/dev/how-to/get-started/deploy-tidb-from-docker-compose/).
 
 #### How to separately record the slow query log in TiDB? How to locate the slow query SQL statement?
 

--- a/v3.0/how-to/deploy/orchestrated/ansible.md
+++ b/v3.0/how-to/deploy/orchestrated/ansible.md
@@ -43,7 +43,7 @@ Before you start, make sure you have:
 
     > **Note:**
     >
-    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md) on a single machine.
+    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://pingcap.com/docs/dev/how-to/get-started/deploy-tidb-from-docker-compose/) on a single machine.
 
 2. A Control Machine that meets the following requirements:
 

--- a/v3.0/how-to/deploy/orchestrated/ansible.md
+++ b/v3.0/how-to/deploy/orchestrated/ansible.md
@@ -43,7 +43,7 @@ Before you start, make sure you have:
 
     > **Note:**
     >
-    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check.
+    > When you deploy TiDB using Ansible, **use SSD disks for the data directory of TiKV and PD nodes**. Otherwise, it cannot pass the check. If you only want to try TiDB out and explore the features, it is recommended to [deploy TiDB using Docker Compose](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md) on a single machine.
 
 2. A Control Machine that meets the following requirements:
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR recovers the link of `docker-compose` document (of the `dev` version) in the `v2.1` and `v3.0` documents.

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs/pull/1401

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

`v3.0` `v2.1`

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
