### PR TITLE
reference: fix the default capacity of txn-local-latches

### DIFF
--- a/dev/reference/configuration/tidb-server/configuration-file.md
+++ b/dev/reference/configuration/tidb-server/configuration-file.md
@@ -347,7 +347,7 @@ Configuration related to the transaction latch. It is recommended to enable it w
 ### `capacity`
 
 - The number of slots corresponding to Hash, which automatically adjusts upward to an exponential multiple of 2. Each slot occupies 32 Bytes of memory. If set too small, it might result in slower running speed and poor performance in the scenario where data writing covers a relatively large range (such as importing data).
-- Default value: `1024000`
+- Default value: `2048000`
 
 ## binlog
 

--- a/v3.0/reference/configuration/tidb-server/configuration-file.md
+++ b/v3.0/reference/configuration/tidb-server/configuration-file.md
@@ -347,7 +347,7 @@ Configuration related to the transaction latch. It is recommended to enable it w
 ### `capacity`
 
 - The number of slots corresponding to Hash, which automatically adjusts upward to an exponential multiple of 2. Each slot occupies 32 Bytes of memory. If set too small, it might result in slower running speed and poor performance in the scenario where data writing covers a relatively large range (such as importing data).
-- Default value: `1024000`
+- Default value: `2048000`
 
 ## binlog
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
This PR fixes the default capacity of `txn-local-latches` in `configuration-file.md`.
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/docs-cn/pull/1908
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->