### PR TITLE
reference: remove limit of adding index on generated columns

### DIFF
--- a/reference/mysql-compatibility.md
+++ b/reference/mysql-compatibility.md
@@ -112,7 +112,6 @@ In TiDB DDL does not block reads or writes to tables while in operation. However
 + Add Index:
     - Does not support creating multiple indexes at the same time.
     - Does not support the `VISIBLE/INVISIBLE` index.
-    - Adding an index on a generated column via `ALTER TABLE` is not supported.
     - Other Index Type (HASH/BTREE/RTREE) is supported in syntax, but not applicable.
 + Add Column:
     - Does not support creating multiple columns at the same time.


### PR DESCRIPTION

<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->
Remove the limit of adding index on generated columns.

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-4.0**, **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here--> https://github.com/pingcap/docs-cn/pull/2988 https://github.com/pingcap/docs-cn/pull/2989
- Other reference link(s):<!--Give links here-->
