### PR TITLE
fix auto assign reviewers github action

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,38 +1,111 @@
 ---
+# Changing all md files should request a language review in case of format failures.
+# TomShawn is the repo administrator.
+
 # you can use glob pattern
 
 # You can set multiple reviewers
-# '.github/':
-#   - yikeke
-#   - ran-huang
-
-# 'tiflash/':
-#   - zanmato1984
-#   - kissmydb
-#   - yikeke
-
-# 'tiup/':
-#   - lonng
-#   - lucklove
-#   - kissmydb
-#   - yikeke
-
-# 'sql-statements/':
-#   - bb7133
-
-# 'releases/':
-#   - scsldb
-
-# 'dashboard/':
-#   - breeswish
-
-# 'config-templates/':
-#   - kissmydb
-
-# 'ticdc/':
-#   - WangXiangUSTC
-
-# Changing all md files should request a language review in case of format failures.
-# TomShawn is the repo administrator.
-'*.*':
+'.github/**/*.yml':
   - yikeke
+  - ran-huang
+
+# 'benchmark/**/*.md':
+#   - jackysp
+#   - kissmydb
+#   - TomShawn
+
+'best-practices/**/*.md':
+  - kissmydb
+  - lilin90
+  - TomShawn
+
+'br/**/*.md':
+  - kissmydb
+  - WangXiangUSTC
+  - TomShawn
+
+'config-templates/**/*.yaml':
+  - kissmydb
+  - superlzs0476
+  - TomShawn
+
+'dashboard/**/*.md':
+  - breeswish
+  - hundundm
+  - kissmydb
+  - TomShawn
+
+'faq/**/*.md':
+  - kissmydb
+  - TomShawn
+
+# 'functions-and-operators/**/*.md':
+#   - kissmydb
+#   - TomShawn
+
+# 'media/**/*':
+#   - TomShawn
+#   - lilin90
+
+'releases/**/*.md':
+  - scsldb
+  - uglyengineer
+  - TomShawn
+
+'resources/**/*':
+  - yikeke
+  - lilin90
+
+'scripts/**/*':
+  - yikeke
+  - lilin90
+
+'sql-statements/**/*.md':
+  - bb7133
+  - zimulala
+  - TomShawn
+
+# 'storage-engine/**/*.md':
+#   - TomShawn
+#   - 
+
+# 'sync-diff-inspector/**/*.md':
+#   - TomShawn
+#   - 
+
+# 'system-tables/**/*.md':
+#   - TomShawn
+#   - 
+
+'ticdc/**/*.md':
+  - WangXiangUSTC
+  - 3pointer
+  - kissmydb
+  - TomShawn
+
+'tidb-binlog/**/*.md':
+  - july2993
+  - kissmydb
+  - TomShawn
+
+'tidb-lightning/**/*.md':
+  - WangXiangUSTC
+  - kissmydb
+  - TomShawn
+
+'tiflash/**/*.md':
+  - ilovesoup
+  - zanmato1984
+  - kissmydb
+  - yikeke
+
+'tiup/**/*.md':
+  - lonng
+  - lucklove
+  - kissmydb
+  - yikeke
+
+# All other file pattern will match the following:
+
+'**/*':
+  - TomShawn

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,7 +9,7 @@ jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
     steps:
-    - uses: shufo/auto-assign-reviewer-by-files@v1.0.0
+    - uses: shufo/auto-assign-reviewer-by-files@v1.1.1
       with:
         config: '.github/assign-by-files.yml'
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/3649, https://github.com/pingcap/docs-cn/pull/3778
- Other reference link(s):
