### PR TITLE
dev, v3.0, v2.1: add safe-mode config in binlog reparo doc (new)

### DIFF
--- a/dev/reference/tools/tidb-binlog/reparo.md
+++ b/dev/reference/tools/tidb-binlog/reparo.md
@@ -44,6 +44,8 @@ Usage of Reparo:
     Specifies the time point of finishing the recovery process.
     Format: "2006-01-02 15:04:05"
     If it is not set, the recovery process ends up with the last binlog file.
+-safe-mode bool
+    Specifies whether to enable safe mode. When enabled, it supports repeated replication.
 ```
 
 ### Description of the configuration file
@@ -80,6 +82,11 @@ log-level = "info"
 # while the SQL statement is not executed.
 # If it is set to "mysql", you need to configure `host`, `port`, `user` and `password` in [dest-db].
 dest-type = "mysql"
+
+# Safe-mode configuration
+# Value: "true"/"false" ("false" by default)
+# If it is set to "true", Reparo splits the `UPDATE` statement into a `DELETE` statement plus a `REPLACE` statement.
+safe-mode = false
 
 # `replicate-do-db` and `replicate-do-table` specify the database and table to be recovered.
 # `replicate-do-db` has priority over `replicate-do-table`.

--- a/v2.1/reference/tools/tidb-binlog/reparo.md
+++ b/v2.1/reference/tools/tidb-binlog/reparo.md
@@ -44,6 +44,8 @@ Usage of Reparo:
     Specifies the time point of finishing the recovery process.
     Format: "2006-01-02 15:04:05"
     If it is not set, the recovery process ends up with the last binlog file.
+-safe-mode bool
+    Specifies whether to enable safe mode. When enabled, it supports repeated replication.
 ```
 
 ### Description of the configuration file
@@ -80,6 +82,11 @@ log-level = "info"
 # while the SQL statement is not executed.
 # If it is set to "mysql", you need to configure `host`, `port`, `user` and `password` in [dest-db].
 dest-type = "mysql"
+
+# Safe-mode configuration
+# Value: "true"/"false" ("false" by default)
+# If it is set to "true", Reparo splits the `UPDATE` statement into a `DELETE` statement plus a `REPLACE` statement.
+safe-mode = false
 
 # `replicate-do-db` and `replicate-do-table` specify the database and table to be recovered.
 # `replicate-do-db` has priority over `replicate-do-table`.

--- a/v3.0/reference/tools/tidb-binlog/reparo.md
+++ b/v3.0/reference/tools/tidb-binlog/reparo.md
@@ -45,6 +45,8 @@ Usage of Reparo:
     Specifies the time point of finishing the recovery process.
     Format: "2006-01-02 15:04:05"
     If it is not set, the recovery process ends up with the last binlog file.
+-safe-mode bool
+    Specifies whether to enable safe mode. When enabled, it supports repeated replication.
 ```
 
 ### Description of the configuration file
@@ -81,6 +83,11 @@ log-level = "info"
 # while the SQL statement is not executed.
 # If it is set to "mysql", you need to configure `host`, `port`, `user` and `password` in [dest-db].
 dest-type = "mysql"
+
+# Safe-mode configuration
+# Value: "true"/"false" ("false" by default)
+# If it is set to "true", Reparo splits the `UPDATE` statement into a `DELETE` statement plus a `REPLACE` statement.
+safe-mode = false
 
 # `replicate-do-db` and `replicate-do-table` specify the database and table to be recovered.
 # `replicate-do-db` has priority over `replicate-do-table`.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
- Add a `safe-mode` config in binlog reparo doc
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->
https://github.com/pingcap/docs-cn/pull/1558 (original)
https://github.com/pingcap/docs/pull/1422 (with CLA error)
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->
dev, v3.0, v2.1
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
