### PR TITLE
tidb-in-kubernetes/get-started: fix grep error on macOS

### DIFF
--- a/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -84,6 +84,12 @@ If you have limited access to gcr.io, you can try a mirror. For example:
 helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
 ```
 
+If you are using FreeBSD grep on macOS,try following command:
+
+```shell
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | helm version --client --short | grep -E -o 'v\d+\.\d+\.\d')
+```
+
 Once it is installed, running `helm version` returns both the client and server version. For example:
 
 ```shell

--- a/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -84,7 +84,7 @@ If you have limited access to gcr.io, you can try a mirror. For example:
 helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
 ```
 
-If you are using FreeBSD grep on macOS,try following command:
+If you are using FreeBSD grep on macOS, try the following command:
 
 ```shell
 helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | helm version --client --short | grep -E -o 'v\d+\.\d+\.\d')

--- a/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -81,13 +81,7 @@ helm init
 If you have limited access to gcr.io, you can try a mirror. For example:
 
 ```shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
-```
-
-If you are using FreeBSD grep on macOS, try the following command:
-
-```shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | helm version --client --short | grep -E -o 'v\d+\.\d+\.\d')
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
 ```
 
 Once it is installed, running `helm version` returns both the client and server version. For example:

--- a/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -82,7 +82,7 @@ helm init
 If you have limited access to gcr.io, you can try a mirror. For example:
 
 ```shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
 ```
 
 Once it is installed, running `helm version` returns both the client and server version. For example:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
This PR fix a grep command error which will appear on macOS.


### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/docs/issues/1580
https://github.com/pingcap/docs/blob/master/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md#install-helm

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev
I'll update v3.0 when I get two LGTM.
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
