### PR TITLE
change default value for tidb_ddl_reorg_worker_cnt and tidb_ddl_reorg_batch_size

### DIFF
--- a/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -268,14 +268,14 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 - Scope: GLOBAL
 - Default value(before 2.1.17): 16
-- Default value(2.1.17): 4
+- Default value(in 2.1.17 or later): 4
 - This variable is used to set the concurrency of the DDL operation in the `re-organize` phase.
 
 ### tidb_ddl_reorg_batch_size
 
 - Scope: GLOBAL
 - Default value(before 2.1.17): 1024
-- Default value(2.1.17): 256
+- Default value(in 2.1.17 or later): 256
 - This variable is used to set the batch size during the `re-organize` phase of the DDL operation. For example, when TiDB executes the `ADD INDEX` operation, the index data needs to backfilled by `tidb_ddl_reorg_worker_cnt` (the number) concurrent workers. Each worker backfills the index data in batches.
     - If many updating operations such as `UPDATE` and `REPLACE` exist during the `ADD INDEX` operation, a larger batch size indicates a larger probability of transaction conflicts. In this case, you need to adjust the batch size to a smaller value. The minimum value is 32.
     - If the transaction conflict does not exist, you can set the batch size to a large value. The maximum value is 10240. This can increase the speed of the backfilling data, but the write pressure on TiKV also becomes higher.

--- a/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -267,13 +267,15 @@ set @@global.tidb_distsql_scan_concurrency = 10
 ### tidb_ddl_reorg_worker_cnt
 
 - Scope: GLOBAL
-- Default value: 16
+- Default value(before 2.1.17): 16
+- Default value(2.1.17): 4
 - This variable is used to set the concurrency of the DDL operation in the `re-organize` phase.
 
 ### tidb_ddl_reorg_batch_size
 
 - Scope: GLOBAL
-- Default value: 1024
+- Default value(before 2.1.17): 1024
+- Default value(2.1.17): 256
 - This variable is used to set the batch size during the `re-organize` phase of the DDL operation. For example, when TiDB executes the `ADD INDEX` operation, the index data needs to backfilled by `tidb_ddl_reorg_worker_cnt` (the number) concurrent workers. Each worker backfills the index data in batches.
     - If many updating operations such as `UPDATE` and `REPLACE` exist during the `ADD INDEX` operation, a larger batch size indicates a larger probability of transaction conflicts. In this case, you need to adjust the batch size to a smaller value. The minimum value is 32.
     - If the transaction conflict does not exist, you can set the batch size to a large value. The maximum value is 10240. This can increase the speed of the backfilling data, but the write pressure on TiKV also becomes higher.

--- a/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -267,15 +267,15 @@ set @@global.tidb_distsql_scan_concurrency = 10
 ### tidb_ddl_reorg_worker_cnt
 
 - Scope: GLOBAL
-- Default value(before 2.1.17): 16
-- Default value(in 2.1.17 or later): 4
+- Default value (before 2.1.17): 16
+- Default value (in 2.1.17 or later): 4
 - This variable is used to set the concurrency of the DDL operation in the `re-organize` phase.
 
 ### tidb_ddl_reorg_batch_size
 
 - Scope: GLOBAL
-- Default value(before 2.1.17): 1024
-- Default value(in 2.1.17 or later): 256
+- Default value (before 2.1.17): 1024
+- Default value (in 2.1.17 or later): 256
 - This variable is used to set the batch size during the `re-organize` phase of the DDL operation. For example, when TiDB executes the `ADD INDEX` operation, the index data needs to backfilled by `tidb_ddl_reorg_worker_cnt` (the number) concurrent workers. Each worker backfills the index data in batches.
     - If many updating operations such as `UPDATE` and `REPLACE` exist during the `ADD INDEX` operation, a larger batch size indicates a larger probability of transaction conflicts. In this case, you need to adjust the batch size to a smaller value. The minimum value is 32.
     - If the transaction conflict does not exist, you can set the batch size to a large value. The maximum value is 10240. This can increase the speed of the backfilling data, but the write pressure on TiKV also becomes higher.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
```
change tidb_ddl_reorg_worker_cnt 's default value from 16 to 4
change tidb_ddl_reorg_batch_size 's default value from 1024 to 256
```

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB version(s) do your changes apply to? (Required)
```
tidb_ddl_reorg_worker_cnt 's default value is 4
tidb_ddl_reorg_batch_size 's default value is 256 
```

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [ ] master (the latest development version, including v4.0 changes for now)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ✅] v2.1 (TiDB 2.1 versions)

