### PR TITLE
TiFlash: Explain how to set query tso to 1 second earlier

### DIFF
--- a/reference/tiflash/maintain.md
+++ b/reference/tiflash/maintain.md
@@ -110,7 +110,7 @@ This is because TiFlash is in an abnormal state caused by configuration errors o
 
 This is because large amounts of data are written to the cluster, which causes that the TiFlash query encounters a lock and requires query retry.
 
-You can set the query timestamp to one second earlier in TiDB (for example, `set @@tidb_snapshot=412881237115666555;`). This makes less TiFlash queries encounter a lock and mitigates the risk of unstable query time.
+You can set the query timestamp to one second earlier in TiDB. For example, if the current time is '2020-04-08 20:15:01', you can execute `set @@tidb_snapshot='2020-04-08 20:15:00';` before you execute the query. This makes less TiFlash queries encounter a lock and mitigates the risk of unstable query time.
 
 ### Some queries return the `Region Unavailable` error
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

Explain how to set query tso to 1 second earlier

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-4.0**, **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/2659
- Other reference link(s):<!--Give links here-->
