### PR TITLE
reference/sql: prohibit modifying decimal precision

### DIFF
--- a/dev/reference/sql/statements/modify-column.md
+++ b/dev/reference/sql/statements/modify-column.md
@@ -65,6 +65,7 @@ ERROR 1105 (HY000): can't run multi schema change
 
 * Making multiple changes in a single `ALTER TABLE` statement is not currently supported.
 * Only certain types of data type changes are supported. For example, an `INTEGER` to `BIGINT` is supported, but the reverse is not possible. Changing from an integer to a string format or blob is not supported.
+* Modifying precision of the `DECIMAL` data type is not supported.
 
 ## See also
 

--- a/v2.1/reference/sql/statements/modify-column.md
+++ b/v2.1/reference/sql/statements/modify-column.md
@@ -65,6 +65,7 @@ ERROR 1105 (HY000): can't run multi schema change
 
 * Making multiple changes in a single `ALTER TABLE` statement is not currently supported.
 * Only certain types of data type changes are supported. For example, an `INTEGER` to `BIGINT` is supported, but the reverse is not possible. Changing from an integer to a string format or blob is not supported.
+* Modifying precision of the `DECIMAL` data type is not supported.
 
 ## See also
 

--- a/v3.0/reference/sql/statements/modify-column.md
+++ b/v3.0/reference/sql/statements/modify-column.md
@@ -65,6 +65,7 @@ ERROR 1105 (HY000): can't run multi schema change
 
 * Making multiple changes in a single `ALTER TABLE` statement is not currently supported.
 * Only certain types of data type changes are supported. For example, an `INTEGER` to `BIGINT` is supported, but the reverse is not possible. Changing from an integer to a string format or blob is not supported.
+* Modifying precision of the `DECIMAL` data type is not supported.
 
 ## See also
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
Add a description to prohibit modifying the precision of decimals

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->
https://github.com/pingcap/docs-cn/pull/1790

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
dev, v3.0, v2.1
