### PR TITLE
dev,3.0: run port-forward in background to not blocking users

### DIFF
--- a/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes.md
+++ b/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes.md
@@ -28,7 +28,7 @@ You can run the `kubectl port-forward` command to view the monitoring dashboard:
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<release-name>-grafana 3000:3000 &>/tmp/portforward-grafana.log
+kubectl port-forward -n <namespace> svc/<release-name>-grafana 3000:3000 &>/tmp/portforward-grafana.log &
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser and log on with the default username and password `admin`.
@@ -44,7 +44,7 @@ To access the monitoring data directly, run the `kubectl port-forward` command t
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<release-name>-prometheus 9090:9090 &>/tmp/portforward-prometheus.log
+kubectl port-forward -n <namespace> svc/<release-name>-prometheus 9090:9090 &>/tmp/portforward-prometheus.log &
 ```
 
 Then open [http://localhost:9090](http://localhost:9090) in your browser or access this address via a client tool.

--- a/dev/tidb-in-kubernetes/reference/tools/in-kubernetes.md
+++ b/dev/tidb-in-kubernetes/reference/tools/in-kubernetes.md
@@ -15,7 +15,7 @@ Operations on TiDB in Kubernetes require some open source tools. In the meantime
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
 ```
 
 After the above command is executed, you can access the PD service via `127.0.0.1:2379`, and then use the default parameters of `pd-ctl` to operate. For example:
@@ -31,7 +31,7 @@ Assume that your local port `2379` has been occupied and you want to switch to a
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd <local-port>:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd <local-port>:2379 &>/tmp/portforward-pd.log &
 ```
 
 Then you need to explicitly assign a PD port for `pd-ctl`:
@@ -51,13 +51,13 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+    kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
     ```
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl port-forward -n <namespace> <tikv-pod-name> 20160:20160 &>/tmp/portforward-tikv.log
+    kubectl port-forward -n <namespace> <tikv-pod-name> 20160:20160 &>/tmp/portforward-tikv.log &
     ```
 
     After the connection is established, you can access the PD service and the TiKV node via the corresponding port in local:
@@ -119,13 +119,13 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
 ```
 
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> <tidb-pod-name> 10080:10080 &>/tmp/portforward-tidb.log
+kubectl port-forward -n <namespace> <tidb-pod-name> 10080:10080 &>/tmp/portforward-tidb.log &
 ```
 
 Then you can use the `tidb-ctl`:

--- a/v3.0/tidb-in-kubernetes/monitor/tidb-in-kubernetes.md
+++ b/v3.0/tidb-in-kubernetes/monitor/tidb-in-kubernetes.md
@@ -28,7 +28,7 @@ You can run the `kubectl port-forward` command to view the monitoring dashboard:
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<release-name>-grafana 3000:3000 &>/tmp/portforward-grafana.log
+kubectl port-forward -n <namespace> svc/<release-name>-grafana 3000:3000 &>/tmp/portforward-grafana.log &
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser and log on with the default username and password `admin`.
@@ -44,7 +44,7 @@ To access the monitoring data directly, run the `kubectl port-forward` command t
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<release-name>-prometheus 9090:9090 &>/tmp/portforward-prometheus.log
+kubectl port-forward -n <namespace> svc/<release-name>-prometheus 9090:9090 &>/tmp/portforward-prometheus.log &
 ```
 
 Then open [http://localhost:9090](http://localhost:9090) in your browser or access this address via a client tool.

--- a/v3.0/tidb-in-kubernetes/reference/tools/in-kubernetes.md
+++ b/v3.0/tidb-in-kubernetes/reference/tools/in-kubernetes.md
@@ -15,7 +15,7 @@ Operations on TiDB in Kubernetes require some open source tools. In the meantime
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
 ```
 
 After the above command is executed, you can access the PD service via `127.0.0.1:2379`, and then use the default parameters of `pd-ctl` to operate. For example:
@@ -31,7 +31,7 @@ Assume that your local port `2379` has been occupied and you want to switch to a
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd <local-port>:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd <local-port>:2379 &>/tmp/portforward-pd.log &
 ```
 
 Then you need to explicitly assign a PD port for `pd-ctl`:
@@ -51,13 +51,13 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+    kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
     ```
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl port-forward -n <namespace> <tikv-pod-name> 20160:20160 &>/tmp/portforward-tikv.log
+    kubectl port-forward -n <namespace> <tikv-pod-name> 20160:20160 &>/tmp/portforward-tikv.log &
     ```
 
     After the connection is established, you can access the PD service and the TiKV node via the corresponding port in local:
@@ -119,13 +119,13 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log
+kubectl port-forward -n <namespace> svc/<cluster-name>-pd 2379:2379 &>/tmp/portforward-pd.log &
 ```
 
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl port-forward -n <namespace> <tidb-pod-name> 10080:10080 &>/tmp/portforward-tidb.log
+kubectl port-forward -n <namespace> <tidb-pod-name> 10080:10080 &>/tmp/portforward-tidb.log &
 ```
 
 Then you can use the `tidb-ctl`:


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Run port-forward in background to not blocking users
<!--Tell us what you did and why.-->

Related PR: https://github.com/pingcap/docs-cn/pull/1753
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->
`dev` `3.0`
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

