### PR TITLE
Gke terraform add section fluentbit vs fluentd

### DIFF
--- a/dev/tidb-in-kubernetes/deploy/gcp-gke.md
+++ b/dev/tidb-in-kubernetes/deploy/gcp-gke.md
@@ -336,6 +336,11 @@ variable "override_values" {
 }
 ```
 
+### Customize logging
+
+GKE uses Fluentd as its default log collector, which then forwards logs to Stackdriver. The Fluentd process can be quite resource hungry and consume a non-trivial share of CPU and RAM.
+Fluent Bit is a more performant and less resource intensive alternative. It is recommended to use Fluent Bit over Fluentd for a production set up. See [this repository](https://github.com/pingcap/k8s-fluent-bit-stackdriver) for an example of how to set up Fluent Bit on a GKE cluster.
+
 ### Customize node pools
 
 The cluster is created as a regional, as opposed to a zonal cluster. This means that GKE replicates node pools to each availability zone. This is desired to maintain high availability, however for the monitoring services, like Grafana, this is potentially unnecessary. It is possible to manually remove nodes if desired via `gcloud`.

--- a/v3.0/tidb-in-kubernetes/deploy/gcp-gke.md
+++ b/v3.0/tidb-in-kubernetes/deploy/gcp-gke.md
@@ -336,6 +336,10 @@ variable "override_values" {
 }
 ```
 
+### Customize logging
+
+GKE uses Fluentd as its default
+
 ### Customize node pools
 
 The cluster is created as a regional, as opposed to a zonal cluster. This means that GKE replicates node pools to each availability zone. This is desired to maintain high availability, however for the monitoring services, like Grafana, this is potentially unnecessary. It is possible to manually remove nodes if desired via `gcloud`.

--- a/v3.0/tidb-in-kubernetes/deploy/gcp-gke.md
+++ b/v3.0/tidb-in-kubernetes/deploy/gcp-gke.md
@@ -338,7 +338,8 @@ variable "override_values" {
 
 ### Customize logging
 
-GKE uses Fluentd as its default
+GKE uses Fluentd as its default log collector, which then forwards logs to Stackdriver. The Fluentd process can be quite resource hungry and consume a non-trivial share of CPU and RAM.
+Fluent Bit is a more performant and less resource intensive alternative. It is recommended to use Fluent Bit over Fluentd for a production set up. See [this repository](https://github.com/pingcap/k8s-fluent-bit-stackdriver) for an example of how to set up Fluent Bit on a GKE cluster.
 
 ### Customize node pools
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Adds a section to gke terraform guide on using fluent bit instead of fluentd (default log collector on gke)

<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
N/A

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
3.0 and dev

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
