### PR TITLE
reference/configuration: remove retry-limit from the config file

### DIFF
--- a/dev/reference/configuration/tidb-server/configuration-file.md
+++ b/dev/reference/configuration/tidb-server/configuration-file.md
@@ -4,6 +4,8 @@ summary: Learn the TiDB configuration file options that are not involved in comm
 category: deployment
 ---
 
+<!-- markdownlint-disable MD001 -->
+
 # TiDB Configuration File Description
 
 The TiDB configuration file supports more options than command line options. You can find the default configuration file in [config/config.toml.example](https://github.com/pingcap/tidb/blob/master/config/config.toml.example) and rename it to `config.toml`.
@@ -159,12 +161,6 @@ Configuration about performance.
 - To enable `keepalive` in the TCP layer
 - Default: false
 
-### `retry-limit`
-
-- The number of retries that TiDB makes when it encounters a `key` conflict or other errors while committing a transaction
-- Default: 10
-- If the number of retries exceeds `retry-limit` but the transaction still fails, TiDB returns an error
-
 ### `cross-join`
 
 - Default: true
@@ -180,7 +176,9 @@ Configuration about performance.
     - At intervals of `stats-lease`, TiDB checks for column statistics that need to be loaded to the memory
     - At intervals of `200 \* stats-lease`, TiDB writes the feedback cached in the memory to the system table
     - At intervals of `5 \* stats-lease`, TiDB reads the feedback in the system table, and updates the statistics cached in the memory
+
 + When `stats-lease` is set to 0, TiDB periodically reads the feedback in the system table, and updates the statistics cached in the memory every three seconds. But TiDB no longer automatically modifies the following statistics-related system tables:
+
     - `mysql.stats_meta`: TiDB no longer automatically records the number of table rows that are modified by the transaction and updates it to this system table
     - `mysql.stats_histograms`/`mysql.stats_buckets` and `mysql.stats_top_n`: TiDB no longer automatically analyzes and proactively updates statistics
     - `mysql.stats_feedback`: TiDB no longer updates the statistics of the tables and indexes according to a part of statistics returned by the queried data

--- a/v3.0/reference/configuration/tidb-server/configuration-file.md
+++ b/v3.0/reference/configuration/tidb-server/configuration-file.md
@@ -5,6 +5,8 @@ category: deployment
 aliases: ['/docs/op-guide/tidb-config-file/']
 ---
 
+<!-- markdownlint-disable MD001 -->
+
 # TiDB Configuration File Description
 
 The TiDB configuration file supports more options than command line options. You can find the default configuration file in [config/config.toml.example](https://github.com/pingcap/tidb/blob/master/config/config.toml.example) and rename it to `config.toml`.
@@ -160,12 +162,6 @@ Configuration about performance.
 - To enable `keepalive` in the TCP layer
 - Default: false
 
-### `retry-limit`
-
-- The number of retries that TiDB makes when it encounters a `key` conflict or other errors while committing a transaction
-- Default: 10
-- If the number of retries exceeds `retry-limit` but the transaction still fails, TiDB returns an error
-
 ### `cross-join`
 
 - Default: true
@@ -181,7 +177,9 @@ Configuration about performance.
     - At intervals of `stats-lease`, TiDB checks for column statistics that need to be loaded to the memory
     - At intervals of `200 * stats-lease`, TiDB writes the feedback cached in the memory to the system table
     - At intervals of `5 * stats-lease`, TiDB reads the feedback in the system table, and updates the statistics cached in the memory
+
 + When `stats-lease` is set to 0, TiDB periodically reads the feedback in the system table, and updates the statistics cached in the memory every three seconds. But TiDB no longer automatically modifies the following statistics-related system tables:
+
     - `mysql.stats_meta`: TiDB no longer automatically records the number of table rows that are modified by the transaction or updates it to this system table
     - `mysql.stats_histograms`/`mysql.stats_buckets` and `mysql.stats_top_n`: TiDB no longer automatically analyzes or proactively updates statistics
     - `mysql.stats_feedback`: TiDB no longer updates the statistics of the tables and indexes according to a part of statistics returned by the queried data


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
- Remove the description of `retry-limit` in the configuration-file document, because retry-limit is removed after v3.0
- Update format

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1791

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->

dev, v3.0<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
