### PR TITLE
security: fix typo in cert-base-auth

### DIFF
--- a/dev/reference/security/cert-based-authentication.md
+++ b/dev/reference/security/cert-based-authentication.md
@@ -19,7 +19,7 @@ The rest of the document introduces in detail how to perform these operations.
 
 ## Create security keys and certificates
 
-### Install OpenSS
+### Install OpenSSL
 
 It is recommended that you use [OpenSSL](https://www.openssl.org/) to create keys and certificates. Taking the Debian operating system as an example, execute the following command to install OpenSSL:
 

--- a/v3.0/reference/security/cert-based-authentication.md
+++ b/v3.0/reference/security/cert-based-authentication.md
@@ -19,7 +19,7 @@ The rest of the document introduces in detail how to perform these operations.
 
 ## Create security keys and certificates
 
-### Install OpenSS
+### Install OpenSSL
 
 It is recommended that you use [OpenSSL](https://www.openssl.org/) to create keys and certificates. Taking the Debian operating system as an example, execute the following command to install OpenSSL:
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->

fix type OpenSS to OpenSSL

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

https://pingcap.com/docs/stable/reference/security/cert-based-authentication/

https://github.com/pingcap/docs/pull/1737

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->

3.0, 3.1

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v3.1"/"v2.1" indicates the documentation of TiDB 3.0/3.1-beta/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/docs/1739)
<!-- Reviewable:end -->
