### PR TITLE
dev/v3.0/v2.1: rename tidb_back_off_weight to tidb_backoff_weight

### DIFF
--- a/dev/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/dev/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -291,13 +291,13 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
     To decide whether you can enable automatic retry, see [description of optimistic transactions](/reference/transactions/transaction-isolation.md#description-of-optimistic-transactions).
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 - Scope: SESSION | GLOBAL
 - Default value: 2
-- This variable is used to increase the weight of the maximum time of TiDB `back-off`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
+- This variable is used to increase the weight of the maximum time of TiDB `backoff`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
 
-    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_back_off_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
+    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_backoff_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
 
     In the case of a poor network environment, appropriately increasing the value of this variable can effectively alleviate error reporting to the application end caused by timeout. If the application end wants to receive the error information more quickly, minimize the value of this variable.
 

--- a/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -263,13 +263,13 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
     To decide whether you can enable automatic retry, see [description of optimistic transactions](/reference/transactions/transaction-isolation.md#description-of-optimistic-transactions).
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 - Scope: SESSION | GLOBAL
 - Default value: 2
-- This variable is used to increase the weight of the maximum time of TiDB `back-off`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
+- This variable is used to increase the weight of the maximum time of TiDB `backoff`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
 
-    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_back_off_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
+    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_backoff_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
 
     In the case of a poor network environment, appropriately increasing the value of this variable can effectively alleviate error reporting to the application end caused by timeout. If the application end wants to receive the error information more quickly, minimize the value of this variable.
 

--- a/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -291,13 +291,13 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
     To decide whether you can enable automatic retry, see [description of optimistic transactions](/reference/transactions/transaction-isolation.md#description-of-optimistic-transactions).
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 - Scope: SESSION | GLOBAL
 - Default value: 2
-- This variable is used to increase the weight of the maximum time of TiDB `back-off`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
+- This variable is used to increase the weight of the maximum time of TiDB `backoff`, that is, the maximum retry time for sending a retry request when an internal network or other component (TiKV, PD) failure is encountered. This variable can be used to adjust the maximum retry time and the minimum value is 1.
 
-    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_back_off_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
+    For example, the base timeout for TiDB to take TSO from PD is 15 seconds. When `tidb_backoff_weight = 2`, the maximum timeout for taking TSO is: *base time * 2 = 30 seconds*.
 
     In the case of a poor network environment, appropriately increasing the value of this variable can effectively alleviate error reporting to the application end caused by timeout. If the application end wants to receive the error information more quickly, minimize the value of this variable.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR renames `tidb_back_off_weight` to `tidb_backoff_weight` to make it consistent with `tidb_backoff_lock_fast`.

<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1722


### Which version does your change affect? <!--REMOVE this item if it is not applicable-->
dev, v3.0, v2.1
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
