### PR TITLE
reference/tools: fix a command typo

### DIFF
--- a/dev/reference/tools/pd-control.md
+++ b/dev/reference/tools/pd-control.md
@@ -564,7 +564,7 @@ Description of various types:
 Usage:
 
 ```bash
->> region miss-peer
+>> region check miss-peer
 {
   "count": 2,
   "regions": [......],

--- a/dev/reference/tools/pd-control.md
+++ b/dev/reference/tools/pd-control.md
@@ -21,11 +21,15 @@ As a command line tool of PD, PD Control obtains the state information of the cl
 
 Single-command mode:
 
-    ./pd-ctl store -d -u http://127.0.0.1:2379
+```
+./pd-ctl store -d -u http://127.0.0.1:2379
+```
 
 Interactive mode:
 
-    ./pd-ctl -u http://127.0.0.1:2379
+```
+./pd-ctl -u http://127.0.0.1:2379
+```
 
 Use environment variables:
 
@@ -223,10 +227,10 @@ The configuration above is global. You can also tune the configuration by config
 >
 > The configuration of the namespace only supports editing `leader-schedule-limit`, `region-schedule-limit`, `replica-schedule-limit` and `max-replicas`.
 
-    ```bash
-    >> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
-    >> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
-    ```
+```bash
+>> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
+>> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
+```
 
 - `tolerant-size-ratio` controls the size of the balance buffer area. When the score difference between the leader or Region of the two stores is less than specified multiple times of the Region size, it is considered in balance by PD.
 

--- a/v2.1-legacy/tools/pd-control.md
+++ b/v2.1-legacy/tools/pd-control.md
@@ -564,7 +564,7 @@ Description of various types:
 Usage:
 
 ```bash
->> region miss-peer
+>> region check miss-peer
 {
   "count": 2,
   "regions": [......],

--- a/v2.1/reference/tools/pd-control.md
+++ b/v2.1/reference/tools/pd-control.md
@@ -564,7 +564,7 @@ Description of various types:
 Usage:
 
 ```bash
->> region miss-peer
+>> region check miss-peer
 {
   "count": 2,
   "regions": [......],

--- a/v2.1/reference/tools/pd-control.md
+++ b/v2.1/reference/tools/pd-control.md
@@ -21,11 +21,15 @@ As a command line tool of PD, PD Control obtains the state information of the cl
 
 Single-command mode:
 
-    ./pd-ctl store -d -u http://127.0.0.1:2379
+```
+./pd-ctl store -d -u http://127.0.0.1:2379
+```
 
 Interactive mode:
 
-    ./pd-ctl -u http://127.0.0.1:2379
+```
+./pd-ctl -u http://127.0.0.1:2379
+```
 
 Use environment variables:
 
@@ -45,7 +49,7 @@ Use TLS to encrypt:
 ### \-\-pd,-u
 
 + PD address
-+ Default address: http://127.0.0.1:2379
++ Default address: `http://127.0.0.1:2379`
 + Environment variable: PD_ADDR
 
 ### \-\-detach,-d
@@ -223,10 +227,10 @@ The configuration above is global. You can also tune the configuration by config
 >
 > The configuration of the namespace only supports editing `leader-schedule-limit`, `region-schedule-limit`, `replica-schedule-limit` and `max-replicas`.
 
-    ```bash
-    >> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
-    >> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
-    ```
+```bash
+>> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
+>> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
+```
 
 - `tolerant-size-ratio` controls the size of the balance buffer area. When the score difference between the leader or Region of the two stores is less than specified multiple times of the Region size, it is considered in balance by PD.
 

--- a/v3.0/reference/tools/pd-control.md
+++ b/v3.0/reference/tools/pd-control.md
@@ -565,7 +565,7 @@ Description of various types:
 Usage:
 
 ```bash
->> region miss-peer
+>> region check miss-peer
 {
   "count": 2,
   "regions": [......],

--- a/v3.0/reference/tools/pd-control.md
+++ b/v3.0/reference/tools/pd-control.md
@@ -22,11 +22,15 @@ As a command line tool of PD, PD Control obtains the state information of the cl
 
 Single-command mode:
 
-    ./pd-ctl store -d -u http://127.0.0.1:2379
+```
+./pd-ctl store -d -u http://127.0.0.1:2379
+```
 
 Interactive mode:
 
-    ./pd-ctl -u http://127.0.0.1:2379
+```
+./pd-ctl -u http://127.0.0.1:2379
+```
 
 Use environment variables:
 
@@ -46,7 +50,7 @@ Use TLS to encrypt:
 ### \-\-pd,-u
 
 + PD address
-+ Default address: http://127.0.0.1:2379
++ Default address: `http://127.0.0.1:2379`
 + Environment variable: PD_ADDR
 
 ### \-\-detach,-d
@@ -224,10 +228,10 @@ The configuration above is global. You can also tune the configuration by config
 >
 > The configuration of the namespace only supports editing `leader-schedule-limit`, `region-schedule-limit`, `replica-schedule-limit` and `max-replicas`.
 
-    ```bash
-    >> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
-    >> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
-    ```
+```bash
+>> config set namespace ts1 leader-schedule-limit 4 // 4 tasks of leader scheduling at the same time at most for the namespace named ts1
+>> config set namespace ts2 region-schedule-limit 2 // 2 tasks of region scheduling at the same time at most for the namespace named ts2
+```
 
 - `tolerant-size-ratio` controls the size of the balance buffer area. When the score difference between the leader or Region of the two stores is less than specified multiple times of the Region size, it is considered in balance by PD.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR fixes a command typo in `pd-control.md`.

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1845

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->

`dev`, `v2.1`, `v3.0`
