### PR TITLE
AUTO_INCREMENT: update keyword auto_increment to CAPS

### DIFF
--- a/dev/how-to/get-started/data-migration.md
+++ b/dev/how-to/get-started/data-migration.md
@@ -128,7 +128,7 @@ We achieve that by having set `auto-increment-increment=5` and `auto-increment-o
     do
         mysql -h 127.0.0.1 -P "$((3306+i))" -u root <<EoSQL
             create database dmtest1;
-            create table dmtest1.t1 (id bigint unsigned not null auto_increment primary key, c char(32), port int);
+            create table dmtest1.t1 (id bigint unsigned not null AUTO_INCREMENT primary key, c char(32), port int);
     EoSQL
     done
     ```

--- a/dev/how-to/get-started/import-example-database.md
+++ b/dev/how-to/get-started/import-example-database.md
@@ -28,16 +28,16 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
- trip_id bigint NOT NULL PRIMARY KEY auto_increment,
- duration integer not null,
- start_date datetime,
- end_date datetime,
- start_station_number integer,
- start_station varchar(255),
- end_station_number integer,
- end_station varchar(255),
- bike_number varchar(255),
- member_type varchar(255)
+ trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
+ duration INTEGER NOT NULL,
+ start_date DATETIME,
+ end_date DATETIME,
+ start_station_number INTEGER,
+ start_station VARCHAR(255),
+ end_station_number INTEGER,
+ end_station VARCHAR(255),
+ bike_number VARCHAR(255),
+ member_type VARCHAR(255)
 );
 ```
 

--- a/dev/how-to/get-started/tidb-binlog.md
+++ b/dev/how-to/get-started/tidb-binlog.md
@@ -254,7 +254,7 @@ mysql -h 127.0.0.1 -P 4000 --prompt='TiDB [\d]> ' -u root
 ```sql
 create database tidbtest;
 use tidbtest;
-create table t1 (id int unsigned not null auto_increment primary key);
+create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 insert into t1 () values (),(),(),(),();
 select * from t1;
 ```
@@ -267,7 +267,7 @@ Query OK, 0 rows affected (0.12 sec)
 
 TiDB [(none)]> use tidbtest;
 Database changed
-TiDB [tidbtest]> create table t1 (id int unsigned not null auto_increment primary key);
+TiDB [tidbtest]> create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 Query OK, 0 rows affected (0.11 sec)
 
 TiDB [tidbtest]> insert into t1 () values (),(),(),(),();

--- a/dev/how-to/get-started/tidb-binlog.md
+++ b/dev/how-to/get-started/tidb-binlog.md
@@ -234,9 +234,9 @@ MariaDB [(none)]> show databases;
 Here we can already see the `tidb_binlog` database, which contains the `checkpoint` table used by `drainer` to record up to what point binary logs from the TiDB cluster have been applied.
 
 ```sql
-MariaDB [tidb_binlog]> use tidb_binlog;
+MariaDB [tidb_binlog]> USE tidb_binlog;
 Database changed
-MariaDB [tidb_binlog]> select * from checkpoint;
+MariaDB [tidb_binlog]> SELECT * FROM checkpoint;
 +---------------------+---------------------------------------------+
 | clusterID           | checkPoint                                  |
 +---------------------+---------------------------------------------+
@@ -252,29 +252,29 @@ mysql -h 127.0.0.1 -P 4000 --prompt='TiDB [\d]> ' -u root
 ```
 
 ```sql
-create database tidbtest;
-use tidbtest;
-create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
-insert into t1 () values (),(),(),(),();
-select * from t1;
+CREATE DATABASE tidbtest;
+USE tidbtest;
+CREATE TABLE t1 (id INT unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO t1 () VALUES (),(),(),(),();
+SELECT * FROM t1;
 ```
 
 Expected output:
 
 ```
-TiDB [(none)]> create database tidbtest;
+TiDB [(none)]> CREATE DATABASE tidbtest;
 Query OK, 0 rows affected (0.12 sec)
 
-TiDB [(none)]> use tidbtest;
+TiDB [(none)]> USE tidbtest;
 Database changed
-TiDB [tidbtest]> create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
+TiDB [tidbtest]> create TABLE t1 (id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY);
 Query OK, 0 rows affected (0.11 sec)
 
-TiDB [tidbtest]> insert into t1 () values (),(),(),(),();
+TiDB [tidbtest]> INSERT INTO t1 () VALUES (),(),(),(),();
 Query OK, 5 rows affected (0.01 sec)
 Records: 5  Duplicates: 0  Warnings: 0
 
-TiDB [tidbtest]> select * from t1;
+TiDB [tidbtest]> SELECT * FROM t1;
 +----+
 | id |
 +----+
@@ -290,9 +290,9 @@ TiDB [tidbtest]> select * from t1;
 Switching back to the MariaDB client, we should find the new database, new table, and the newly inserted rows:
 
 ```sql
-use tidbtest;
-show tables;
-select * from t1;
+USE tidbtest;
+SHOW TABLES;
+SELECT * FROM t1;
 ```
 
 Expected output:
@@ -303,7 +303,7 @@ Reading table information for completion of table and column names
 You can turn off this feature to get a quicker startup with -A
 
 Database changed
-MariaDB [tidbtest]> show tables;
+MariaDB [tidbtest]> SHOW TABLES;
 +--------------------+
 | Tables_in_tidbtest |
 +--------------------+
@@ -311,7 +311,7 @@ MariaDB [tidbtest]> show tables;
 +--------------------+
 1 row in set (0.00 sec)
 
-MariaDB [tidbtest]> select * from t1;
+MariaDB [tidbtest]> SELECT * FROM t1;
 +----+
 | id |
 +----+

--- a/dev/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/dev/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -527,7 +527,7 @@ set tidb_query_log_max_len = 20
 
 - Scope: SESSION
 - Default value: 0
-- This variable is used to set whether the `auto_increment` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+- This variable is used to set whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### tidb_enable_stmt_summary <span class="version-mark">New in v3.0.4</span>
 

--- a/dev/reference/mysql-compatibility.md
+++ b/dev/reference/mysql-compatibility.md
@@ -55,7 +55,7 @@ In TiDB, auto-increment columns are only guaranteed to be incremental and unique
 Assume that you have a table with the auto-increment ID:
 
 ```sql
-create table t(id int unique key auto_increment, c int);
+create table t(id int unique key AUTO_INCREMENT, c int);
 ```
 
 The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
@@ -67,7 +67,7 @@ The operations are executed as follows:
 1. The client issues the `insert into t values (1, 1)` statement to Instance B which sets the `id` to 1 and the statement is executed successfully.
 2. The client issues the `insert into t (c) (1)` statement to Instance A. This statement does not specify the value of `id`, so Instance A allocates the value. Currently, Instances A caches the auto-increment ID of [1, 30000], so it allocates the `id` value to 1 and adds 1 to the local counter. However, at this time the data with the `id` of 1 already exists in the cluster, therefore it reports `Duplicated Error`.
 
-Also, starting from TiDB 2.1.18 and 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `auto_increment` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+Also, starting from TiDB 2.1.18 and 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### Performance schema
 
@@ -92,7 +92,7 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
     - Adding an index on a generated column via `ALTER TABLE` is not supported.
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `auto_increment` while adding it.
+    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `AUTO_INCREMENT` while adding it.
 + Drop Column: Does not support dropping the `PRIMARY KEY` column or index column.
 + Change/Modify Column:
     - Does not support lossy changes, such as from `BIGINT` to `INTEGER` or `VARCHAR(255)` to `VARCHAR(10)`.

--- a/dev/reference/sql/character-set.md
+++ b/dev/reference/sql/character-set.md
@@ -59,7 +59,7 @@ mysql> SHOW COLLATION WHERE Charset = 'utf8mb4';
 For compatibility with MySQL, TiDB will allow other collation names to be used:
 
 ```sql
-mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY auto_increment, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
+mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY AUTO_INCREMENT, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
 Query OK, 0 rows affected (0.00 sec)
 
 mysql> INSERT INTO t1 VALUES (1, 'a');

--- a/dev/reference/sql/constraints.md
+++ b/dev/reference/sql/constraints.md
@@ -20,12 +20,12 @@ TiDB currently only supports `FOREIGN KEY` creation in DDL commands. For example
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  doc JSON
 );
 
 CREATE TABLE orders (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  user_id INT NOT NULL,
  doc JSON,
  FOREIGN KEY fk_user_id (user_id) REFERENCES users(id)
@@ -68,7 +68,7 @@ TiDB supports the `NOT NULL` constraint with identical semantics to MySQL. For e
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  age INT NOT NULL,
  last_login TIMESTAMP
 );
@@ -83,7 +83,7 @@ mysql> INSERT INTO users (id,age,last_login) VALUES (NULL,123,NULL);
 Query OK, 1 row affected (0.03 sec)
 ```
 
-* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `auto_increment`. This results in the next auto-value being allocated.
+* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `AUTO_INCREMENT`. This results in the next auto-value being allocated.
 
 * The second `INSERT` statement fails because the `age` column was defined as `NOT NULL`.
 
@@ -142,7 +142,7 @@ In TiDB, `UNIQUE` constraints are checked lazily by default. By batching checks 
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );
@@ -170,7 +170,7 @@ By changing `tidb_constraint_check_in_place` to `TRUE`, `UNIQUE` constraints wil
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );

--- a/dev/reference/sql/statements/add-column.md
+++ b/dev/reference/sql/statements/add-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD COLUMN` statement adds a column to an existing table. Thi
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (NULL);

--- a/dev/reference/sql/statements/add-index.md
+++ b/dev/reference/sql/statements/add-index.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD INDEX` statement adds an index to an existing table. This
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/alter-table.md
+++ b/dev/reference/sql/statements/alter-table.md
@@ -28,7 +28,7 @@ This statement modifies an existing table to conform to a new table structure. T
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/analyze-table.md
+++ b/dev/reference/sql/statements/analyze-table.md
@@ -27,7 +27,7 @@ TiDB will also automatically update its statistics over time as it discovers tha
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/change-column.md
+++ b/dev/reference/sql/statements/change-column.md
@@ -37,7 +37,7 @@ The `ALTER TABLE.. CHANGE COLUMN` statement changes a column on an existing tabl
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/create-index.md
+++ b/dev/reference/sql/statements/create-index.md
@@ -45,7 +45,7 @@ This statement adds a new index to an existing table. It is an alternative synta
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/create-view.md
+++ b/dev/reference/sql/statements/create-view.md
@@ -45,7 +45,7 @@ The `CREATE VIEW` statement saves a `SELECT` statement as a queryable object, si
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/delete.md
+++ b/dev/reference/sql/statements/delete.md
@@ -17,7 +17,7 @@ The `DELETE` statement removes rows from a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/drop-column.md
+++ b/dev/reference/sql/statements/drop-column.md
@@ -29,7 +29,7 @@ This statement drops a column from a specified table. `DROP COLUMN` is online in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, col1 INT NOT NULL, col2 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, col1 INT NOT NULL, col2 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (col1,col2) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);

--- a/dev/reference/sql/statements/drop-index.md
+++ b/dev/reference/sql/statements/drop-index.md
@@ -29,7 +29,7 @@ This statement removes an index from a specified table, marking space as free in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/drop-view.md
+++ b/dev/reference/sql/statements/drop-view.md
@@ -25,7 +25,7 @@ This statement drops an view object from the currently selected database. It doe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/explain-analyze.md
+++ b/dev/reference/sql/statements/explain-analyze.md
@@ -25,7 +25,7 @@ The `EXPLAIN ANALYZE` statement works similar to `EXPLAIN`, with the major diffe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/dev/reference/sql/statements/explain.md
+++ b/dev/reference/sql/statements/explain.md
@@ -36,7 +36,7 @@ mysql> EXPLAIN SELECT 1;
 +-------------------+-------+------+---------------+
 2 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -18,7 +18,7 @@ The `LOAD DATA` statement batch loads data into a TiDB table.
 
 ```sql
 mysql> CREATE TABLE trips (
-    ->  trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+    ->  trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
     ->  duration integer not null,
     ->  start_date datetime,
     ->  end_date datetime,

--- a/dev/reference/sql/statements/modify-column.md
+++ b/dev/reference/sql/statements/modify-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. MODIFY COLUMN` statement modifies a column on an existing tab
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/rename-index.md
+++ b/dev/reference/sql/statements/rename-index.md
@@ -21,7 +21,7 @@ The statement `ALTER TABLE .. RENAME INDEX` renames an existing index to a new n
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL, INDEX col1 (c1));
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL, INDEX col1 (c1));
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> SHOW CREATE TABLE t1\G

--- a/dev/reference/sql/statements/replace.md
+++ b/dev/reference/sql/statements/replace.md
@@ -33,7 +33,7 @@ The `REPLACE` statement is semantically a combined `DELETE`+`INSERT` statement. 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/dev/reference/sql/statements/select.md
+++ b/dev/reference/sql/statements/select.md
@@ -80,7 +80,7 @@ The `SELECT` statement is used to read data from TiDB.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/show-indexes.md
+++ b/dev/reference/sql/statements/show-indexes.md
@@ -33,7 +33,7 @@ The statement `SHOW INDEXES [FROM|IN]` lists the indexes on a specified table.  
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT, INDEX(col1));
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT, INDEX(col1));
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> SHOW INDEXES FROM t1;

--- a/dev/reference/sql/statements/show-table-status.md
+++ b/dev/reference/sql/statements/show-table-status.md
@@ -25,7 +25,7 @@ This statement shows various statistics about tables in TiDB. If the statistics 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/trace.md
+++ b/dev/reference/sql/statements/trace.md
@@ -38,7 +38,7 @@ mysql> trace format='row' select * from mysql.user;
 +---------------------------+-----------------+------------+
 10 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (1),(2),(3),(4),(5);

--- a/dev/reference/sql/statements/update.md
+++ b/dev/reference/sql/statements/update.md
@@ -33,7 +33,7 @@ The `UPDATE` statement is used to modify data in a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/dev/releases/2.1.16.md
+++ b/dev/releases/2.1.16.md
@@ -29,7 +29,7 @@ TiDB Ansible version: 2.1.16
     - Fix the issue that `NULL` is not returned correctly because the value of `YEAR` in the `DATE_ADD`/`DATE_SUB` result overflows when it is smaller than 0 or larger than 65535 [#11477](https://github.com/pingcap/tidb/pull/11477)
     - Add in the slow query table a `Succ` field that indicates whether the execution succeeds [#11412](https://github.com/pingcap/tidb/pull/11421)
     - Fix the MySQL incompatibility issue caused by fetching the current timestamp multiple times when a SQL statement involves calculations of the current time (such as `CURRENT_TIMESTAMP` or `NOW`) [#11392](https://github.com/pingcap/tidb/pull/11392)
-    - Fix the issue that the auto_increment columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
+    - Fix the issue that the AUTO_INCREMENT columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
     - Fix the issue that `NULL` is not returned correctly when the `CONVERT_TZ` function accepts an invalid argument [#11357](https://github.com/pingcap/tidb/pull/11357)
     - Fix the issue that an error is reported by the `PARTITION BY LIST` statement. (Currently only the syntax is supported; when TiDB executes the statement, a regular table is created and a prompting message is provided) [#11236](https://github.com/pingcap/tidb/pull/11236)
     - Fix the issue that `Mod(%)`, `Multiple(*)`, and `Minus(-)` operations return an inconsistent `0` result with that in MySQL when there are many decimal digits (such as `select 0.000 % 0.11234500000000000000`) [#11353](https://github.com/pingcap/tidb/pull/11353)

--- a/dev/releases/3.0.4.md
+++ b/dev/releases/3.0.4.md
@@ -80,7 +80,7 @@ TiDB Ansible version: 3.0.4
     - Fix the issue that the uncommented TiDB-specific syntax `PRE_SPLIT_REGIONS` might cause errors in the downstream database during data replication [#12120](https://github.com/pingcap/tidb/pull/12120)
     - Add the `split-region-max-num` variable in the configuration file so that the maximum allowable number of Regions is adjustable [#12097](https://github.com/pingcap/tidb/pull/12079)
     - Support splitting a Region into multiple Regions and fix the timeout issue during Region scatterings [#12343](https://github.com/pingcap/tidb/pull/12343)
-    - Fix the issue that the `drop index` statement fails when the index that contains an `auto_increment` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
+    - Fix the issue that the `drop index` statement fails when the index that contains an `AUTO_INCREMENT` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
 - Monitor
     - Add the `connection_transient_failure_count` monitoring metrics to count the number of gRPC connection errors in `tikvclient` [#12093](https://github.com/pingcap/tidb/pull/12093)
 

--- a/v1.0/sql/mysql-compatibility.md
+++ b/v1.0/sql/mysql-compatibility.md
@@ -38,7 +38,7 @@ The auto-increment ID feature in TiDB is only guaranteed to be automatically inc
 > In a cluster of two TiDB servers, namely TiDB A and TiDB B, TiDB A caches [1,5000] auto-increment ID, while TiDB B caches [5001,10000] auto-increment ID. Use the following statement to create a table with auto-increment ID:
 > 
 > ```
-> create table t(id int unique key auto_increment, c int);
+> create table t(id int unique key AUTO_INCREMENT, c int);
 > ```
 >
 > The statement is executed as follows:
@@ -62,7 +62,7 @@ TiDB implements the asynchronous schema changes algorithm in F1. The Data Manipu
 + Drop Index
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the primary key, or creating a unique index, or specifying auto_increment while adding it.
+    - Does not support setting a column as the primary key, or creating a unique index, or specifying AUTO_INCREMENT while adding it.
 + Drop Column: Does not support dropping the primary key column or index column.
 + Alter Column
 + Change/Modify Column

--- a/v2.0/sql/mysql-compatibility.md
+++ b/v2.0/sql/mysql-compatibility.md
@@ -38,7 +38,7 @@ The auto-increment ID feature in TiDB is only guaranteed to be automatically inc
 > Assume that you have a table with the auto-increment ID:
 > 
 > ```
-> create table t(id int unique key auto_increment, c int);
+> create table t(id int unique key AUTO_INCREMENT, c int);
 > ```
 > 
 > The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
@@ -66,7 +66,7 @@ TiDB implements the asynchronous schema changes algorithm in F1. The Data Manipu
 + Drop Index
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the primary key, or creating a unique index, or specifying auto_increment while adding it.
+    - Does not support setting a column as the primary key, or creating a unique index, or specifying AUTO_INCREMENT while adding it.
 + Drop Column: Does not support dropping the primary key column or index column.
 + Alter Column
 + Change/Modify Column

--- a/v2.1-legacy/bikeshare-example-database.md
+++ b/v2.1-legacy/bikeshare-example-database.md
@@ -30,7 +30,7 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
- trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+ trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
  duration integer not null,
  start_date datetime,
  end_date datetime,

--- a/v2.1-legacy/sql/mysql-compatibility.md
+++ b/v2.1-legacy/sql/mysql-compatibility.md
@@ -48,7 +48,7 @@ The auto-increment ID feature in TiDB is only guaranteed to be automatically inc
 > 
 > Assume that you have a table with the auto-increment ID:
 > 
-> `create table t(id int unique key auto_increment, c int);`
+> `create table t(id int unique key AUTO_INCREMENT, c int);`
 > 
 > The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
 >
@@ -79,7 +79,7 @@ TiDB implements the asynchronous schema changes algorithm in F1. The Data Manipu
 + Drop Index
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the primary key, or creating a unique index, or specifying auto_increment while adding it.
+    - Does not support setting a column as the primary key, or creating a unique index, or specifying AUTO_INCREMENT while adding it.
 + Drop Column: Does not support dropping the primary key column or index column.
 + Alter Column
 + Change/Modify Column

--- a/v2.1/how-to/get-started/data-migration.md
+++ b/v2.1/how-to/get-started/data-migration.md
@@ -119,7 +119,7 @@ for i in 1 2 3
 do
     mysql -h 127.0.0.1 -P "$((3306+i))" -u root <<EoSQL
         create database dmtest1;
-        create table dmtest1.t1 (id bigint unsigned not null auto_increment primary key, c char(32), port int);
+        create table dmtest1.t1 (id bigint unsigned not null AUTO_INCREMENT primary key, c char(32), port int);
 EoSQL
 done
 ```

--- a/v2.1/how-to/get-started/import-example-database.md
+++ b/v2.1/how-to/get-started/import-example-database.md
@@ -28,7 +28,7 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
- trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+ trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
  duration integer not null,
  start_date datetime,
  end_date datetime,

--- a/v2.1/how-to/get-started/tidb-binlog.md
+++ b/v2.1/how-to/get-started/tidb-binlog.md
@@ -254,7 +254,7 @@ mysql -h 127.0.0.1 -P 4000 --prompt='TiDB [\d]> ' -u root
 ```sql
 create database tidbtest;
 use tidbtest;
-create table t1 (id int unsigned not null auto_increment primary key);
+create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 insert into t1 () values (),(),(),(),();
 select * from t1;
 ```
@@ -267,7 +267,7 @@ Query OK, 0 rows affected (0.12 sec)
 
 TiDB [(none)]> use tidbtest;
 Database changed
-TiDB [tidbtest]> create table t1 (id int unsigned not null auto_increment primary key);
+TiDB [tidbtest]> create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 Query OK, 0 rows affected (0.11 sec)
 
 TiDB [tidbtest]> insert into t1 () values (),(),(),(),();

--- a/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -368,4 +368,4 @@ set tidb_query_log_max_len = 20
 
 - Scope: SESSION
 - Default value: 0
-- This variable is used to set whether the `auto_increment` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+- This variable is used to set whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.

--- a/v2.1/reference/mysql-compatibility.md
+++ b/v2.1/reference/mysql-compatibility.md
@@ -55,7 +55,7 @@ In TiDB, auto-increment columns are only guaranteed to be incremental and unique
 Assume that you have a table with the auto-increment ID:
 
 ```sql
-create table t(id int unique key auto_increment, c int);
+create table t(id int unique key AUTO_INCREMENT, c int);
 ```
 
 The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
@@ -67,7 +67,7 @@ The operations are executed as follows:
 1. The client issues the `insert into t values (1, 1)` statement to Instance B which sets the `id` to 1 and the statement is executed successfully.
 2. The client issues the `insert into t (c) (1)` statement to Instance A. This statement does not specify the value of `id`, so Instance A allocates the value. Currently, Instances A caches the auto-increment ID of [1, 30000], so it allocates the `id` value to 1 and adds 1 to the local counter. However, at this time the data with the `id` of 1 already exists in the cluster, therefore it reports `Duplicated Error`.
 
-Also, starting from TiDB 2.1.18, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `auto_increment` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+Also, starting from TiDB 2.1.18, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### Performance schema
 
@@ -90,7 +90,7 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
     - Adding an index on a generated column via `ALTER TABLE` is not supported.
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `auto_increment` while adding it.
+    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `AUTO_INCREMENT` while adding it.
 + Drop Column: Does not support dropping the `PRIMARY KEY` column or index column.
 + Change/Modify Column:
     - Does not support lossy changes, such as from `BIGINT` to `INTEGER` or `VARCHAR(255)` to `VARCHAR(10)`.

--- a/v2.1/reference/sql/character-set.md
+++ b/v2.1/reference/sql/character-set.md
@@ -302,7 +302,7 @@ mysql> SHOW COLLATION WHERE Charset = 'utf8mb4';
 For compatibility with MySQL, TiDB will allow other collation names to be used:
 
 ```sql
-mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY auto_increment, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
+mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY AUTO_INCREMENT, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
 Query OK, 0 rows affected (0.00 sec)
 
 mysql> INSERT INTO t1 VALUES (1, 'a');

--- a/v2.1/reference/sql/constraints.md
+++ b/v2.1/reference/sql/constraints.md
@@ -20,12 +20,12 @@ TiDB currently only supports `FOREIGN KEY` creation in DDL commands. For example
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  doc JSON
 );
 
 CREATE TABLE orders (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  user_id INT NOT NULL,
  doc JSON,
  FOREIGN KEY fk_user_id (user_id) REFERENCES users(id)
@@ -68,7 +68,7 @@ TiDB supports the `NOT NULL` constraint with identical semantics to MySQL. For e
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  age INT NOT NULL,
  last_login TIMESTAMP
 );
@@ -83,7 +83,7 @@ mysql> INSERT INTO users (id,age,last_login) VALUES (NULL,123,NULL);
 Query OK, 1 row affected (0.03 sec)
 ```
 
-* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `auto_increment`. This results in the next auto-value being allocated.
+* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `AUTO_INCREMENT`. This results in the next auto-value being allocated.
 
 * The second `INSERT` statement fails because the `age` column was defined as `NOT NULL`.
 
@@ -142,7 +142,7 @@ In TiDB, `UNIQUE` constraints are checked lazily by default. By batching checks 
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );
@@ -170,7 +170,7 @@ By changing `tidb_constraint_check_in_place` to `TRUE`, `UNIQUE` constraints wil
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );

--- a/v2.1/reference/sql/statements/add-column.md
+++ b/v2.1/reference/sql/statements/add-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD COLUMN` statement adds a column to an existing table. Thi
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (NULL);

--- a/v2.1/reference/sql/statements/add-index.md
+++ b/v2.1/reference/sql/statements/add-index.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD INDEX` statement adds an index to an existing table. This
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/alter-table.md
+++ b/v2.1/reference/sql/statements/alter-table.md
@@ -28,7 +28,7 @@ This statement modifies an existing table to conform to a new table structure. T
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/analyze-table.md
+++ b/v2.1/reference/sql/statements/analyze-table.md
@@ -27,7 +27,7 @@ TiDB will also automatically update its statistics over time as it discovers tha
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/change-column.md
+++ b/v2.1/reference/sql/statements/change-column.md
@@ -37,7 +37,7 @@ The `ALTER TABLE.. CHANGE COLUMN` statement changes a column on an existing tabl
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/create-index.md
+++ b/v2.1/reference/sql/statements/create-index.md
@@ -45,7 +45,7 @@ This statement adds a new index to an existing table. It is an alternative synta
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/delete.md
+++ b/v2.1/reference/sql/statements/delete.md
@@ -17,7 +17,7 @@ The `DELETE` statement removes rows from a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/drop-column.md
+++ b/v2.1/reference/sql/statements/drop-column.md
@@ -29,7 +29,7 @@ This statement drops a column from a specified table. `DROP COLUMN` is online in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, col1 INT NOT NULL, col2 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, col1 INT NOT NULL, col2 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (col1,col2) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);

--- a/v2.1/reference/sql/statements/drop-index.md
+++ b/v2.1/reference/sql/statements/drop-index.md
@@ -29,7 +29,7 @@ This statement removes an index from a specified table, marking space as free in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/explain-analyze.md
+++ b/v2.1/reference/sql/statements/explain-analyze.md
@@ -25,7 +25,7 @@ The `EXPLAIN ANALYZE` statement works similar to `EXPLAIN`, with the major diffe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v2.1/reference/sql/statements/explain.md
+++ b/v2.1/reference/sql/statements/explain.md
@@ -36,7 +36,7 @@ mysql> EXPLAIN SELECT 1;
 +-------------------+-------+------+---------------+
 2 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v2.1/reference/sql/statements/load-data.md
+++ b/v2.1/reference/sql/statements/load-data.md
@@ -18,7 +18,7 @@ The `LOAD DATA` statement batch loads data into a TiDB table.
 
 ```sql
 mysql> CREATE TABLE trips (
-    ->  trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+    ->  trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
     ->  duration integer not null,
     ->  start_date datetime,
     ->  end_date datetime,

--- a/v2.1/reference/sql/statements/modify-column.md
+++ b/v2.1/reference/sql/statements/modify-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. MODIFY COLUMN` statement modifies a column on an existing tab
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/rename-index.md
+++ b/v2.1/reference/sql/statements/rename-index.md
@@ -21,7 +21,7 @@ The statement `ALTER TABLE .. RENAME INDEX` renames an existing index to a new n
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL, INDEX col1 (c1));
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL, INDEX col1 (c1));
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> SHOW CREATE TABLE t1\G

--- a/v2.1/reference/sql/statements/replace.md
+++ b/v2.1/reference/sql/statements/replace.md
@@ -33,7 +33,7 @@ The `REPLACE` statement is semantically a combined `DELETE`+`INSERT` statement. 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v2.1/reference/sql/statements/select.md
+++ b/v2.1/reference/sql/statements/select.md
@@ -80,7 +80,7 @@ The `SELECT` statement is used to read data from TiDB.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/show-indexes.md
+++ b/v2.1/reference/sql/statements/show-indexes.md
@@ -33,7 +33,7 @@ The statement `SHOW INDEXES [FROM|IN]` lists the indexes on a specified table.  
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT, INDEX(col1));
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT, INDEX(col1));
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> SHOW INDEXES FROM t1;

--- a/v2.1/reference/sql/statements/show-table-status.md
+++ b/v2.1/reference/sql/statements/show-table-status.md
@@ -25,7 +25,7 @@ This statement shows various statistics about tables in TiDB. If the statistics 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/trace.md
+++ b/v2.1/reference/sql/statements/trace.md
@@ -38,7 +38,7 @@ mysql> trace format='row' select * from mysql.user;
 +---------------------------+-----------------+------------+
 10 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (1),(2),(3),(4),(5);

--- a/v2.1/reference/sql/statements/update.md
+++ b/v2.1/reference/sql/statements/update.md
@@ -33,7 +33,7 @@ The `UPDATE` statement is used to modify data in a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v2.1/releases/2.1.16.md
+++ b/v2.1/releases/2.1.16.md
@@ -29,7 +29,7 @@ TiDB Ansible version: 2.1.16
     - Fix the issue that `NULL` is not returned correctly because the value of `YEAR` in the `DATE_ADD`/`DATE_SUB` result overflows when it is smaller than 0 or larger than 65535 [#11477](https://github.com/pingcap/tidb/pull/11477)
     - Add in the slow query table a `Succ` field that indicates whether the execution succeeds [#11412](https://github.com/pingcap/tidb/pull/11421)
     - Fix the MySQL incompatibility issue caused by fetching the current timestamp multiple times when a SQL statement involves calculations of the current time (such as `CURRENT_TIMESTAMP` or `NOW`) [#11392](https://github.com/pingcap/tidb/pull/11392)
-    - Fix the issue that the auto_increment columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
+    - Fix the issue that the AUTO_INCREMENT columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
     - Fix the issue that `NULL` is not returned correctly when the `CONVERT_TZ` function accepts an invalid argument [#11357](https://github.com/pingcap/tidb/pull/11357)
     - Fix the issue that an error is reported by the `PARTITION BY LIST` statement. (Currently only the syntax is supported; when TiDB executes the statement, a regular table is created and a prompting message is provided) [#11236](https://github.com/pingcap/tidb/pull/11236)
     - Fix the issue that `Mod(%)`, `Multiple(*)`, and `Minus(-)` operations return an inconsistent `0` result with that in MySQL when there are many decimal digits (such as `select 0.000 % 0.11234500000000000000`) [#11353](https://github.com/pingcap/tidb/pull/11353)

--- a/v3.0/how-to/get-started/data-migration.md
+++ b/v3.0/how-to/get-started/data-migration.md
@@ -119,7 +119,7 @@ for i in 1 2 3
 do
     mysql -h 127.0.0.1 -P "$((3306+i))" -u root <<EoSQL
         create database dmtest1;
-        create table dmtest1.t1 (id bigint unsigned not null auto_increment primary key, c char(32), port int);
+        create table dmtest1.t1 (id bigint unsigned not null AUTO_INCREMENT primary key, c char(32), port int);
 EoSQL
 done
 ```

--- a/v3.0/how-to/get-started/import-example-database.md
+++ b/v3.0/how-to/get-started/import-example-database.md
@@ -29,7 +29,7 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
- trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+ trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
  duration integer not null,
  start_date datetime,
  end_date datetime,

--- a/v3.0/how-to/get-started/tidb-binlog.md
+++ b/v3.0/how-to/get-started/tidb-binlog.md
@@ -254,7 +254,7 @@ mysql -h 127.0.0.1 -P 4000 --prompt='TiDB [\d]> ' -u root
 ```sql
 create database tidbtest;
 use tidbtest;
-create table t1 (id int unsigned not null auto_increment primary key);
+create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 insert into t1 () values (),(),(),(),();
 select * from t1;
 ```
@@ -267,7 +267,7 @@ Query OK, 0 rows affected (0.12 sec)
 
 TiDB [(none)]> use tidbtest;
 Database changed
-TiDB [tidbtest]> create table t1 (id int unsigned not null auto_increment primary key);
+TiDB [tidbtest]> create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 Query OK, 0 rows affected (0.11 sec)
 
 TiDB [tidbtest]> insert into t1 () values (),(),(),(),();

--- a/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -527,7 +527,7 @@ set tidb_query_log_max_len = 20
 
 - Scope: SESSION
 - Default value: 0
-- This variable is used to set whether the `auto_increment` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+- This variable is used to set whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### tidb_enable_stmt_summary <span class="version-mark">New in v3.0.4</span>
 

--- a/v3.0/reference/mysql-compatibility.md
+++ b/v3.0/reference/mysql-compatibility.md
@@ -55,7 +55,7 @@ In TiDB, auto-increment columns are only guaranteed to be incremental and unique
 Assume that you have a table with the auto-increment ID:
 
 ```sql
-create table t(id int unique key auto_increment, c int);
+create table t(id int unique key AUTO_INCREMENT, c int);
 ```
 
 The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
@@ -67,7 +67,7 @@ The operations are executed as follows:
 1. The client issues the `insert into t values (1, 1)` statement to Instance B which sets the `id` to 1 and the statement is executed successfully.
 2. The client issues the `insert into t (c) (1)` statement to Instance A. This statement does not specify the value of `id`, so Instance A allocates the value. Currently, Instances A caches the auto-increment ID of [1, 30000], so it allocates the `id` value to 1 and adds 1 to the local counter. However, at this time the data with the `id` of 1 already exists in the cluster, therefore it reports `Duplicated Error`.
 
-Also, starting with TiDB 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `auto_increment` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+Also, starting with TiDB 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### Performance schema
 
@@ -92,7 +92,7 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
     - Adding an index on a generated column via `ALTER TABLE` is not supported.
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `auto_increment` while adding it.
+    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `AUTO_INCREMENT` while adding it.
 + Drop Column: Does not support dropping the `PRIMARY KEY` column or index column.
 + Change/Modify Column:
     - Does not support lossy changes, such as from `BIGINT` to `INTEGER` or `VARCHAR(255)` to `VARCHAR(10)`.

--- a/v3.0/reference/sql/character-set.md
+++ b/v3.0/reference/sql/character-set.md
@@ -59,7 +59,7 @@ mysql> SHOW COLLATION WHERE Charset = 'utf8mb4';
 For compatibility with MySQL, TiDB will allow other collation names to be used:
 
 ```sql
-mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY auto_increment, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
+mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY AUTO_INCREMENT, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
 Query OK, 0 rows affected (0.00 sec)
 
 mysql> INSERT INTO t1 VALUES (1, 'a');

--- a/v3.0/reference/sql/constraints.md
+++ b/v3.0/reference/sql/constraints.md
@@ -21,12 +21,12 @@ TiDB currently only supports `FOREIGN KEY` creation in DDL commands. For example
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  doc JSON
 );
 
 CREATE TABLE orders (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  user_id INT NOT NULL,
  doc JSON,
  FOREIGN KEY fk_user_id (user_id) REFERENCES users(id)
@@ -69,7 +69,7 @@ TiDB supports the `NOT NULL` constraint with identical semantics to MySQL. For e
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  age INT NOT NULL,
  last_login TIMESTAMP
 );
@@ -84,7 +84,7 @@ mysql> INSERT INTO users (id,age,last_login) VALUES (NULL,123,NULL);
 Query OK, 1 row affected (0.03 sec)
 ```
 
-* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `auto_increment`. This results in the next auto-value being allocated.
+* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `AUTO_INCREMENT`. This results in the next auto-value being allocated.
 
 * The second `INSERT` statement fails because the `age` column was defined as `NOT NULL`.
 
@@ -143,7 +143,7 @@ In TiDB, `UNIQUE` constraints are checked lazily by default. By batching checks 
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );
@@ -171,7 +171,7 @@ By changing `tidb_constraint_check_in_place` to `TRUE`, `UNIQUE` constraints wil
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );

--- a/v3.0/reference/sql/statements/add-column.md
+++ b/v3.0/reference/sql/statements/add-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD COLUMN` statement adds a column to an existing table. Thi
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (NULL);

--- a/v3.0/reference/sql/statements/add-index.md
+++ b/v3.0/reference/sql/statements/add-index.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD INDEX` statement adds an index to an existing table. This
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/alter-table.md
+++ b/v3.0/reference/sql/statements/alter-table.md
@@ -28,7 +28,7 @@ This statement modifies an existing table to conform to a new table structure. T
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/analyze-table.md
+++ b/v3.0/reference/sql/statements/analyze-table.md
@@ -27,7 +27,7 @@ TiDB will also automatically update its statistics over time as it discovers tha
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/change-column.md
+++ b/v3.0/reference/sql/statements/change-column.md
@@ -37,7 +37,7 @@ The `ALTER TABLE.. CHANGE COLUMN` statement changes a column on an existing tabl
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/create-index.md
+++ b/v3.0/reference/sql/statements/create-index.md
@@ -45,7 +45,7 @@ This statement adds a new index to an existing table. It is an alternative synta
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/create-view.md
+++ b/v3.0/reference/sql/statements/create-view.md
@@ -45,7 +45,7 @@ The `CREATE VIEW` statement saves a `SELECT` statement as a queryable object, si
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/delete.md
+++ b/v3.0/reference/sql/statements/delete.md
@@ -17,7 +17,7 @@ The `DELETE` statement removes rows from a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/drop-column.md
+++ b/v3.0/reference/sql/statements/drop-column.md
@@ -29,7 +29,7 @@ This statement drops a column from a specified table. `DROP COLUMN` is online in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, col1 INT NOT NULL, col2 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, col1 INT NOT NULL, col2 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (col1,col2) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);

--- a/v3.0/reference/sql/statements/drop-index.md
+++ b/v3.0/reference/sql/statements/drop-index.md
@@ -29,7 +29,7 @@ This statement removes an index from a specified table, marking space as free in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/drop-view.md
+++ b/v3.0/reference/sql/statements/drop-view.md
@@ -25,7 +25,7 @@ This statement drops an view object from the currently selected database. It doe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/explain-analyze.md
+++ b/v3.0/reference/sql/statements/explain-analyze.md
@@ -25,7 +25,7 @@ The `EXPLAIN ANALYZE` statement works similar to `EXPLAIN`, with the major diffe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.0/reference/sql/statements/explain.md
+++ b/v3.0/reference/sql/statements/explain.md
@@ -37,7 +37,7 @@ mysql> EXPLAIN SELECT 1;
 +-------------------+-------+------+---------------+
 2 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.0/reference/sql/statements/load-data.md
+++ b/v3.0/reference/sql/statements/load-data.md
@@ -18,7 +18,7 @@ The `LOAD DATA` statement batch loads data into a TiDB table.
 
 ```sql
 mysql> CREATE TABLE trips (
-    ->  trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+    ->  trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
     ->  duration integer not null,
     ->  start_date datetime,
     ->  end_date datetime,

--- a/v3.0/reference/sql/statements/modify-column.md
+++ b/v3.0/reference/sql/statements/modify-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. MODIFY COLUMN` statement modifies a column on an existing tab
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/rename-index.md
+++ b/v3.0/reference/sql/statements/rename-index.md
@@ -21,7 +21,7 @@ The statement `ALTER TABLE .. RENAME INDEX` renames an existing index to a new n
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL, INDEX col1 (c1));
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL, INDEX col1 (c1));
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> SHOW CREATE TABLE t1\G

--- a/v3.0/reference/sql/statements/replace.md
+++ b/v3.0/reference/sql/statements/replace.md
@@ -33,7 +33,7 @@ The `REPLACE` statement is semantically a combined `DELETE`+`INSERT` statement. 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.0/reference/sql/statements/select.md
+++ b/v3.0/reference/sql/statements/select.md
@@ -81,7 +81,7 @@ The `SELECT` statement is used to read data from TiDB.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/show-indexes.md
+++ b/v3.0/reference/sql/statements/show-indexes.md
@@ -33,7 +33,7 @@ The statement `SHOW INDEXES [FROM|IN]` lists the indexes on a specified table.  
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT, INDEX(col1));
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT, INDEX(col1));
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> SHOW INDEXES FROM t1;

--- a/v3.0/reference/sql/statements/show-table-status.md
+++ b/v3.0/reference/sql/statements/show-table-status.md
@@ -25,7 +25,7 @@ This statement shows various statistics about tables in TiDB. If the statistics 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/trace.md
+++ b/v3.0/reference/sql/statements/trace.md
@@ -38,7 +38,7 @@ mysql> trace format='row' select * from mysql.user;
 +---------------------------+-----------------+------------+
 10 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (1),(2),(3),(4),(5);

--- a/v3.0/reference/sql/statements/update.md
+++ b/v3.0/reference/sql/statements/update.md
@@ -33,7 +33,7 @@ The `UPDATE` statement is used to modify data in a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.0/releases/2.1.16.md
+++ b/v3.0/releases/2.1.16.md
@@ -29,7 +29,7 @@ TiDB Ansible version: 2.1.16
     - Fix the issue that `NULL` is not returned correctly because the value of `YEAR` in the `DATE_ADD`/`DATE_SUB` result overflows when it is smaller than 0 or larger than 65535 [#11477](https://github.com/pingcap/tidb/pull/11477)
     - Add in the slow query table a `Succ` field that indicates whether the execution succeeds [#11412](https://github.com/pingcap/tidb/pull/11421)
     - Fix the MySQL incompatibility issue caused by fetching the current timestamp multiple times when a SQL statement involves calculations of the current time (such as `CURRENT_TIMESTAMP` or `NOW`) [#11392](https://github.com/pingcap/tidb/pull/11392)
-    - Fix the issue that the auto_increment columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
+    - Fix the issue that the AUTO_INCREMENT columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
     - Fix the issue that `NULL` is not returned correctly when the `CONVERT_TZ` function accepts an invalid argument [#11357](https://github.com/pingcap/tidb/pull/11357)
     - Fix the issue that an error is reported by the `PARTITION BY LIST` statement. (Currently only the syntax is supported; when TiDB executes the statement, a regular table is created and a prompting message is provided) [#11236](https://github.com/pingcap/tidb/pull/11236)
     - Fix the issue that `Mod(%)`, `Multiple(*)`, and `Minus(-)` operations return an inconsistent `0` result with that in MySQL when there are many decimal digits (such as `select 0.000 % 0.11234500000000000000`) [#11353](https://github.com/pingcap/tidb/pull/11353)

--- a/v3.0/releases/3.0.4.md
+++ b/v3.0/releases/3.0.4.md
@@ -80,7 +80,7 @@ TiDB Ansible version: 3.0.4
     - Fix the issue that the uncommented TiDB-specific syntax `PRE_SPLIT_REGIONS` might cause errors in the downstream database during data replication [#12120](https://github.com/pingcap/tidb/pull/12120)
     - Add the `split-region-max-num` variable in the configuration file so that the maximum allowable number of Regions is adjustable [#12097](https://github.com/pingcap/tidb/pull/12079)
     - Support splitting a Region into multiple Regions and fix the timeout issue during Region scatterings [#12343](https://github.com/pingcap/tidb/pull/12343)
-    - Fix the issue that the `drop index` statement fails when the index that contains an `auto_increment` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
+    - Fix the issue that the `drop index` statement fails when the index that contains an `AUTO_INCREMENT` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
 - Monitor
     - Add the `connection_transient_failure_count` monitoring metrics to count the number of gRPC connection errors in `tikvclient` [#12093](https://github.com/pingcap/tidb/pull/12093)
 

--- a/v3.1/how-to/get-started/data-migration.md
+++ b/v3.1/how-to/get-started/data-migration.md
@@ -119,7 +119,7 @@ for i in 1 2 3
 do
     mysql -h 127.0.0.1 -P "$((3306+i))" -u root <<EoSQL
         create database dmtest1;
-        create table dmtest1.t1 (id bigint unsigned not null auto_increment primary key, c char(32), port int);
+        create table dmtest1.t1 (id bigint unsigned not null AUTO_INCREMENT primary key, c char(32), port int);
 EoSQL
 done
 ```

--- a/v3.1/how-to/get-started/import-example-database.md
+++ b/v3.1/how-to/get-started/import-example-database.md
@@ -28,7 +28,7 @@ CREATE DATABASE bikeshare;
 USE bikeshare;
 
 CREATE TABLE trips (
- trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+ trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
  duration integer not null,
  start_date datetime,
  end_date datetime,

--- a/v3.1/how-to/get-started/tidb-binlog.md
+++ b/v3.1/how-to/get-started/tidb-binlog.md
@@ -254,7 +254,7 @@ mysql -h 127.0.0.1 -P 4000 --prompt='TiDB [\d]> ' -u root
 ```sql
 create database tidbtest;
 use tidbtest;
-create table t1 (id int unsigned not null auto_increment primary key);
+create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 insert into t1 () values (),(),(),(),();
 select * from t1;
 ```
@@ -267,7 +267,7 @@ Query OK, 0 rows affected (0.12 sec)
 
 TiDB [(none)]> use tidbtest;
 Database changed
-TiDB [tidbtest]> create table t1 (id int unsigned not null auto_increment primary key);
+TiDB [tidbtest]> create table t1 (id int unsigned not null AUTO_INCREMENT primary key);
 Query OK, 0 rows affected (0.11 sec)
 
 TiDB [tidbtest]> insert into t1 () values (),(),(),(),();

--- a/v3.1/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v3.1/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -527,7 +527,7 @@ set tidb_query_log_max_len = 20
 
 - Scope: SESSION
 - Default value: 0
-- This variable is used to set whether the `auto_increment` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+- This variable is used to set whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### tidb_enable_stmt_summary
 

--- a/v3.1/reference/mysql-compatibility.md
+++ b/v3.1/reference/mysql-compatibility.md
@@ -55,7 +55,7 @@ In TiDB, auto-increment columns are only guaranteed to be incremental and unique
 Assume that you have a table with the auto-increment ID:
 
 ```sql
-create table t(id int unique key auto_increment, c int);
+create table t(id int unique key AUTO_INCREMENT, c int);
 ```
 
 The principle of the auto-increment ID in TiDB is that each tidb-server instance caches a section of ID values (currently 30000 IDs are cached) for allocation and fetches the next section after this section is used up.
@@ -67,7 +67,7 @@ The operations are executed as follows:
 1. The client issues the `insert into t values (1, 1)` statement to Instance B which sets the `id` to 1 and the statement is executed successfully.
 2. The client issues the `insert into t (c) (1)` statement to Instance A. This statement does not specify the value of `id`, so Instance A allocates the value. Currently, Instances A caches the auto-increment ID of [1, 30000], so it allocates the `id` value to 1 and adds 1 to the local counter. However, at this time the data with the `id` of 1 already exists in the cluster, therefore it reports `Duplicated Error`.
 
-Also, starting with TiDB 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `auto_increment` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
+Also, starting with TiDB 3.0.4, TiDB supports using the system variable `tidb_allow_remove_auto_inc` to control whether the `AUTO_INCREMENT` property of a column is allowed to be removed by executing  `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` statements. It is not allowed by default.
 
 ### Performance schema
 
@@ -92,7 +92,7 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
     - Adding an index on a generated column via `ALTER TABLE` is not supported.
 + Add Column:
     - Does not support creating multiple columns at the same time.
-    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `auto_increment` while adding it.
+    - Does not support setting a column as the `PRIMARY KEY`, or creating a unique index, or specifying `AUTO_INCREMENT` while adding it.
 + Drop Column: Does not support dropping the `PRIMARY KEY` column or index column.
 + Change/Modify Column:
     - Does not support lossy changes, such as from `BIGINT` to `INTEGER` or `VARCHAR(255)` to `VARCHAR(10)`.

--- a/v3.1/reference/sql/character-set.md
+++ b/v3.1/reference/sql/character-set.md
@@ -58,7 +58,7 @@ mysql> SHOW COLLATION WHERE Charset = 'utf8mb4';
 For compatibility with MySQL, TiDB will allow other collation names to be used:
 
 ```sql
-mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY auto_increment, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
+mysql> CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY AUTO_INCREMENT, b VARCHAR(10)) COLLATE utf8mb4_unicode_520_ci;
 Query OK, 0 rows affected (0.00 sec)
 
 mysql> INSERT INTO t1 VALUES (1, 'a');

--- a/v3.1/reference/sql/constraints.md
+++ b/v3.1/reference/sql/constraints.md
@@ -20,12 +20,12 @@ TiDB currently only supports `FOREIGN KEY` creation in DDL commands. For example
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  doc JSON
 );
 
 CREATE TABLE orders (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  user_id INT NOT NULL,
  doc JSON,
  FOREIGN KEY fk_user_id (user_id) REFERENCES users(id)
@@ -68,7 +68,7 @@ TiDB supports the `NOT NULL` constraint with identical semantics to MySQL. For e
 
 ```sql
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  age INT NOT NULL,
  last_login TIMESTAMP
 );
@@ -83,7 +83,7 @@ mysql> INSERT INTO users (id,age,last_login) VALUES (NULL,123,NULL);
 Query OK, 1 row affected (0.03 sec)
 ```
 
-* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `auto_increment`. This results in the next auto-value being allocated.
+* The first `INSERT` statement succeeded because `NULL` is permitted as a special value for columns defined as `AUTO_INCREMENT`. This results in the next auto-value being allocated.
 
 * The second `INSERT` statement fails because the `age` column was defined as `NOT NULL`.
 
@@ -142,7 +142,7 @@ In TiDB, `UNIQUE` constraints are checked lazily by default. By batching checks 
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );
@@ -170,7 +170,7 @@ By changing `tidb_constraint_check_in_place` to `TRUE`, `UNIQUE` constraints wil
 ```sql
 DROP TABLE IF EXISTS users;
 CREATE TABLE users (
- id INT NOT NULL PRIMARY KEY auto_increment,
+ id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
  username VARCHAR(60) NOT NULL,
  UNIQUE KEY (username)
 );

--- a/v3.1/reference/sql/statements/add-column.md
+++ b/v3.1/reference/sql/statements/add-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD COLUMN` statement adds a column to an existing table. Thi
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (NULL);

--- a/v3.1/reference/sql/statements/add-index.md
+++ b/v3.1/reference/sql/statements/add-index.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. ADD INDEX` statement adds an index to an existing table. This
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/alter-table.md
+++ b/v3.1/reference/sql/statements/alter-table.md
@@ -28,7 +28,7 @@ This statement modifies an existing table to conform to a new table structure. T
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/analyze-table.md
+++ b/v3.1/reference/sql/statements/analyze-table.md
@@ -27,7 +27,7 @@ TiDB will also automatically update its statistics over time as it discovers tha
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/change-column.md
+++ b/v3.1/reference/sql/statements/change-column.md
@@ -37,7 +37,7 @@ The `ALTER TABLE.. CHANGE COLUMN` statement changes a column on an existing tabl
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/create-index.md
+++ b/v3.1/reference/sql/statements/create-index.md
@@ -45,7 +45,7 @@ This statement adds a new index to an existing table. It is an alternative synta
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/create-view.md
+++ b/v3.1/reference/sql/statements/create-view.md
@@ -45,7 +45,7 @@ The `CREATE VIEW` statement saves a `SELECT` statement as a queryable object, si
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/delete.md
+++ b/v3.1/reference/sql/statements/delete.md
@@ -17,7 +17,7 @@ The `DELETE` statement removes rows from a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/drop-column.md
+++ b/v3.1/reference/sql/statements/drop-column.md
@@ -29,7 +29,7 @@ This statement drops a column from a specified table. `DROP COLUMN` is online in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, col1 INT NOT NULL, col2 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, col1 INT NOT NULL, col2 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (col1,col2) VALUES (1,1),(2,2),(3,3),(4,4),(5,5);

--- a/v3.1/reference/sql/statements/drop-index.md
+++ b/v3.1/reference/sql/statements/drop-index.md
@@ -29,7 +29,7 @@ This statement removes an index from a specified table, marking space as free in
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/drop-view.md
+++ b/v3.1/reference/sql/statements/drop-view.md
@@ -25,7 +25,7 @@ This statement drops an view object from the currently selected database. It doe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/explain-analyze.md
+++ b/v3.1/reference/sql/statements/explain-analyze.md
@@ -25,7 +25,7 @@ The `EXPLAIN ANALYZE` statement works similar to `EXPLAIN`, with the major diffe
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.1/reference/sql/statements/explain.md
+++ b/v3.1/reference/sql/statements/explain.md
@@ -36,7 +36,7 @@ mysql> EXPLAIN SELECT 1;
 +-------------------+-------+------+---------------+
 2 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.10 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.1/reference/sql/statements/load-data.md
+++ b/v3.1/reference/sql/statements/load-data.md
@@ -18,7 +18,7 @@ The `LOAD DATA` statement batch loads data into a TiDB table.
 
 ```sql
 mysql> CREATE TABLE trips (
-    ->  trip_id bigint NOT NULL PRIMARY KEY auto_increment,
+    ->  trip_id bigint NOT NULL PRIMARY KEY AUTO_INCREMENT,
     ->  duration integer not null,
     ->  start_date datetime,
     ->  end_date datetime,

--- a/v3.1/reference/sql/statements/modify-column.md
+++ b/v3.1/reference/sql/statements/modify-column.md
@@ -33,7 +33,7 @@ The `ALTER TABLE.. MODIFY COLUMN` statement modifies a column on an existing tab
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (col1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/rename-index.md
+++ b/v3.1/reference/sql/statements/rename-index.md
@@ -21,7 +21,7 @@ The statement `ALTER TABLE .. RENAME INDEX` renames an existing index to a new n
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL, INDEX col1 (c1));
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL, INDEX col1 (c1));
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> SHOW CREATE TABLE t1\G

--- a/v3.1/reference/sql/statements/replace.md
+++ b/v3.1/reference/sql/statements/replace.md
@@ -33,7 +33,7 @@ The `REPLACE` statement is semantically a combined `DELETE`+`INSERT` statement. 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.1/reference/sql/statements/select.md
+++ b/v3.1/reference/sql/statements/select.md
@@ -80,7 +80,7 @@ The `SELECT` statement is used to read data from TiDB.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/show-indexes.md
+++ b/v3.1/reference/sql/statements/show-indexes.md
@@ -33,7 +33,7 @@ The statement `SHOW INDEXES [FROM|IN]` lists the indexes on a specified table.  
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment, col1 INT, INDEX(col1));
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT, col1 INT, INDEX(col1));
 Query OK, 0 rows affected (0.12 sec)
 
 mysql> SHOW INDEXES FROM t1;

--- a/v3.1/reference/sql/statements/show-table-status.md
+++ b/v3.1/reference/sql/statements/show-table-status.md
@@ -25,7 +25,7 @@ This statement shows various statistics about tables in TiDB. If the statistics 
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/trace.md
+++ b/v3.1/reference/sql/statements/trace.md
@@ -38,7 +38,7 @@ mysql> trace format='row' select * from mysql.user;
 +---------------------------+-----------------+------------+
 10 rows in set (0.00 sec)
 
-mysql> CREATE TABLE t1 (id int not null primary key auto_increment);
+mysql> CREATE TABLE t1 (id int not null primary key AUTO_INCREMENT);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 VALUES (1),(2),(3),(4),(5);

--- a/v3.1/reference/sql/statements/update.md
+++ b/v3.1/reference/sql/statements/update.md
@@ -33,7 +33,7 @@ The `UPDATE` statement is used to modify data in a specified table.
 ## Examples
 
 ```sql
-mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY auto_increment, c1 INT NOT NULL);
+mysql> CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, c1 INT NOT NULL);
 Query OK, 0 rows affected (0.11 sec)
 
 mysql> INSERT INTO t1 (c1) VALUES (1), (2), (3);

--- a/v3.1/reference/sql/views.md
+++ b/v3.1/reference/sql/views.md
@@ -20,24 +20,24 @@ Querying a view is similar to querying an ordinary table. However, when TiDB que
 The following example creates a view, queries this view, and delete this view:
 
 ```sql
-tidb> create table t(a int, b int);
+tidb> CREATE TABLE t(a INT, b INT);
 Query OK, 0 rows affected (0.01 sec)
 
-tidb> insert into t values(1, 1),(2,2),(3,3);
+tidb> INSERT INTO t VALUES(1, 1),(2,2),(3,3);
 Query OK, 3 rows affected (0.00 sec)
 Records: 3  Duplicates: 0  Warnings: 0
 
-tidb> create table s(a int);
+tidb> CREATE TABLE s(a INT);
 Query OK, 0 rows affected (0.01 sec)
 
-tidb> insert into s values(2),(3);
+tidb> INSERT INTO s VALUES(2),(3);
 Query OK, 2 rows affected (0.01 sec)
 Records: 2  Duplicates: 0  Warnings: 0
 
-tidb> create view v as select s.a from t left join s on t.a = s.a;
+tidb> CREATE VIEW v AS SELECT s.a FROM t LEFT JOIN s ON t.a = s.a;
 Query OK, 0 rows affected (0.01 sec)
 
-tidb> select * from v;
+tidb> SELECT * FROM v;
 +------+
 | a    |
 +------+
@@ -47,7 +47,7 @@ tidb> select * from v;
 +------+
 3 rows in set (0.00 sec)
 
-tidb> drop view v;
+tidb> DROP VIEW v;
 Query OK, 0 rows affected (0.02 sec)
 ```
 

--- a/v3.1/releases/2.1.16.md
+++ b/v3.1/releases/2.1.16.md
@@ -29,7 +29,7 @@ TiDB Ansible version: 2.1.16
     - Fix the issue that `NULL` is not returned correctly because the value of `YEAR` in the `DATE_ADD`/`DATE_SUB` result overflows when it is smaller than 0 or larger than 65535 [#11477](https://github.com/pingcap/tidb/pull/11477)
     - Add in the slow query table a `Succ` field that indicates whether the execution succeeds [#11412](https://github.com/pingcap/tidb/pull/11421)
     - Fix the MySQL incompatibility issue caused by fetching the current timestamp multiple times when a SQL statement involves calculations of the current time (such as `CURRENT_TIMESTAMP` or `NOW`) [#11392](https://github.com/pingcap/tidb/pull/11392)
-    - Fix the issue that the auto_increment columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
+    - Fix the issue that the AUTO_INCREMENT columns do not handle the FLOAT or DOUBLE type [#11389](https://github.com/pingcap/tidb/pull/11389)
     - Fix the issue that `NULL` is not returned correctly when the `CONVERT_TZ` function accepts an invalid argument [#11357](https://github.com/pingcap/tidb/pull/11357)
     - Fix the issue that an error is reported by the `PARTITION BY LIST` statement. (Currently only the syntax is supported; when TiDB executes the statement, a regular table is created and a prompting message is provided) [#11236](https://github.com/pingcap/tidb/pull/11236)
     - Fix the issue that `Mod(%)`, `Multiple(*)`, and `Minus(-)` operations return an inconsistent `0` result with that in MySQL when there are many decimal digits (such as `select 0.000 % 0.11234500000000000000`) [#11353](https://github.com/pingcap/tidb/pull/11353)

--- a/v3.1/releases/3.0.4.md
+++ b/v3.1/releases/3.0.4.md
@@ -80,7 +80,7 @@ TiDB Ansible version: 3.0.4
     - Fix the issue that the uncommented TiDB-specific syntax `PRE_SPLIT_REGIONS` might cause errors in the downstream database during data replication [#12120](https://github.com/pingcap/tidb/pull/12120)
     - Add the `split-region-max-num` variable in the configuration file so that the maximum allowable number of Regions is adjustable [#12097](https://github.com/pingcap/tidb/pull/12079)
     - Support splitting a Region into multiple Regions and fix the timeout issue during Region scatterings [#12343](https://github.com/pingcap/tidb/pull/12343)
-    - Fix the issue that the `drop index` statement fails when the index that contains an `auto_increment` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
+    - Fix the issue that the `drop index` statement fails when the index that contains an `AUTO_INCREMENT` column referenced by two indexes [#12344](https://github.com/pingcap/tidb/pull/12344)
 - Monitor
     - Add the `connection_transient_failure_count` monitoring metrics to count the number of gRPC connection errors in `tikvclient` [#12093](https://github.com/pingcap/tidb/pull/12093)
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
did: update keyword auto_increment to AUTO_INCREMENT
why: issue: https://github.com/pingcap/docs/issues/699
"In #695 we determined that SQL keywords should be in all caps. There are a number of pages that require updating."
### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
N/A
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev/v1.0/v2.0/v2.1/v2.1-legacy/v3.0/v3.1
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v3.1"/"v2.1" indicates the documentation of TiDB 3.0/3.1-beta/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->
