### PR TITLE
TOC: fix a wrong link for DM relay log

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -322,7 +322,7 @@
         - [DM Overview](/reference/tools/data-migration/overview.md)
         - [Restrictions](/reference/tools/data-migration/overview.md#usage-restrictions)
         - [DM-worker](/reference/tools/data-migration/dm-worker-intro.md)
-        - [DM Relay Log](/reference/tools/data-migration/dm-worker-intro.md)
+        - [DM Relay Log](/reference/tools/data-migration/relay-log.md)
       + Features
         - [Table Routing](/reference/tools/data-migration/features/overview.md#table-routing)
         - [Black and White Lists](/reference/tools/data-migration/features/overview.md#black-and-white-table-lists)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

Fix a wrong link in TOC for DM relay log.

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version, including v4.0 changes for now)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

N/A