### PR TITLE
auto assign reviewer github action in relase-* branches

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,16 @@
+---
+# when the issuer is not a bot, assign yikeke as reviewer
+((?!sre-bot).)*:
+  - yikeke
+
+# # you can set multiple reviewers
+# smith:
+#   - user1
+#   - user2
+# # you can use regexp to match issuer
+# john.*:
+#   - foo
+#   - bar
+# # fallback
+# .*:
+#   - foo

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -2,6 +2,7 @@
 # when the issuer is not a bot, assign yikeke as reviewer
 ((?!sre-bot).)*:
   - yikeke
+  - TomShawn
 
 # # you can set multiple reviewers
 # smith:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,6 +1,6 @@
 ---
 # when the issuer is not a bot, assign yikeke as reviewer
-((?!sre-bot).)*:
+^(?!sre-bot)$:
   - yikeke
   - TomShawn
 

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,15 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    branches:
+      - release-*
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: shufo/auto-assign-reviewer-by-issuer@v1.0.0
+      with:
+        config: '.github/reviewers.yml'
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - release-*
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
   assign:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: 
- Other reference link(s): https://github.com/pingcap/docs/pull/2854

Add github action https://github.com/marketplace/actions/auto-assign-reviewer-by-issuer
