### PR TITLE
add auto assign reviewer github action

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -35,4 +35,4 @@
 # Changing all md files should request a language review in case of format failures.
 # TomShawn is the repo administrator.
 '*.*':
-  - TomShawn
+  - yikeke

--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,0 +1,38 @@
+---
+# you can use glob pattern
+
+# You can set multiple reviewers
+# '.github/':
+#   - yikeke
+#   - ran-huang
+
+# 'tiflash/':
+#   - zanmato1984
+#   - kissmydb
+#   - yikeke
+
+# 'tiup/':
+#   - lonng
+#   - lucklove
+#   - kissmydb
+#   - yikeke
+
+# 'sql-statements/':
+#   - bb7133
+
+# 'releases/':
+#   - scsldb
+
+# 'dashboard/':
+#   - breeswish
+
+# 'config-templates/':
+#   - kissmydb
+
+# 'ticdc/':
+#   - WangXiangUSTC
+
+# Changing all md files should request a language review in case of format failures.
+# TomShawn is the repo administrator.
+'*.*':
+  - TomShawn

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,15 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened]
+
+jobs:
+  assign_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: shufo/auto-assign-reviewer-by-files@v1.0.0
+      with:
+        config: '.github/assign-by-files.yml'
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

makes yikeke the default reviewer for all prs in docs repo

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/3637
- Other reference link(s):
