### PR TITLE
reference: modify the default value description of tidb_distsql_scan_concurrency

### DIFF
--- a/dev/reference/performance/statistics.md
+++ b/dev/reference/performance/statistics.md
@@ -118,7 +118,7 @@ Currently, when you run the `ANALYZE` statement, the task is divided into multip
 
 #### `tidb_distsql_scan_concurrency`
 
-When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `10`.
+When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `15`.
 
 #### `tidb_index_serial_scan_concurrency`
 

--- a/v2.1/reference/performance/statistics.md
+++ b/v2.1/reference/performance/statistics.md
@@ -61,7 +61,7 @@ Currently, when you run the `ANALYZE` statement, the task is divided into multip
 
 #### `tidb_distsql_scan_concurrency`
 
-When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `10`.
+When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `15`.
 
 #### `tidb_index_serial_scan_concurrency`
 

--- a/v3.0/reference/performance/statistics.md
+++ b/v3.0/reference/performance/statistics.md
@@ -119,7 +119,7 @@ Currently, when you run the `ANALYZE` statement, the task is divided into multip
 
 #### `tidb_distsql_scan_concurrency`
 
-When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `10`.
+When you analyze regular columns, you can use the `tidb_distsql_scan_concurrency` parameter to control the number of Region to be read at one time. The default value is `15`.
 
 #### `tidb_index_serial_scan_concurrency`
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
This PR changes the value of tidb_distsql_scan_concurrency from 10 to 15 in `statistics.md`
### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/docs-cn/pull/1904
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, v2.1, v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->