### PR TITLE
reference/sql/data-types/string : fix syntax for tinytext

### DIFF
--- a/dev/reference/sql/data-types/string.md
+++ b/dev/reference/sql/data-types/string.md
@@ -31,7 +31,7 @@ TiDB supports all the MySQL string types, including `CHAR`, `VARCHAR`, `BINARY`,
 `TINYTEXT` is a string of variable-length. The length (M) is optional, with a maximum length of 255 characters:
 
 ```sql
-TINYTEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
+TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 ```
 
 ### `TEXT` type

--- a/v2.0/sql/datatype.md
+++ b/v2.0/sql/datatype.md
@@ -218,7 +218,7 @@ LONGBLOB
 TEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
 > A TEXT column. M represents the maximum column length ranging from 0 to 65,535. The maximum length of TEXT is based on the size of the longest row and the character set.
 
-TINYTEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
+TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 > A TEXT column with a maximum length of 255 characters.
 
 MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]

--- a/v2.1/reference/sql/data-types/string.md
+++ b/v2.1/reference/sql/data-types/string.md
@@ -31,7 +31,7 @@ TiDB supports all the MySQL string types, including `CHAR`, `VARCHAR`, `BINARY`,
 `TINYTEXT` is a string of variable-length. The length (M) is optional, with a maximum length of 255 characters:
 
 ```sql
-TINYTEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
+TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 ```
 
 ### `TEXT` type

--- a/v3.0/reference/sql/data-types/string.md
+++ b/v3.0/reference/sql/data-types/string.md
@@ -31,7 +31,7 @@ TiDB supports all the MySQL string types, including `CHAR`, `VARCHAR`, `BINARY`,
 `TINYTEXT` is a string of variable-length. The length (M) is optional, with a maximum length of 255 characters:
 
 ```sql
-TINYTEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
+TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 ```
 
 ### `TEXT` type


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted?

Change `TINYTEXT[(M)]` to `TINYTEXT`. 
Because both MySQL and TiDB don't support create a column with type `TINYTEXT(number)` but `TINYTEXT`.

```SQL
> select tidb_version() \G
tidb_version() | Release Version: v4.0.0-alpha-103-g9d71884e0
Git Commit Hash: 9d71884e0fc6a7ccb31bf0bfc91baec6b85e79a7
Git Branch: master
UTC Build Time: 2019-08-21 03:43:29
GoVersion: go version go1.12.5 darwin/amd64
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false

> create table t_1(tt5 tinytext(5))  -- This will throw error
(1064, 'You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 30 near "(5))" ')

> create table t_1(tt5 tinytext) -- This is OK

```


### What is the related PR or file link(s)? 

https://github.com/pingcap/docs-cn/pull/1827

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, v3.0, v2.1, v2.0

