### PR TITLE
reference/sql: correct description about push_down expression alias before v3.0.3

### DIFF
--- a/dev/reference/sql/functions-and-operators/expressions-pushed-down.md
+++ b/dev/reference/sql/functions-and-operators/expressions-pushed-down.md
@@ -98,31 +98,31 @@ tidb> explain select * from t where a < 2 and a > 2;
 >
 > - `admin reload expr_pushdown_blacklist` only takes effect on the TiDB server that executes this SQL statement. To make it apply to all TiDB servers, execute the SQL statement on each TiDB server.
 > - The feature of blacklisting specific expressions is supported in TiDB 3.0.0 or later versions.
-> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-insensitive) instead, as shown in the following table:
+> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-sensitive) instead, as shown in the following table:
 
 | Operator Name | Aliases |
 | :-------- | :---------- |
-| < | LT |
-| > | GT |
-| <= | LE |
-| >= | GT |
-| = | EQ |
-| != | NE |
-| <> | NE |
-| <=> | NullEQ |
+| < | lt |
+| > | gt |
+| <= | le |
+| >= | ge |
+| = | eq |
+| != | ne |
+| <> | ne |
+| <=> | nulleq |
 | &#124; | bitor |
 | && | bitand|
 | &#124;&#124; | or |
 | ! | not |
-| in | IN |
-| + | PLUS|
-|  - | MINUS |
-| * | MUL |
-|  / | DIV |
-| DIV | INTDIV |
-| IS NULL | ISNULL |
-| IS TRUE | ISTRUE |
-| IS FALSE | ISFALSE |
+| in | in |
+| + | plus|
+| - | minus |
+| * | mul |
+| / | div |
+| DIV | intdiv|
+| IS NULL | isnull |
+| IS TRUE | istrue |
+| IS FALSE | isfalse |
 
 [json_extract]: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-extract
 [json_short_extract]: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-column-path

--- a/v3.0/reference/sql/functions-and-operators/expressions-pushed-down.md
+++ b/v3.0/reference/sql/functions-and-operators/expressions-pushed-down.md
@@ -98,31 +98,31 @@ tidb> explain select * from t where a < 2 and a > 2;
 >
 > - `admin reload expr_pushdown_blacklist` only takes effect on the TiDB server that executes this SQL statement. To make it apply to all TiDB servers, execute the SQL statement on each TiDB server.
 > - The feature of blacklisting specific expressions is supported in TiDB 3.0.0 or later versions.
-> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-insensitive) instead, as shown in the following table:
+> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-sensitive) instead, as shown in the following table:
 
 | Operator Name | Aliases |
 | :-------- | :---------- |
-| < | LT |
-| > | GT |
-| <= | LE |
-| >= | GT |
-| = | EQ |
-| != | NE |
-| <> | NE |
-| <=> | NullEQ |
+| < | lt |
+| > | gt |
+| <= | le |
+| >= | ge |
+| = | eq |
+| != | ne |
+| <> | ne |
+| <=> | nulleq |
 | &#124; | bitor |
 | && | bitand|
 | &#124;&#124; | or |
 | ! | not |
-| in | IN |
-| + | PLUS|
-|  - | MINUS |
-| * | MUL |
-|  / | DIV |
-| DIV | INTDIV |
-| IS NULL | ISNULL |
-| IS TRUE | ISTRUE |
-| IS FALSE | ISFALSE |
+| in | in |
+| + | plus|
+| - | minus |
+| * | mul |
+| / | div |
+| DIV | intdiv|
+| IS NULL | isnull |
+| IS TRUE | istrue |
+| IS FALSE | isfalse |
 
 [json_extract]: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-extract
 [json_short_extract]: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-column-path

--- a/v3.1/reference/sql/functions-and-operators/expressions-pushed-down.md
+++ b/v3.1/reference/sql/functions-and-operators/expressions-pushed-down.md
@@ -98,31 +98,31 @@ tidb> explain select * from t where a < 2 and a > 2;
 >
 > - `admin reload expr_pushdown_blacklist` only takes effect on the TiDB server that executes this SQL statement. To make it apply to all TiDB servers, execute the SQL statement on each TiDB server.
 > - The feature of blacklisting specific expressions is supported in TiDB 3.0.0 or later versions.
-> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-insensitive) instead, as shown in the following table:
+> - TiDB 3.0.3 or earlier versions does not support adding some of the operators (such as ">", "+", "is null") to the blacklist by using their original names. You need to use their aliases (case-sensitive) instead, as shown in the following table:
 
 | Operator Name | Aliases |
 | :-------- | :---------- |
-| < | LT |
-| > | GT |
-| <= | LE |
-| >= | GT |
-| = | EQ |
-| != | NE |
-| <> | NE |
-| <=> | NullEQ |
+| < | lt |
+| > | gt |
+| <= | le |
+| >= | ge |
+| = | eq |
+| != | ne |
+| <> | ne |
+| <=> | nulleq |
 | &#124; | bitor |
 | && | bitand|
 | &#124;&#124; | or |
 | ! | not |
-| in | IN |
-| + | PLUS|
-|  - | MINUS |
-| * | MUL |
-|  / | DIV |
-| DIV | INTDIV |
-| IS NULL | ISNULL |
-| IS TRUE | ISTRUE |
-| IS FALSE | ISFALSE |
+| in | in |
+| + | plus|
+| - | minus |
+| * | mul |
+| / | div |
+| DIV | intdiv|
+| IS NULL | isnull |
+| IS TRUE | istrue |
+| IS FALSE | isfalse |
 
 [json_extract]: https://v3.1.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-extract
 [json_short_extract]: https://v3.1.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-column-path


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->
This PR updates description about pushdown expression alias before v3.0.3.
<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### What is the related PR or file link(s)? <!--Required-->
<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- [ ] Reference link(s):<!--Give links here-->
- [x] This PR is to align with:<!--Give links here-->https://github.com/pingcap/docs-cn/pull/2192 & https://github.com/pingcap/docs-cn/pull/2202
- [ ] N/A (not applicable)

### Which TiDB version(s) does your changes apply to? <!--Required-->

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [ ] All active versions: dev, v3.0, v2.1, v3.1
- [x] dev (the latest development version)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] All active and inactive versions
- [ ] N/A (not applicable)

**Note:** If your changes apply to multiple TiDB versions, make sure you update the documents in the **corresponding** version folders such as "dev", "v3.0", "v2.1" and "v3.1" in this PR.

- [ ] Updated one version first. Will update other versions after I get two LGTMs.