### PR TITLE
reference/tools: remove latest from download document

### DIFF
--- a/reference/tools/download.md
+++ b/reference/tools/download.md
@@ -22,7 +22,7 @@ In addition, the Kafka version of TiDB Binlog is also provided.
 
 > **Note:**
 >
-> `{version}` in the above download link indicates the version number of TiDB. For example, the download link for `v3.0.5` is `https://download.pingcap.org/tidb-v3.0.5-linux-amd64.tar.gz`. You can also download the latest unpublished version by replacing `{version}` with `latest`.
+> `{version}` in the above download link indicates the version number of TiDB. For example, the download link for `v3.0.5` is `https://download.pingcap.org/tidb-v3.0.5-linux-amd64.tar.gz`.
 
 ## TiDB Lightning
 
@@ -34,7 +34,7 @@ Download [TiDB Lightning](/reference/tools/tidb-lightning/overview.md) by using 
 
 > **Note:**
 >
-> `{version}` in the above download link indicates the version number of TiDB Lightning. For example, the download link for `v3.0.5` is `https://download.pingcap.org/tidb-toolkit-v3.0.5-linux-amd64.tar.gz`. You can also download the latest unpublished version by replacing `{version}` with `latest`.
+> `{version}` in the above download link indicates the version number of TiDB Lightning. For example, the download link for `v3.0.5` is `https://download.pingcap.org/tidb-toolkit-v3.0.5-linux-amd64.tar.gz`.
 
 ## TiDB DM (Data Migration)
 
@@ -46,7 +46,7 @@ Download [DM](/reference/tools/data-migration/overview.md) by using the download
 
 > **Note:**
 >
-> `{version}` in the above download link indicates the version number of DM. For example, the download link for `v1.0.1` is `https://download.pingcap.org/dm-v1.0.1-linux-amd64.tar.gz`. You can check the published DM versions in the [DM Release](https://github.com/pingcap/dm/releases) page. You can also download the latest unpublished version by replacing `{version}` with `latest`.
+> `{version}` in the above download link indicates the version number of DM. For example, the download link for `v1.0.1` is `https://download.pingcap.org/dm-v1.0.1-linux-amd64.tar.gz`. You can check the published DM versions in the [DM Release](https://github.com/pingcap/dm/releases) page.
 
 ## Syncer, Loader, and Mydumper
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

Remove the latest version from the download document.

Some users use the latest version, but the latest version is built from our develop branch, which is unstable and may be incompatible with the release version. We don't suggest users use the latest version.

### What is the related PR or file link(s)? <!--Required-->

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- Reference link(s):<!--Give links here-->
- This PR is to align with:<!--Give links here--> https://github.com/pingcap/docs-cn/pull/2296
- [ ] N/A (not applicable)

**Important Notice:**

**If your changes apply to multiple TiDB documentation versions**, to trigger the bot to cherry-pick this PR to other release branches, make sure you add labels such as:

- **needs-cherry-pick-3.0**
- **needs-cherry-pick-3.1**
- **needs-cherry-pick-2.1**
