### PR TITLE
scripts: add verify links check and fix some broken links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
             git fetch upstream
             markdownlint $(git diff-tree --name-only --no-commit-id -r upstream/master..HEAD -- '*.md' ':(exclude).github/*' ':(exclude)v1.0/*' ':(exclude)v2.0/*' ':(exclude)v2.1-legacy/*')
 
+      - run:
+          name: "Check links"
+          command: |
+            scripts/verify-links.sh
 
   build:
     docker:

--- a/dev/reference/system-databases/information-schema.md
+++ b/dev/reference/system-databases/information-schema.md
@@ -632,7 +632,7 @@ The `STATE` column shows the execution status of a specific `ANALYZE` task. Its 
 
 ## SLOW\_QUERY table
 
-The `SLOW_QUERY` table maps slow query logs. Its column names and field names of slow query logs have an one-to-one corresponse relationship. For details, see [Identify Slow Queries](/how-to/maintain/identify-slow-queries.md/#identify-slow-queries).
+The `SLOW_QUERY` table maps slow query logs. Its column names and field names of slow query logs have an one-to-one corresponse relationship. For details, see [Identify Slow Queries](/how-to/maintain/identify-slow-queries.md#identify-slow-queries).
 
 ```sql
 mysql> desc slow_query\G

--- a/scripts/markdown-link-check.tpl
+++ b/scripts/markdown-link-check.tpl
@@ -1,0 +1,24 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^(http|https|ftp|mailto):"
+        },
+        {
+            "pattern": "\\.\\./media/"
+        }
+    ],
+    "replacementPatterns": [
+        {
+            "pattern": "^(?!(\\.|/media/))",
+            "replacement": "<DOC_ROOT>/"
+        },
+        {
+            "pattern": "^/media/",
+            "replacement": "<ROOT>/media/"
+        },
+        {
+            "pattern": "#.+",
+            "replacement": ""
+        }
+    ]
+}

--- a/scripts/verify-links.sh
+++ b/scripts/verify-links.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# This script is used to verify links in markdown docs.
+#
+# - External links are ignored in CI because these links may go down out of our contorl.
+# - Anchors are ignored
+# - Internal links conventions
+#   - Links starting with '/media/' are relative to site root
+#   - Links starting with one or two dots are relative to the directory in which files reside
+#   - Other links are relative to the root of the version directory (e.g. v1.0, v2.0, v3.0)
+# - When a file was moved, all other references are required to be updated for now, even if alias are given
+#   - This is recommended because of less redirects and better anchors support.
+#
+
+ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+if ! which markdown-link-check &>/dev/null; then
+    sudo npm install -g markdown-link-check@3.7.3
+fi
+
+CONFIG_TMP=$(mktemp)
+
+trap 'rm -f $CONFIG_TMP' EXIT
+
+# TODO fix later
+IGNORE_DIRS=(v1.0 v2.0 v2.1 v2.1-legacy)
+
+function in_array() {
+    local i=$1
+    shift
+    local a=("${@}")
+    local e
+    for e in "${a[@]}"; do
+        [[ "$e" == "$i" ]] && return 0;
+    done
+    return 1
+}
+
+# Check all directories starting with 'v\d.*' and dev.
+error_files=0
+error_output=""
+for d in dev $(ls -d v[0-9]*); do
+    if in_array $d "${IGNORE_DIRS[@]}"; then
+        echo "info: directory $d skipped"
+        continue
+    fi
+    echo "info: checking links under $d directory..."
+    sed \
+        -e "s#<ROOT>#$ROOT#g" \
+        -e "s#<DOC_ROOT>#$ROOT/$d#g" \
+        scripts/markdown-link-check.tpl > $CONFIG_TMP
+    cat $CONFIG_TMP
+    for f in $(find "$d" -type f -name '*.md'); do
+        echo markdown-link-check --config "$CONFIG_TMP" "$f" -q
+        output=$(markdown-link-check --color --config "$CONFIG_TMP" "$f" -q)
+        if [ $? -ne 0 ]; then
+            ((error_files++))
+            error_output+="$output"
+        fi
+        echo "$output"
+    done
+done
+
+echo ""
+if [ $error_files -gt 0 ]; then
+    echo "error: $error_files files have invalid links (or alias links which are recommended to be replaced with latest one), please fix them!"
+    echo ""
+    echo "=== ERROR REPORT == ":
+    echo "$error_output"
+    exit 1
+else
+    echo "info: all files are ok!"
+fi

--- a/v3.0/how-to/get-started/read-historical-data.md
+++ b/v3.0/how-to/get-started/read-historical-data.md
@@ -36,7 +36,7 @@ After reading data from history versions, you can read data from the latest vers
 
 TiDB implements Multi-Version Concurrency Control (MVCC) to manage data versions. The history versions of data are kept because each update/removal creates a new version of the data object instead of updating/removing the data object in-place. But not all the versions are kept. If the versions are older than a specific time, they will be removed completely to reduce the storage occupancy and the performance overhead caused by too many history versions.
 
-In TiDB, Garbage Collection (GC) runs periodically to remove the obsolete data versions. For GC details, see [TiDB Garbage Collection (GC)](/reference/garbage-collection.md)
+In TiDB, Garbage Collection (GC) runs periodically to remove the obsolete data versions. For GC details, see [TiDB Garbage Collection (GC)](/reference/garbage-collection/overview.md)
 
 Pay special attention to the following two variables:
 

--- a/v3.0/reference/system-databases/information-schema.md
+++ b/v3.0/reference/system-databases/information-schema.md
@@ -633,7 +633,7 @@ The `STATE` column shows the execution status of a specific `ANALYZE` task. Its 
 
 ## SLOW\_QUERY table
 
-The `SLOW_QUERY` table maps slow query logs. Its column names and field names of slow query logs have an one-to-one corresponse relationship. For details, see [Identify Slow Queries](/how-to/maintain/identify-slow-queries.md/#identify-slow-queries).
+The `SLOW_QUERY` table maps slow query logs. Its column names and field names of slow query logs have an one-to-one corresponse relationship. For details, see [Identify Slow Queries](/how-to/maintain/identify-slow-queries.md#identify-slow-queries).
 
 ```sql
 mysql> desc slow_query\G


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This has been merged into [docs-cn repo](https://github.com/pingcap/docs-cn/pull/1693).

Add a script to verify internal links and fix some broken links under dev and v3.0 directories.

- External links are ignored in CI because these links may go down out of our control.
- Anchors are ignored
- Internal links conventions
   - Links starting with '/media/' are relative to the site root
   - Links starting with one or two dots are relative to the directory in which files reside
   - Other links are relative to the root of the version directory (e.g. v1.0, v2.0, v3.0)
 - When a file was moved, all other references are required to be updated for now, even if alias is given
   - This is recommended because of fewer redirects and better anchors support.

Why: Avoid broken links in CI phrase.

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev
v3.0

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`