### PR TITLE
Add note about not supporting multiple ALTER TABLE operations

### DIFF
--- a/reference/mysql-compatibility.md
+++ b/reference/mysql-compatibility.md
@@ -102,6 +102,7 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
     - Only supports changing the `CHARACTER SET` attribute from `utf8` to `utf8mb4`.
 + `LOCK [=] {DEFAULT|NONE|SHARED|EXCLUSIVE}`: the syntax is supported, but is not applicable to TiDB. All DDL changes that are supported do not lock the table.
 + `ALGORITHM [=] {DEFAULT|INSTANT|INPLACE|COPY}`: the syntax for `ALGORITHM=INSTANT` and `ALGORITHM=INPLACE` is fully supported, but it works differently from MySQL because some operations that are `INPLACE` in MySQL are `INSTANT` in TiDB. The syntax `ALGORITHM=COPY` is not applicable to TIDB and returns a warning.
++ Multiple operations cannot be completed in a single `ALTER TABLE` statement. For example, it's not possible to add multiple columns or indexes in a single statement.
 
 + The following Table Options are not supported in syntax:
     - `WITH/WITHOUT VALIDATION`


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->

Added a note about ALTER TABLE in TiDB not supporting multiple ALTER operations in a single statement.

