### PR TITLE
reference/tools: add "-tidb-password" cli flag in tidb-lightning config

### DIFF
--- a/dev/reference/tools/tidb-lightning/config.md
+++ b/dev/reference/tools/tidb-lightning/config.md
@@ -304,6 +304,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB server port (default = 4000) | `tidb.port` |
 | --tidb-status *port* | TiDB status port (default = 10080) | `tidb.status-port` |
 | --tidb-user *user* | User name to connect to TiDB | `tidb.user` |
+| --tidb-password *password* | Password to connect to TiDB | `tidb.password` |
 
 If a command line parameter and the corresponding setting in the configuration file are both provided, the command line parameter will be used. For example, running `./tidb-lightning -L debug --config cfg.toml` would always set the log level to "debug" regardless of the content of `cfg.toml`.
 

--- a/v3.0/reference/tools/tidb-lightning/config.md
+++ b/v3.0/reference/tools/tidb-lightning/config.md
@@ -296,6 +296,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB server port (default = 4000) | `tidb.port` |
 | --tidb-status *port* | TiDB status port (default = 10080) | `tidb.status-port` |
 | --tidb-user *user* | User name to connect to TiDB | `tidb.user` |
+| --tidb-password *password* | Password to connect to TiDB | `tidb.password` |
 
 If a command line parameter and the corresponding setting in the configuration file are both provided, the command line parameter will be used. For example, running `./tidb-lightning -L debug --config cfg.toml` would always set the log level to "debug" regardless of the content of `cfg.toml`.
 

--- a/v3.1/reference/tools/tidb-lightning/config.md
+++ b/v3.1/reference/tools/tidb-lightning/config.md
@@ -296,6 +296,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB server port (default = 4000) | `tidb.port` |
 | --tidb-status *port* | TiDB status port (default = 10080) | `tidb.status-port` |
 | --tidb-user *user* | User name to connect to TiDB | `tidb.user` |
+| --tidb-password *password* | Password to connect to TiDB | `tidb.password` |
 
 If a command line parameter and the corresponding setting in the configuration file are both provided, the command line parameter will be used. For example, running `./tidb-lightning -L debug --config cfg.toml` would always set the log level to "debug" regardless of the content of `cfg.toml`.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Adds reference to `-tidb-password` command line flag for tidb-lightning in the config section

<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/tidb-lightning/pull/253

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, 3.0, 3.1

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v3.1"/"v2.1" indicates the documentation of TiDB 3.0/3.1-beta/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
