### PR TITLE
 reference/performance: Fix `EXPLAIN ANALYZE output format`. 

### DIFF
--- a/reference/performance/understanding-the-query-execution-plan.md
+++ b/reference/performance/understanding-the-query-execution-plan.md
@@ -76,7 +76,7 @@ As an extension to `EXPLAIN`, `EXPLAIN ANALYZE` will execute the query and provi
 
 * `loops` is the number of times the operator was called from the parent operator.
 
-* `rows` is the total number of rows that were returned by this operator. So for example, you can compare the accuracy of the `count` column to `rows`/`loops` in the `execution_info` column to assess how accurate the query optimizer's estimations are.
+* `rows` is the total number of rows that were returned by this operator. So for example, you can compare the accuracy of the `count` column to `rows` in the `execution_info` column to assess how accurate the query optimizer's estimations are.
 
 ### Example usage
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->

In `explain analyze` statements, `count` should be compared to `rows`, instead of `rows/loops`.

This PR fixed it.
