### PR TITLE
tiup: update the default value for `readpool.storage.use-unified-pool`

### DIFF
--- a/how-to/deploy/orchestrated/tiup.md
+++ b/how-to/deploy/orchestrated/tiup.md
@@ -347,6 +347,7 @@ monitored:
   # deploy_dir: "/tidb-deploy/monitored-9100"
   # data_dir: "/tidb-data/monitored-9100"
   # log_dir: "/tidb-deploy/monitored-9100/log"
+
 # # Server configs are used to specify the runtime configuration of TiDB components.
 # # All configuration items can be found in TiDB docs:
 # # - TiDB: https://pingcap.com/docs/stable/reference/configuration/tidb-server/configuration-file/
@@ -369,7 +370,7 @@ server_configs:
     # rocksdb.max-sub-compactions: 1
     # storage.block-cache.capacity: "16GB"
     # readpool.unified.max-thread-count: 12
-    readpool.storage.use-unified-pool: true
+    readpool.storage.use-unified-pool: false
     readpool.coprocessor.use-unified-pool: true
   pd:
     schedule.leader-schedule-limit: 4
@@ -523,12 +524,12 @@ You need to fill in the result in the configuration file (as described in the St
 
 - Configuration optimization for TiKV
 
-    - Make `readpool` thread pool self-adaptive. Configure the `readpool.unified.max-thread-count` parameter to make `readpool.storage` and `readpool.coprocessor` share a unified thread pool, and also enable self-adaptive switches for them.
+    - Make `readpool` thread pool self-adaptive. Configure the `readpool.unified.max-thread-count` parameter to make `readpool.storage` and `readpool.coprocessor` share a unified thread pool, and also set self-adaptive switches for them respectively.
 
         - Enable `readpool.storage` and `readpool.coprocessor`:
 
             ```yaml
-            readpool.storage.use-unified-pool: true
+            readpool.storage.use-unified-pool: false
             readpool.coprocessor.use-unified-pool: true
             ```
 
@@ -638,7 +639,7 @@ monitored:
 server_configs:
   tikv:
     readpool.unified.max-thread-count: <fill in the calculated result from the calculation formula provided before>
-    readpool.storage.use-unified-pool: true
+    readpool.storage.use-unified-pool: false
     readpool.coprocessor.use-unified-pool: true
     storage.block-cache.capacity: "<fill in the calculated result from the calculation formula provided before>"
     raftstore.capacity: "<fill in the calculated result from the calculation formula provided before>"
@@ -1308,7 +1309,7 @@ tidb_servers:
       # rocksdb.max-sub-compactions: 1
       # storage.block-cache.capacity: "16GB"
       # readpool.unified.max-thread-count: 12
-      readpool.storage.use-unified-pool: true
+      readpool.storage.use-unified-pool: false
       readpool.coprocessor.use-unified-pool: true
     pd:
       schedule.leader-schedule-limit: 4

--- a/quick-start-with-tidb.md
+++ b/quick-start-with-tidb.md
@@ -206,7 +206,7 @@ Other requirements for the deployment machine:
      tidb:
        log.slow-threshold: 300
      tikv:
-       readpool.storage.use-unified-pool: true
+       readpool.storage.use-unified-pool: false
        readpool.coprocessor.use-unified-pool: true
      pd:
        replication.enable-placement-rules: true


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->
Update the default value for `readpool.storage.use-unified-pool`

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-4.0**, **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here-->https://github.com/pingcap/docs-cn/pull/2877
- Other reference link(s):<!--Give links here-->
