### PR TITLE
tidb-binlog: remove config of reparo

### DIFF
--- a/reference/tidb-binlog/reparo.md
+++ b/reference/tidb-binlog/reparo.md
@@ -58,12 +58,6 @@ Usage of Reparo:
 # The storage directory for the binlog file in the protobuf format that Drainer outputs
 data-dir = "./data.drainer"
 
-# Uses the index file to locate `ts`. Set this parameter if `start-ts` is set. The file
-# directory is {data-dir}/{index-name}.
-# index-name = "binlog.index"
-# log-file = ""
-# log-rotate = "hour"
-
 # The level of the output information of logs
 # Value: "debug"/"info"/"warn"/"error"/"fatal" ("info" by default)
 log-level = "info"


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

Remove useless config of reparo from `reference/tidb-binlog/reparo.md`

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-4.0**, **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/2828
- Other reference link(s):<!--Give links here-->
