### PR TITLE
tidb-in-kubernetes: fix "extraLabels" description

### DIFF
--- a/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster.md
+++ b/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster.md
@@ -24,7 +24,7 @@ TiDB Operator uses `Helm` to deploy and manage TiDB clusters. The configuration 
 | :----- | :---- | :----- |
 | `rbac.create` | Whether to enable the RBAC mode of Kubernetes | `true` |
 | `clusterName` |The TiDB cluster name. This variable is unset by default. In this case, `tidb-cluster` directly replaces it with `ReleaseName` when the cluster is being installed. | `nil` |
-| `extraLabels` | The custom labels attached to the TiDB cluster. See [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) | `{}` |
+| `extraLabels` | Adds extra labels to the `TidbCluster` object (CRD). See [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) | `{}` |
 | `schedulerName` | The scheduler used by the TiDB cluster | `tidb-scheduler` |
 | `timezone` | The default timezone used by the TiDB cluster | `UTC` |
 | `pvReclaimPolicy` | The reclaim policy for PV (Persistent Volume) used by the TiDB cluster | `Retain` |

--- a/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster.md
+++ b/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster.md
@@ -24,7 +24,7 @@ TiDB Operator uses `Helm` to deploy and manage TiDB clusters. The configuration 
 | :----- | :---- | :----- |
 | `rbac.create` | Whether to enable the RBAC mode of Kubernetes | `true` |
 | `clusterName` |The TiDB cluster name. This variable is unset by default. In this case, `tidb-cluster` directly replaces it with `ReleaseName` when the cluster is being installed. | `nil` |
-| `extraLabels` | The custom labels attached to the TiDB cluster. See [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) | `{}` |
+| `extraLabels` | Adds extra labels to the `TidbCluster` object (CRD). See [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) | `{}` |
 | `schedulerName` | The scheduler used by the TiDB cluster | `tidb-scheduler` |
 | `timezone` | The default timezone used by the TiDB cluster | `UTC` |
 | `pvReclaimPolicy` | The reclaim policy for PV (Persistent Volume) used by the TiDB cluster | `Retain` |


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

Fix `extraLabels` description in TiDB in K8s doc

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1736

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev, v3.0

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
