### PR TITLE
reference/performance: specify index name of primary key for USE_INDEX_MERGE

### DIFF
--- a/reference/performance/optimizer-hints.md
+++ b/reference/performance/optimizer-hints.md
@@ -192,7 +192,7 @@ select /*+ USE_INDEX_MERGE(t1, idx_a, idx_b, idx_c) */ * from t t1 where t1.a > 
 
 > **Note:**
 >
-> The parameters of `USE_INDEX_MERGE` refer to index names, rather than column names. The index name of the primary key index is `primary`.
+> The parameters of `USE_INDEX_MERGE` refer to index names, rather than column names. The index name of the primary key is `primary`.
 
 ### NO_INDEX_MERGE()
 

--- a/reference/performance/optimizer-hints.md
+++ b/reference/performance/optimizer-hints.md
@@ -190,6 +190,10 @@ The `USE_INDEX_MERGE(t1_name, idx1_name [, idx2_name ...])` hint tells the optim
 select /*+ USE_INDEX_MERGE(t1, idx_a, idx_b, idx_c) */ * from t t1 where t1.a > 10 or t1.b > 10;
 ```
 
+> **Note:**
+>
+> The parameters of `USE_INDEX_MERGE` refer to index names, rather than column names. The index name of the primary key index is `primary`.
+
 ### NO_INDEX_MERGE()
 
 The `NO_INDEX_MERGE()` hint disables the index merge feature of the optimizer.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

Add a note to specify index name of primary key for USE_INDEX_MERGE

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-4.0**, **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/2350
- Other reference link(s):<!--Give links here-->
