### PR TITLE
v2.1/reference/sql: remove "ROWS (R)" from the reserved word list

### DIFF
--- a/v2.1/reference/sql/language-structure/keywords-and-reserved-words.md
+++ b/v2.1/reference/sql/language-structure/keywords-and-reserved-words.md
@@ -334,7 +334,6 @@ The following list shows the keywords and reserved words in TiDB. The reserved w
 - ROW
 - ROW_COUNT
 - ROW_FORMAT
-- ROWS (R)
 
 <a name="S" class="letter">S</a>
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

v2.1/reference/sql: remove "ROWS (R)" from the reserved word list

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs/pull/1428

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

v2.1

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
