### PR TITLE
tools: update master/slave to primary/secondary for binlog and sync-diff-inspector

### DIFF
--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -18,7 +18,7 @@ mysql> select * from tidb_binlog.checkpoint;
 +---------------------+---------------------------------------------------------------------------------------------------------+
 | clusterID           | checkPoint                                                                                              |
 +---------------------+---------------------------------------------------------------------------------------------------------+
-| 6711243465327639221 | {"commitTS":409622383615541249,"ts-map":{"master-ts":409621863377928194,"slave-ts":409621863377928345}} |
+| 6711243465327639221 | {"commitTS":409622383615541249,"ts-map":{"primary-ts":409621863377928194,"secondary-ts":409621863377928345}} |
 +---------------------+---------------------------------------------------------------------------------------------------------+
 ```
 
@@ -39,7 +39,7 @@ Here is a configuration example of the `Databases config` section:
     password = "123456"
     # The instance ID of the source database, the unique identifier of a database instance
     instance-id = "source-1"
-    # Uses the snapshot function of TiDB, corresponding to the master-ts in ts-map
+    # Uses the snapshot function of TiDB, corresponding to the primary-ts in ts-map
     snapshot = "409621863377928194"
 
 # Configuration of the target database instance
@@ -48,7 +48,7 @@ Here is a configuration example of the `Databases config` section:
     port = 4001
     user = "root"
     password = "123456"
-    # Uses the snapshot function of TiDB, corresponding to the slave-ts in ts-map
+    # Uses the snapshot function of TiDB, corresponding to the secondary-ts in ts-map
     snapshot = "409621863377928345"
 ```
 
@@ -56,3 +56,4 @@ Here is a configuration example of the `Databases config` section:
 >
 > - Set `db-type` of Drainer to `tidb` to ensure that `ts-map` is saved in the checkpoint.
 > - Modify the Garbage Collection (GC) time of TiKV to ensure that the historical data corresponding to snapshot is not collected by GC during the data check. It is recommended that you modify the GC time to 1 hour and recover the setting after the check.
+> - In some versions of TiDB-Binlog, `master-ts` and `slave-ts` are stored in  `ts-map`, and `master-ts` is equivalent to `primary-ts`, and `slave-ts` is equivalent to `secondary-ts`.

--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -56,4 +56,4 @@ Here is a configuration example of the `Databases config` section:
 >
 > - Set `db-type` of Drainer to `tidb` to ensure that `ts-map` is saved in the checkpoint.
 > - Modify the Garbage Collection (GC) time of TiKV to ensure that the historical data corresponding to snapshot is not collected by GC during the data check. It is recommended that you modify the GC time to 1 hour and recover the setting after the check.
-> - In some versions of TiDB-Binlog, `master-ts` and `slave-ts` are stored in  `ts-map`, and `master-ts` is equivalent to `primary-ts`, and `slave-ts` is equivalent to `secondary-ts`.
+> - In some versions of TiDB-Binlog, `master-ts` and `slave-ts` are stored in `ts-map`, and `master-ts` is equivalent to `primary-ts`, and `slave-ts` is equivalent to `secondary-ts`.

--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -56,4 +56,4 @@ Here is a configuration example of the `Databases config` section:
 >
 > - Set `db-type` of Drainer to `tidb` to ensure that `ts-map` is saved in the checkpoint.
 > - Modify the Garbage Collection (GC) time of TiKV to ensure that the historical data corresponding to snapshot is not collected by GC during the data check. It is recommended that you modify the GC time to 1 hour and recover the setting after the check.
-> - In some versions of TiDB-Binlog, `master-ts` and `slave-ts` are stored in `ts-map`, and `master-ts` is equivalent to `primary-ts`, and `slave-ts` is equivalent to `secondary-ts`.
+> - In some versions of TiDB Binlog, `master-ts` and `slave-ts` are stored in `ts-map`. `master-ts` is equivalent to `primary-ts` and `slave-ts` is equivalent to `secondary-ts`.


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

update master/slave to primary/secondary for binlog and sync-diff-inspector

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- Other reference link(s): https://github.com/pingcap/tidb-binlog/pull/982
