### PR TITLE
dev, v3.0, v2.1, v2.1-legacy: correct the scope of a tidb_opt_insubquery_unfold

### DIFF
--- a/dev/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/dev/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -43,12 +43,6 @@ set @@global.tidb_distsql_scan_concurrency = 10
 - This variable is used to set whether the optimizer executes the optimization operation of pushing down the aggregate function to the position before Join.
 - When the aggregate operation is slow in query, you can set the variable value to 1.
 
-### tidb_opt_insubquery_unfold
-
-- Scope: SESSION
-- Default value: 0
-- This variable is used to set whether the optimizer executes the optimization operation of unfolding the "in-" subquery.
-
 ### tidb_auto_analyze_ratio
 
 - Scope: GLOBAL

--- a/v2.1-legacy/sql/tidb-specific.md
+++ b/v2.1-legacy/sql/tidb-specific.md
@@ -45,7 +45,7 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 ### tidb_opt_insubquery_unfold
 
-- Scope: SESSION
+- Scope: SESSION | GLOBAL
 - Default value: 0
 - This variable is used to set whether the optimizer executes the optimization operation of unfolding the "in-" subquery.
 

--- a/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -45,7 +45,7 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 ### tidb_opt_insubquery_unfold
 
-- Scope: SESSION
+- Scope: SESSION | GLOBAL
 - Default value: 0
 - This variable is used to set whether the optimizer executes the optimization operation of unfolding the "in-" subquery.
 

--- a/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -43,12 +43,6 @@ set @@global.tidb_distsql_scan_concurrency = 10
 - This variable is used to set whether the optimizer executes the optimization operation of pushing down the aggregate function to the position before Join.
 - When the aggregate operation is slow in query, you can set the variable value to 1.
 
-### tidb_opt_insubquery_unfold
-
-- Scope: SESSION
-- Default value: 0
-- This variable is used to set whether the optimizer executes the optimization operation of unfolding the "in-" subquery.
-
 ### tidb_auto_analyze_ratio
 
 - Scope: GLOBAL


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
- Correct the scope of a tidb_opt_insubquery_unfold for release-2.1
- Remove tidb_opt_insubquery_unfold since master and 3.0 do not support it
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->
https://github.com/pingcap/docs-cn/pull/1763
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required-->
dev, v3.0, v2.1, v2.1-legacy
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
