### PR TITLE
add old website aliases to all files in docs release-3.1 branch

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -2,6 +2,7 @@
 title: TiDB Introduction
 summary: Learn how to quickly start a TiDB cluster.
 category: introduction
+aliases: ['/docs/v3.1/_index/']
 ---
 
 # TiDB Introduction

--- a/adopters.md
+++ b/adopters.md
@@ -3,6 +3,7 @@ title: TiDB Adopters
 summary: Learn about the list of TiDB adopters in various industries.
 category: adopters
 i18n_link: "https://pingcap.com/cases-cn/"
+aliases: ['/docs/v3.1/adopters/']
 ---
 
 # TiDB Adopters

--- a/alert-rules.md
+++ b/alert-rules.md
@@ -2,7 +2,7 @@
 title: TiDB Cluster Alert Rules
 summary: Learn the alert rules in a TiDB cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/alert-rules/']
+aliases: ['/docs/v3.1/alert-rules/','/docs/v3.1/reference/alert-rules/']
 ---
 
 <!-- markdownlint-disable MD024 -->

--- a/architecture.md
+++ b/architecture.md
@@ -2,6 +2,7 @@
 title: TiDB Architecture
 summary: The key architecture components of the TiDB platform
 category: introduction
+aliases: ['/docs/v3.1/architecture/']
 ---
 
 # TiDB Architecture

--- a/auto-random.md
+++ b/auto-random.md
@@ -2,7 +2,7 @@
 title: AUTO_RANDOM
 summary: Learn the AUTO_RANDOM attribute.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/attributes/auto-random/']
+aliases: ['/docs/v3.1/auto-random/','/docs/v3.1/reference/sql/attributes/auto-random/']
 ---
 
 # AUTO_RANDOM <span class="version-mark">New in v3.1.0</span>

--- a/backup-and-restore-using-mydumper-lightning.md
+++ b/backup-and-restore-using-mydumper-lightning.md
@@ -1,7 +1,7 @@
 ---
 title: Use Mydumper and TiDB Lightning for Backup and Restoration
 category: how-to
-aliases: ['/docs/v3.1/how-to/maintain/backup-and-restore/mydumper-lightning/','/docs/v3.1/how-to/maintain/backup-and-restore/']
+aliases: ['/docs/v3.1/backup-and-restore-using-mydumper-lightning/','/docs/v3.1/how-to/maintain/backup-and-restore/mydumper-lightning/','/docs/v3.1/how-to/maintain/backup-and-restore/']
 ---
 
 # Use Mydumper and TiDB Lightning for Data Backup and Restoration

--- a/basic-sql-operations.md
+++ b/basic-sql-operations.md
@@ -2,7 +2,7 @@
 title: Explore SQL with TiDB
 summary: Learn about the basic SQL statements for the TiDB database.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/explore-sql/']
+aliases: ['/docs/v3.1/basic-sql-operations/','/docs/v3.1/how-to/get-started/explore-sql/']
 ---
 
 # Explore SQL with TiDB

--- a/benchmark/benchmark-tidb-using-sysbench.md
+++ b/benchmark/benchmark-tidb-using-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: How to Test TiDB Using Sysbench
 category: benchmark
-aliases: ['/docs/v3.1/benchmark/how-to-run-sysbench/']
+aliases: ['/docs/v3.1/benchmark/benchmark-tidb-using-sysbench/','/docs/v3.1/benchmark/how-to-run-sysbench/']
 ---
 
 # How to Test TiDB Using Sysbench

--- a/benchmark/benchmark-tidb-using-tpcc.md
+++ b/benchmark/benchmark-tidb-using-tpcc.md
@@ -1,7 +1,7 @@
 ---
 title: How to Run TPC-C Test on TiDB
 category: benchmark
-aliases: ['/docs/v3.1/benchmark/how-to-run-tpcc/']
+aliases: ['/docs/v3.1/benchmark/benchmark-tidb-using-tpcc/','/docs/v3.1/benchmark/how-to-run-tpcc/']
 ---
 
 # How to Run TPC-C Test on TiDB

--- a/benchmark/online-workloads-and-add-index-operations.md
+++ b/benchmark/online-workloads-and-add-index-operations.md
@@ -2,7 +2,7 @@
 title: Interaction Test on Online Workloads and ADD INDEX Operations
 summary: This document tests the interaction effects between online workloads and `ADD INDEX` operations.
 category: benchmark
-aliases: ['/docs/v3.1/benchmark/add-index-with-load/']
+aliases: ['/docs/v3.1/benchmark/online-workloads-and-add-index-operations/','/docs/v3.1/benchmark/add-index-with-load/']
 ---
 
 # Interaction Test on Online Workloads and `ADD INDEX` Operations

--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1
 category: benchmark
-aliases: ['/docs/v3.1/benchmark/sysbench-v4/']
+aliases: ['/docs/v3.1/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.1/benchmark/sysbench-v4/']
 ---
 
 # TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v3.0-performance-benchmarking-with-tpcc.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB TPC-C Performance Test Report -- v3.0 vs. v2.1
 category: benchmark
-aliases: ['/docs/v3.1/benchmark/tpcc/']
+aliases: ['/docs/v3.1/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/v3.1/benchmark/tpcc/']
 ---
 
 # TiDB TPC-C Performance Test Report -- v3.0 vs. v2.1

--- a/best-practices/grafana-monitor-best-practices.md
+++ b/best-practices/grafana-monitor-best-practices.md
@@ -2,7 +2,7 @@
 title: Best Practices for Monitoring TiDB Using Grafana
 summary: Learn seven tips for efficiently using Grafana to monitor TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/grafana-monitor/']
+aliases: ['/docs/v3.1/best-practices/grafana-monitor-best-practices/','/docs/v3.1/reference/best-practices/grafana-monitor/']
 ---
 
 # Best Practices for Monitoring TiDB Using Grafana

--- a/best-practices/haproxy-best-practices.md
+++ b/best-practices/haproxy-best-practices.md
@@ -2,7 +2,7 @@
 title: Best Practices for Using HAProxy in TiDB
 summary: This document describes best practices for configuration and usage of HAProxy in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/haproxy/']
+aliases: ['/docs/v3.1/best-practices/haproxy-best-practices/','/docs/v3.1/reference/best-practices/haproxy/']
 ---
 
 # Best Practices for Using HAProxy in TiDB

--- a/best-practices/high-concurrency-best-practices.md
+++ b/best-practices/high-concurrency-best-practices.md
@@ -2,7 +2,7 @@
 title: Highly Concurrent Write Best Practices
 summary: Learn best practices for highly-concurrent write-intensive workloads in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/high-concurrency/']
+aliases: ['/docs/v3.1/best-practices/high-concurrency-best-practices/','/docs/v3.1/reference/best-practices/high-concurrency/']
 ---
 
 # Highly Concurrent Write Best Practices

--- a/best-practices/java-app-best-practices.md
+++ b/best-practices/java-app-best-practices.md
@@ -2,7 +2,7 @@
 title: Best Practices for Developing Java Applications with TiDB
 summary: Learn the best practices for developing Java applications with TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/java-app/']
+aliases: ['/docs/v3.1/best-practices/java-app-best-practices/','/docs/v3.1/reference/best-practices/java-app/']
 ---
 
 # Best Practices for Developing Java Applications with TiDB

--- a/best-practices/massive-regions-best-practices.md
+++ b/best-practices/massive-regions-best-practices.md
@@ -2,7 +2,7 @@
 title: Best Practices for TiKV Performance Tuning with Massive Regions
 summary: Learn how to tune the performance of TiKV with a massive amount of Regions.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/massive-regions/']
+aliases: ['/docs/v3.1/best-practices/massive-regions-best-practices/','/docs/v3.1/reference/best-practices/massive-regions/']
 ---
 
 # Best Practices for TiKV Performance Tuning with Massive Regions

--- a/best-practices/pd-scheduling-best-practices.md
+++ b/best-practices/pd-scheduling-best-practices.md
@@ -2,7 +2,7 @@
 title: PD Scheduling Best Practices
 summary: Learn best practice and strategy for PD scheduling.
 category: reference
-aliases: ['/docs/v3.1/reference/best-practices/pd-scheduling/']
+aliases: ['/docs/v3.1/best-practices/pd-scheduling-best-practices/','/docs/v3.1/reference/best-practices/pd-scheduling/']
 ---
 
 # PD Scheduling Best Practices

--- a/br/backup-and-restore-faq.md
+++ b/br/backup-and-restore-faq.md
@@ -2,6 +2,7 @@
 title: Backup & Restore FAQ
 summary: Learn about Frequently Asked Questions (FAQ) and the solutions of BR.
 category: FAQ
+aliases: ['/docs/v3.1/br/backup-and-restore-faq/']
 ---
 
 # Backup & Restore FAQ

--- a/br/backup-and-restore-tool.md
+++ b/br/backup-and-restore-tool.md
@@ -2,7 +2,7 @@
 title: Use BR to Back up and Restore Data
 summary: Learn how to back up and restore data of the TiDB cluster using BR.
 category: how-to
-aliases: ['/docs/v3.1/reference/tools/br/br/','/docs/v3.1/how-to/maintain/backup-and-restore/br/']
+aliases: ['/docs/v3.1/br/backup-and-restore-tool/','/docs/v3.1/reference/tools/br/br/','/docs/v3.1/how-to/maintain/backup-and-restore/br/']
 ---
 
 # Use BR to Back up and Restore Data

--- a/br/backup-and-restore-use-cases.md
+++ b/br/backup-and-restore-use-cases.md
@@ -2,7 +2,7 @@
 title: BR Usage Scenarios
 summary: Learn the scenarios of backing up and restoring data using BR.
 category: how-to
-aliases: ['/docs/v3.1/reference/tools/br/use-cases/']
+aliases: ['/docs/v3.1/br/backup-and-restore-use-cases/','/docs/v3.1/reference/tools/br/use-cases/']
 ---
 
 # BR Usage Scenarios

--- a/certificate-authentication.md
+++ b/certificate-authentication.md
@@ -2,7 +2,7 @@
 title: Certificate-Based Authentication for Login
 summary: Learn the certificate-based authentication used for login.
 category: reference
-aliases: ['/docs/v3.1/reference/security/cert-based-authentication/']
+aliases: ['/docs/v3.1/certificate-authentication/','/docs/v3.1/reference/security/cert-based-authentication/']
 ---
 
 # Certificate-Based Authentication for Login <span class="version-mark">New in v3.0.8</span>

--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -2,7 +2,7 @@
 title: Character Set Support
 summary: Learn about the supported character sets in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/character-set/']
+aliases: ['/docs/v3.1/character-set-and-collation/','/docs/v3.1/reference/sql/character-set/']
 ---
 
 # Character Set Support

--- a/check-cluster-status-using-sql-statements.md
+++ b/check-cluster-status-using-sql-statements.md
@@ -2,7 +2,7 @@
 title: Check the TiDB Cluster Status Using SQL Statements
 summary: This document introduces that TiDB offers some SQL statements and system tables to check the TiDB cluster status.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/check-cluster-status-using-sql-statements/']
+aliases: ['/docs/v3.1/check-cluster-status-using-sql-statements/','/docs/v3.1/reference/performance/check-cluster-status-using-sql-statements/']
 ---
 
 # Check the TiDB Cluster Status Using SQL Statements

--- a/command-line-flags-for-pd-configuration.md
+++ b/command-line-flags-for-pd-configuration.md
@@ -2,7 +2,7 @@
 title: PD Configuration Flags
 summary: Learn some configuration flags of PD.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/pd-server/configuration/']
+aliases: ['/docs/v3.1/command-line-flags-for-pd-configuration/','/docs/v3.1/reference/configuration/pd-server/configuration/']
 ---
 
 # PD Configuration Flags

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -2,7 +2,7 @@
 title: Configuration Options
 summary: Learn some configuration options for TiDB
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/tidb-server/configuration/']
+aliases: ['/docs/v3.1/command-line-flags-for-tidb-configuration/','/docs/v3.1/reference/configuration/tidb-server/configuration/']
 ---
 
 # Configuration Options

--- a/command-line-flags-for-tikv-configuration.md
+++ b/command-line-flags-for-tikv-configuration.md
@@ -2,7 +2,7 @@
 title: TiKV Configuration Flags
 summary: Learn some configuration flags of TiKV.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/tikv-server/configuration/']
+aliases: ['/docs/v3.1/command-line-flags-for-tikv-configuration/','/docs/v3.1/reference/configuration/tikv-server/configuration/']
 ---
 
 # TiKV Configuration Flags

--- a/comment-syntax.md
+++ b/comment-syntax.md
@@ -2,7 +2,7 @@
 title: Comment Syntax
 summary: Learn about the three comment styles in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/comment-syntax/']
+aliases: ['/docs/v3.1/comment-syntax/','/docs/v3.1/reference/sql/language-structure/comment-syntax/']
 ---
 
 # Comment Syntax

--- a/community.md
+++ b/community.md
@@ -2,6 +2,7 @@
 title: Connect with us
 summary: Learn about how to connect with us.
 category: community
+aliases: ['/docs/v3.1/community/']
 ---
 
 # Connect with us

--- a/configure-memory-usage.md
+++ b/configure-memory-usage.md
@@ -2,7 +2,7 @@
 title: TiDB Memory Control
 summary: Learn how to configure the memory quota of a query and avoid OOM (out of memory).
 category: how-to
-aliases: ['/docs/v3.1/how-to/configure/memory-control/']
+aliases: ['/docs/v3.1/configure-memory-usage/','/docs/v3.1/how-to/configure/memory-control/']
 ---
 
 # TiDB Memory Control

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -2,6 +2,7 @@
 title: Placement Rules
 summary: Learn how to configure Placement Rules.
 category: how-to
+aliases: ['/docs/v3.1/configure-placement-rules/']
 ---
 
 # Placement Rules

--- a/configure-time-zone.md
+++ b/configure-time-zone.md
@@ -2,7 +2,7 @@
 title: Time Zone Support
 summary: Learn how to set the time zone and its format.
 category: how-to
-aliases: ['/docs/v3.1/how-to/configure/time-zone/']
+aliases: ['/docs/v3.1/configure-time-zone/','/docs/v3.1/how-to/configure/time-zone/']
 ---
 
 # Time Zone Support

--- a/connectors-and-apis.md
+++ b/connectors-and-apis.md
@@ -2,7 +2,7 @@
 title: Connectors and APIs
 summary: Learn about the connectors and APIs.
 category: reference
-aliases: ['/docs/v3.1/reference/supported-clients/']
+aliases: ['/docs/v3.1/connectors-and-apis/','/docs/v3.1/reference/supported-clients/']
 ---
 
 # Connectors and APIs

--- a/constraints.md
+++ b/constraints.md
@@ -2,7 +2,7 @@
 title: Constraints
 summary: Learn how SQL Constraints apply to TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/constraints/']
+aliases: ['/docs/v3.1/constraints/','/docs/v3.1/reference/sql/constraints/']
 ---
 
 # Constraints

--- a/contribute.md
+++ b/contribute.md
@@ -2,6 +2,7 @@
 title: Contribute
 summary: Learn how to contribute to the TiDB database.
 category: how-to
+aliases: ['/docs/v3.1/contribute/']
 ---
 
 # Contribute

--- a/data-type-date-and-time.md
+++ b/data-type-date-and-time.md
@@ -2,7 +2,7 @@
 title: Date and Time Types
 summary: Learn about the supported date and time types.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/date-and-time/']
+aliases: ['/docs/v3.1/data-type-date-and-time/','/docs/v3.1/reference/sql/data-types/date-and-time/']
 ---
 
 # Date and Time Types

--- a/data-type-default-values.md
+++ b/data-type-default-values.md
@@ -2,7 +2,7 @@
 title: TiDB Data Type
 summary: Learn about default values for data types in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/default-values/']
+aliases: ['/docs/v3.1/data-type-default-values/','/docs/v3.1/reference/sql/data-types/default-values/']
 ---
 
 # Default Values

--- a/data-type-json.md
+++ b/data-type-json.md
@@ -2,7 +2,7 @@
 title: TiDB Data Type
 summary: Learn about the JSON data type in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/json/']
+aliases: ['/docs/v3.1/data-type-json/','/docs/v3.1/reference/sql/data-types/json/']
 ---
 
 # JSON Type

--- a/data-type-numeric.md
+++ b/data-type-numeric.md
@@ -2,7 +2,7 @@
 title: Numeric Types
 summary: Learn about numeric data types supported in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/numeric/']
+aliases: ['/docs/v3.1/data-type-numeric/','/docs/v3.1/reference/sql/data-types/numeric/']
 ---
 
 # Numeric Types

--- a/data-type-overview.md
+++ b/data-type-overview.md
@@ -2,7 +2,7 @@
 title: Data Types
 summary: Learn about the data types supported in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/overview/']
+aliases: ['/docs/v3.1/data-type-overview/','/docs/v3.1/reference/sql/data-types/overview/']
 ---
 
 # Data Types

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -2,7 +2,7 @@
 title: String types
 summary: Learn about the string types supported in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/data-types/string/']
+aliases: ['/docs/v3.1/data-type-string/','/docs/v3.1/reference/sql/data-types/string/']
 ---
 
 # String Types

--- a/deploy-tidb-from-binary.md
+++ b/deploy-tidb-from-binary.md
@@ -2,7 +2,7 @@
 title: Local Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/deploy-tidb-from-binary/']
+aliases: ['/docs/v3.1/deploy-tidb-from-binary/','/docs/v3.1/how-to/get-started/deploy-tidb-from-binary/']
 ---
 
 # Local Deployment from Binary Tarball

--- a/deploy-tidb-from-dbdeployer.md
+++ b/deploy-tidb-from-dbdeployer.md
@@ -2,7 +2,7 @@
 title: Install from DBdeployer
 summary: Install TiDB using the DBdeployer package manager.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/deploy-tidb-from-dbdeployer/']
+aliases: ['/docs/v3.1/deploy-tidb-from-dbdeployer/','/docs/v3.1/how-to/get-started/deploy-tidb-from-dbdeployer/']
 ---
 
 # Install from DBdeployer

--- a/deploy-tidb-from-homebrew.md
+++ b/deploy-tidb-from-homebrew.md
@@ -2,7 +2,7 @@
 title: Deploy a TiDB Cluster from Homebrew
 summary: Install TiDB using the Homebrew package manager.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/deploy-tidb-from-homebrew/']
+aliases: ['/docs/v3.1/deploy-tidb-from-homebrew/','/docs/v3.1/how-to/get-started/deploy-tidb-from-homebrew/']
 ---
 
 # Deploy a TiDB Cluster from Homebrew

--- a/download-ecosystem-tools.md
+++ b/download-ecosystem-tools.md
@@ -2,7 +2,7 @@
 title: Download Tools
 summary: Download the most officially maintained versions of TiDB enterprise tools.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/download/']
+aliases: ['/docs/v3.1/download-ecosystem-tools/','/docs/v3.1/reference/tools/download/']
 ---
 
 # Download Tools

--- a/ecosystem-tool-user-case.md
+++ b/ecosystem-tool-user-case.md
@@ -2,6 +2,7 @@
 title: TiDB Ecosystem Tools Use Cases
 summary: Learn the common use cases of TiDB ecosystem tools and how to choose the tools.
 category: reference
+aliases: ['/docs/v3.1/ecosystem-tool-user-case/']
 ---
 
 # TiDB Ecosystem Tools Use Cases

--- a/ecosystem-tool-user-guide.md
+++ b/ecosystem-tool-user-guide.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Ecosystem Tools Overview
 category: reference
-aliases: ['/docs/v3.1/reference/tools/user-guide/','/docs/v3.1/how-to/migrate/from-mysql/','/docs/v3.1/how-to/migrate/incrementally-from-mysql/','/docs/v3.1/how-to/migrate/overview/']
+aliases: ['/docs/v3.1/ecosystem-tool-user-guide/','/docs/v3.1/reference/tools/user-guide/','/docs/v3.1/how-to/migrate/from-mysql/','/docs/v3.1/how-to/migrate/incrementally-from-mysql/','/docs/v3.1/how-to/migrate/overview/']
 ---
 
 # TiDB Ecosystem Tools Overview

--- a/enable-tls-between-components.md
+++ b/enable-tls-between-components.md
@@ -2,7 +2,7 @@
 title: Enable TLS Authentication and Encrypt the Stored Data
 summary: Learn how to enable TLS authentication and encrypt the stored data in a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/secure/enable-tls-between-components/']
+aliases: ['/docs/v3.1/enable-tls-between-components/','/docs/v3.1/how-to/secure/enable-tls-between-components/']
 ---
 
 # Enable TLS Authentication and Encrypt the Stored Data

--- a/encrypted-connections-with-tls-protocols.md
+++ b/encrypted-connections-with-tls-protocols.md
@@ -2,7 +2,7 @@
 title: Enable TLS for MySQL Clients
 summary: Use the encrypted connection to ensure data security.
 category: how-to
-aliases: ['/docs/v3.1/how-to/secure/enable-tls-clients/']
+aliases: ['/docs/v3.1/encrypted-connections-with-tls-protocols/','/docs/v3.1/how-to/secure/enable-tls-clients/']
 ---
 
 # Enable TLS for MySQL Clients

--- a/error-codes.md
+++ b/error-codes.md
@@ -2,7 +2,7 @@
 title: Error Codes and Troubleshooting
 summary: Learn about the error codes and solutions in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/error-codes/']
+aliases: ['/docs/v3.1/error-codes/','/docs/v3.1/reference/error-codes/']
 ---
 
 # Error Codes and Troubleshooting

--- a/execution-plan-binding.md
+++ b/execution-plan-binding.md
@@ -2,7 +2,7 @@
 title: Execution Plan Binding
 summary: Learn about execution plan binding operations in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/execution-plan-bind/']
+aliases: ['/docs/v3.1/execution-plan-binding/','/docs/v3.1/reference/performance/execution-plan-bind/']
 ---
 
 # Execution Plan Binding

--- a/export-or-backup-using-dumpling.md
+++ b/export-or-backup-using-dumpling.md
@@ -2,6 +2,7 @@
 title: Export or Backup Data Using Dumpling
 summary: Use the Dumpling tool to export or backup data in TiDB.
 category: how-to
+aliases: ['/docs/v3.1/export-or-backup-using-dumpling/']
 ---
 
 # Export or Backup Data Using Dumpling

--- a/expression-syntax.md
+++ b/expression-syntax.md
@@ -2,7 +2,7 @@
 title: Expression Syntax
 summary: Learn about the expression syntax in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/expression-syntax/']
+aliases: ['/docs/v3.1/expression-syntax/','/docs/v3.1/reference/sql/language-structure/expression-syntax/']
 ---
 
 # Expression Syntax

--- a/faq/tidb-faq.md
+++ b/faq/tidb-faq.md
@@ -2,7 +2,7 @@
 title: TiDB FAQ
 summary: Learn about the most frequently asked questions (FAQs) relating to TiDB.
 category: faq
-aliases: ['/docs/v3.1/faq/tidb/']
+aliases: ['/docs/v3.1/faq/tidb-faq/','/docs/v3.1/faq/tidb/']
 ---
 
 # TiDB FAQ

--- a/faq/upgrade-faq.md
+++ b/faq/upgrade-faq.md
@@ -2,7 +2,7 @@
 title: FAQs After Upgrade
 summary: Learn about the FAQs after upgrading TiDB.
 category: faq
-aliases: ['/docs/v3.1/faq/upgrade/']
+aliases: ['/docs/v3.1/faq/upgrade-faq/','/docs/v3.1/faq/upgrade/']
 ---
 
 # FAQs After Upgrade

--- a/follower-read.md
+++ b/follower-read.md
@@ -2,7 +2,7 @@
 title: Follower Read
 summary: This document describes the use and implementation of Follower Read.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/follower-read/']
+aliases: ['/docs/v3.1/follower-read/','/docs/v3.1/reference/performance/follower-read/']
 ---
 
 # Follower Read

--- a/functions-and-operators/aggregate-group-by-functions.md
+++ b/functions-and-operators/aggregate-group-by-functions.md
@@ -2,7 +2,7 @@
 title: Aggregate (GROUP BY) Functions
 summary: Learn about the supported aggregate functions in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/aggregate-group-by-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/aggregate-group-by-functions/','/docs/v3.1/reference/sql/functions-and-operators/aggregate-group-by-functions/']
 ---
 
 # Aggregate (GROUP BY) Functions

--- a/functions-and-operators/bit-functions-and-operators.md
+++ b/functions-and-operators/bit-functions-and-operators.md
@@ -2,7 +2,7 @@
 title: Bit Functions and Operators
 summary: Learn about the bit functions and operators.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/bit-functions-and-operators/']
+aliases: ['/docs/v3.1/functions-and-operators/bit-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/bit-functions-and-operators/']
 ---
 
 # Bit Functions and Operators

--- a/functions-and-operators/cast-functions-and-operators.md
+++ b/functions-and-operators/cast-functions-and-operators.md
@@ -2,7 +2,7 @@
 title: Cast Functions and Operators
 summary: Learn about the cast functions and operators.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/cast-functions-and-operators/']
+aliases: ['/docs/v3.1/functions-and-operators/cast-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/cast-functions-and-operators/']
 ---
 
 # Cast Functions and Operators

--- a/functions-and-operators/control-flow-functions.md
+++ b/functions-and-operators/control-flow-functions.md
@@ -2,7 +2,7 @@
 title: Control Flow Functions
 summary: Learn about the Control Flow functions.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/control-flow-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/control-flow-functions/','/docs/v3.1/reference/sql/functions-and-operators/control-flow-functions/']
 ---
 
 # Control Flow Functions

--- a/functions-and-operators/date-and-time-functions.md
+++ b/functions-and-operators/date-and-time-functions.md
@@ -2,7 +2,7 @@
 title: Date and Time Functions
 summary: Learn how to use the data and time functions.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/date-and-time-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/date-and-time-functions/','/docs/v3.1/reference/sql/functions-and-operators/date-and-time-functions/']
 ---
 
 # Date and Time Functions

--- a/functions-and-operators/encryption-and-compression-functions.md
+++ b/functions-and-operators/encryption-and-compression-functions.md
@@ -2,7 +2,7 @@
 title: Encryption and Compression Functions
 summary: Learn about the encryption and compression functions.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/encryption-and-compression-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/encryption-and-compression-functions/','/docs/v3.1/reference/sql/functions-and-operators/encryption-and-compression-functions/']
 ---
 
 # Encryption and Compression Functions

--- a/functions-and-operators/expressions-pushed-down.md
+++ b/functions-and-operators/expressions-pushed-down.md
@@ -2,7 +2,7 @@
 title: List of Expressions for Pushdown
 summary: Learn a list of expressions that can be pushed down to TiKV and the related operations.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/expressions-pushed-down/']
+aliases: ['/docs/v3.1/functions-and-operators/expressions-pushed-down/','/docs/v3.1/reference/sql/functions-and-operators/expressions-pushed-down/']
 ---
 
 # List of Expressions for Pushdown

--- a/functions-and-operators/functions-and-operators-overview.md
+++ b/functions-and-operators/functions-and-operators-overview.md
@@ -2,7 +2,7 @@
 title: Function and Operator Reference
 summary: Learn how to use the functions and operators.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/reference/']
+aliases: ['/docs/v3.1/functions-and-operators/functions-and-operators-overview/','/docs/v3.1/reference/sql/functions-and-operators/reference/']
 ---
 
 # Function and Operator Reference

--- a/functions-and-operators/information-functions.md
+++ b/functions-and-operators/information-functions.md
@@ -2,7 +2,7 @@
 title: Information Functions
 summary: Learn about the information functions.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/information-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/information-functions/','/docs/v3.1/reference/sql/functions-and-operators/information-functions/']
 ---
 
 # Information Functions

--- a/functions-and-operators/json-functions.md
+++ b/functions-and-operators/json-functions.md
@@ -2,7 +2,7 @@
 title: JSON Functions
 summary: Learn about JSON functions.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/json-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/json-functions/','/docs/v3.1/reference/sql/functions-and-operators/json-functions/']
 ---
 
 # JSON Functions

--- a/functions-and-operators/miscellaneous-functions.md
+++ b/functions-and-operators/miscellaneous-functions.md
@@ -2,7 +2,7 @@
 title: Miscellaneous Functions
 summary: Learn about miscellaneous functions in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/miscellaneous-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/miscellaneous-functions/','/docs/v3.1/reference/sql/functions-and-operators/miscellaneous-functions/']
 ---
 
 # Miscellaneous Functions

--- a/functions-and-operators/numeric-functions-and-operators.md
+++ b/functions-and-operators/numeric-functions-and-operators.md
@@ -2,7 +2,7 @@
 title: Numeric Functions and Operators
 summary: Learn about the numeric functions and operators.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/numeric-functions-and-operators/']
+aliases: ['/docs/v3.1/functions-and-operators/numeric-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/numeric-functions-and-operators/']
 ---
 
 # Numeric Functions and Operators

--- a/functions-and-operators/operators.md
+++ b/functions-and-operators/operators.md
@@ -2,7 +2,7 @@
 title: Operators
 summary: Learn about the operators precedence, comparison functions and operators, logical operators, and assignment operators.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/operators/']
+aliases: ['/docs/v3.1/functions-and-operators/operators/','/docs/v3.1/reference/sql/functions-and-operators/operators/']
 ---
 
 # Operators

--- a/functions-and-operators/precision-math.md
+++ b/functions-and-operators/precision-math.md
@@ -2,7 +2,7 @@
 title: Precision Math
 summary: Learn about the precision math in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/precision-math/']
+aliases: ['/docs/v3.1/functions-and-operators/precision-math/','/docs/v3.1/reference/sql/functions-and-operators/precision-math/']
 ---
 
 # Precision Math

--- a/functions-and-operators/string-functions.md
+++ b/functions-and-operators/string-functions.md
@@ -2,7 +2,7 @@
 title: String Functions
 summary: Learn about the string functions in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/string-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/string-functions/','/docs/v3.1/reference/sql/functions-and-operators/string-functions/']
 ---
 
 # String Functions

--- a/functions-and-operators/type-conversion-in-expression-evaluation.md
+++ b/functions-and-operators/type-conversion-in-expression-evaluation.md
@@ -2,7 +2,7 @@
 title: Type Conversion in Expression Evaluation
 summary: Learn about the type conversion in expression evaluation.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/type-conversion/']
+aliases: ['/docs/v3.1/functions-and-operators/type-conversion-in-expression-evaluation/','/docs/v3.1/reference/sql/functions-and-operators/type-conversion/']
 ---
 
 # Type Conversion in Expression Evaluation

--- a/functions-and-operators/window-functions.md
+++ b/functions-and-operators/window-functions.md
@@ -2,7 +2,7 @@
 title: Window Functions
 summary: This document introduces window functions supported in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/functions-and-operators/window-functions/']
+aliases: ['/docs/v3.1/functions-and-operators/window-functions/','/docs/v3.1/reference/sql/functions-and-operators/window-functions/']
 ---
 
 # Window Functions

--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -2,7 +2,7 @@
 title: GC Configuration
 summary: Learn about GC configuration parameters.
 category: reference
-aliases: ['/docs/v3.1/reference/garbage-collection/configuration/']
+aliases: ['/docs/v3.1/garbage-collection-configuration/','/docs/v3.1/reference/garbage-collection/configuration/']
 ---
 
 # GC Configuration

--- a/garbage-collection-overview.md
+++ b/garbage-collection-overview.md
@@ -2,7 +2,7 @@
 title: GC Overview
 summary: Learn about Garbage Collection in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/garbage-collection/overview/']
+aliases: ['/docs/v3.1/garbage-collection-overview/','/docs/v3.1/reference/garbage-collection/overview/']
 ---
 
 # GC Overview

--- a/generate-self-signed-certificates.md
+++ b/generate-self-signed-certificates.md
@@ -2,7 +2,7 @@
 title: Generate Self-signed Certificates
 summary: Use `cfssl` to generate self-signed certificates.
 category: how-to
-aliases: ['/docs/v3.1/how-to/secure/generate-self-signed-certificates/']
+aliases: ['/docs/v3.1/generate-self-signed-certificates/','/docs/v3.1/how-to/secure/generate-self-signed-certificates/']
 ---
 
 # Generate Self-signed Certificates

--- a/generated-columns.md
+++ b/generated-columns.md
@@ -2,7 +2,7 @@
 title: Generated Columns
 summary: Learn how to use generated columns.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/generated-columns/']
+aliases: ['/docs/v3.1/generated-columns/','/docs/v3.1/reference/sql/generated-columns/']
 ---
 
 # Generated Columns

--- a/geo-redundancy-deployment.md
+++ b/geo-redundancy-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-DC Deployment Solutions
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/geographic-redundancy/overview/']
+aliases: ['/docs/v3.1/geo-redundancy-deployment/','/docs/v3.1/how-to/deploy/geographic-redundancy/overview/']
 ---
 
 # Cross-DC Deployment Solutions

--- a/get-started-with-tidb-binlog.md
+++ b/get-started-with-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Tutorial
 summary: Learn to deploy TiDB Binlog with a simple TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/tidb-binlog/']
+aliases: ['/docs/v3.1/get-started-with-tidb-binlog/','/docs/v3.1/how-to/get-started/tidb-binlog/']
 ---
 
 # TiDB Binlog Tutorial

--- a/get-started-with-tidb-lightning.md
+++ b/get-started-with-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Tutorial
 summary: Learn how to deploy TiDB Lightning and import full backup data to TiDB.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/tidb-lightning/']
+aliases: ['/docs/v3.1/get-started-with-tidb-lightning/','/docs/v3.1/how-to/get-started/tidb-lightning/']
 ---
 
 # TiDB Lightning Tutorial

--- a/get-started-with-tispark.md
+++ b/get-started-with-tispark.md
@@ -2,7 +2,7 @@
 title: TiSpark Quick Start Guide
 summary: Learn how to use TiSpark quickly.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/tispark/']
+aliases: ['/docs/v3.1/get-started-with-tispark/','/docs/v3.1/how-to/get-started/tispark/']
 ---
 
 # TiSpark Quick Start Guide

--- a/glossary.md
+++ b/glossary.md
@@ -2,6 +2,7 @@
 title: Glossary
 summary: Glossaries about TiDB.
 category: glossary
+aliases: ['/docs/v3.1/glossary/']
 ---
 
 # Glossary

--- a/grafana-overview-dashboard.md
+++ b/grafana-overview-dashboard.md
@@ -2,7 +2,7 @@
 title: Key Metrics
 summary: Learn some key metrics displayed on the Grafana Overview dashboard.
 category: reference
-aliases: ['/docs/v3.1/reference/key-monitoring-metrics/overview-dashboard/']
+aliases: ['/docs/v3.1/grafana-overview-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/overview-dashboard/']
 ---
 
 # Key Metrics

--- a/grafana-pd-dashboard.md
+++ b/grafana-pd-dashboard.md
@@ -2,7 +2,7 @@
 title: Key Monitoring Metrics of PD
 summary: Learn some key metrics displayed on the Grafana PD dashboard.
 category: reference
-aliases: ['/docs/v3.1/reference/key-monitoring-metrics/pd-dashboard/']
+aliases: ['/docs/v3.1/grafana-pd-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/pd-dashboard/']
 ---
 
 # Key Monitoring Metrics of PD

--- a/grafana-tidb-dashboard.md
+++ b/grafana-tidb-dashboard.md
@@ -2,7 +2,7 @@
 title: TiDB Monitoring Metrics
 summary: Learn some key metrics displayed on the Grafana TiDB dashboard.
 category: reference
-aliases: ['/docs/v3.1/reference/key-monitoring-metrics/tidb-dashboard/']
+aliases: ['/docs/v3.1/grafana-tidb-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/tidb-dashboard/']
 ---
 
 # TiDB Monitoring Metrics

--- a/grafana-tikv-dashboard.md
+++ b/grafana-tikv-dashboard.md
@@ -2,7 +2,7 @@
 title: Key Monitoring Metrics of TiKV
 summary: Learn some key metrics displayed on the Grafana TiKV dashboard.
 category: reference
-aliases: ['/docs/v3.1/reference/key-monitoring-metrics/tikv-dashboard/']
+aliases: ['/docs/v3.1/grafana-tikv-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/tikv-dashboard/']
 ---
 
 # Key Monitoring Metrics of TiKV

--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -2,7 +2,7 @@
 title: Software and Hardware Recommendations
 summary: Learn the software and hardware recommendations for deploying and running TiDB.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/hardware-recommendations/']
+aliases: ['/docs/v3.1/hardware-and-software-requirements/','/docs/v3.1/how-to/deploy/hardware-recommendations/']
 ---
 
 # Software and Hardware Recommendations

--- a/identify-expensive-queries.md
+++ b/identify-expensive-queries.md
@@ -1,7 +1,7 @@
 ---
 title: Identify Expensive Queries
 category: how to
-aliases: ['/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-expensive-queries/']
+aliases: ['/docs/v3.1/identify-expensive-queries/','/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-expensive-queries/']
 ---
 
 # Identify Expensive Queries

--- a/identify-slow-queries.md
+++ b/identify-slow-queries.md
@@ -2,7 +2,7 @@
 title: Identify Slow Queries
 summary: Use the slow query log to identify problematic SQL statements.
 category: how-to
-aliases: ['/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-slow-queries/','/docs-cn/v3.1/how-to/maintain/identify-slow-queries/']
+aliases: ['/docs/v3.1/identify-slow-queries/','/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-slow-queries/','/docs-cn/v3.1/how-to/maintain/identify-slow-queries/']
 ---
 
 # Identify Slow Queries

--- a/import-example-data.md
+++ b/import-example-data.md
@@ -2,7 +2,7 @@
 title: Import Example Database
 summary: Install the Bikeshare example database.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/import-example-database/']
+aliases: ['/docs/v3.1/import-example-data/','/docs/v3.1/how-to/get-started/import-example-database/']
 ---
 
 # Import Example Database

--- a/key-features.md
+++ b/key-features.md
@@ -2,6 +2,7 @@
 title: Key Features
 summary: Key features of the TiDB database platform.
 category: concepts
+aliases: ['/docs/v3.1/key-features/']
 ---
 
 # Key Features

--- a/keywords-and-reserved-words.md
+++ b/keywords-and-reserved-words.md
@@ -2,7 +2,7 @@
 title: Keywords and Reserved Words
 summary: Learn about the keywords and reserved words in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/keywords-and-reserved-words/']
+aliases: ['/docs/v3.1/keywords-and-reserved-words/','/docs/v3.1/reference/sql/language-structure/keywords-and-reserved-words/']
 ---
 
 # Keywords and Reserved Words

--- a/literal-values.md
+++ b/literal-values.md
@@ -2,7 +2,7 @@
 title: Literal Values
 summary: Learn how to use various literal values.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/literal-values/']
+aliases: ['/docs/v3.1/literal-values/','/docs/v3.1/reference/sql/language-structure/literal-values/']
 ---
 
 # Literal Values

--- a/load-misuse-handling.md
+++ b/load-misuse-handling.md
@@ -1,7 +1,7 @@
 ---
 title: Common Misuses During Full Data Import
 category: reference
-aliases: ['/docs/v3.1/reference/tools/error-case-handling/load-misuse-handling/']
+aliases: ['/docs/v3.1/load-misuse-handling/','/docs/v3.1/reference/tools/error-case-handling/load-misuse-handling/']
 ---
 
 # Common Misuses During Full Data Import

--- a/loader-overview.md
+++ b/loader-overview.md
@@ -2,7 +2,7 @@
 title: Loader Instructions
 summary: Use Loader to load data to TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/loader/']
+aliases: ['/docs/v3.1/loader-overview/','/docs/v3.1/reference/tools/loader/']
 ---
 
 # Loader Instructions

--- a/location-awareness.md
+++ b/location-awareness.md
@@ -2,7 +2,7 @@
 title: Cluster Topology Configuration
 summary: Learn to configure cluster topology to maximize the capacity for disaster recovery.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/geographic-redundancy/location-awareness/']
+aliases: ['/docs/v3.1/location-awareness/','/docs/v3.1/how-to/deploy/geographic-redundancy/location-awareness/']
 ---
 
 # Cluster Topology Configuration

--- a/maintain-tidb-using-ansible.md
+++ b/maintain-tidb-using-ansible.md
@@ -2,7 +2,7 @@
 title: TiDB Ansible Common Operations
 summary: Learn some common operations when using TiDB Ansible to administer a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/orchestrated/ansible-operations/']
+aliases: ['/docs/v3.1/maintain-tidb-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/ansible-operations/']
 ---
 
 # TiDB Ansible Common Operations

--- a/migrate-from-aurora-mysql-database.md
+++ b/migrate-from-aurora-mysql-database.md
@@ -2,7 +2,7 @@
 title: Migrate from MySQL (Amazon Aurora)
 summary: Learn how to migrate from MySQL (using a case of Amazon Aurora) to TiDB by using TiDB Data Migration (DM).
 category: how-to
-aliases: ['/docs/v3.1/how-to/migrate/from-mysql-aurora/','/docs/v3.1/how-to/migrate/from-aurora/']
+aliases: ['/docs/v3.1/migrate-from-aurora-mysql-database/','/docs/v3.1/how-to/migrate/from-mysql-aurora/','/docs/v3.1/how-to/migrate/from-aurora/']
 ---
 
 # Migrate from MySQL (Amazon Aurora)

--- a/migrate-from-mysql-mydumper-files.md
+++ b/migrate-from-mysql-mydumper-files.md
@@ -2,6 +2,7 @@
 title: Migrate Data from MySQL SQL Files
 summary: Learn how to migrate data from MySQL SQL files to TiDB using TiDB Lightning.
 category: how-to
+aliases: ['/docs/v3.1/migrate-from-mysql-mydumper-files/']
 ---
 
 # Migrate Data from MySQL SQL Files

--- a/monitor-a-tidb-cluster.md
+++ b/monitor-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Monitor a TiDB Cluster
 summary: Learn how to monitor the state of a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/monitor/monitor-a-cluster/']
+aliases: ['/docs/v3.1/monitor-a-tidb-cluster/','/docs/v3.1/how-to/monitor/monitor-a-cluster/']
 ---
 
 # Monitor a TiDB Cluster

--- a/mydumper-overview.md
+++ b/mydumper-overview.md
@@ -2,7 +2,7 @@
 title: Mydumper Instructions
 summary: Use Mydumper to export data from TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/mydumper/']
+aliases: ['/docs/v3.1/mydumper-overview/','/docs/v3.1/reference/tools/mydumper/']
 ---
 
 # Mydumper Instructions

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -2,7 +2,7 @@
 title: Compatibility with MySQL
 summary: Learn about the compatibility of TiDB with MySQL, and the unsupported and different features.
 category: reference
-aliases: ['/docs/v3.1/reference/mysql-compatibility/']
+aliases: ['/docs/v3.1/mysql-compatibility/','/docs/v3.1/reference/mysql-compatibility/']
 ---
 
 # Compatibility with MySQL

--- a/offline-deployment-using-ansible.md
+++ b/offline-deployment-using-ansible.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB Offline Using TiDB Ansible
 summary: Use TiDB Ansible to deploy a TiDB cluster offline.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/orchestrated/offline-ansible/']
+aliases: ['/docs/v3.1/offline-deployment-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/offline-ansible/']
 ---
 
 # Deploy TiDB Offline Using TiDB Ansible

--- a/online-deployment-using-ansible.md
+++ b/online-deployment-using-ansible.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB Using TiDB Ansible
 summary: Use TiDB Ansible to deploy a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/orchestrated/ansible/']
+aliases: ['/docs/v3.1/online-deployment-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/ansible/']
 ---
 
 # Deploy TiDB Using TiDB Ansible

--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -2,7 +2,7 @@
 title: TiDB Optimistic Transaction Model
 summary: Learn the optimistic transaction model in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/transactions/transaction-optimistic/','/docs/v3.1/reference/transactions/transaction-model/']
+aliases: ['/docs/v3.1/optimistic-transaction/','/docs/v3.1/reference/transactions/transaction-optimistic/','/docs/v3.1/reference/transactions/transaction-model/']
 ---
 
 # TiDB Optimistic Transaction Model

--- a/optimizer-hints.md
+++ b/optimizer-hints.md
@@ -2,7 +2,7 @@
 title: Optimizer Hints
 summary: Use Optimizer Hints to influence query execution plans
 category: reference
-aliases: ['/docs/v3.1/reference/performance/optimizer-hints/']
+aliases: ['/docs/v3.1/optimizer-hints/','/docs/v3.1/reference/performance/optimizer-hints/']
 ---
 
 # Optimizer Hints

--- a/overview.md
+++ b/overview.md
@@ -2,6 +2,7 @@
 title: TiDB Introduction
 summary: Learn how to quickly start a TiDB cluster.
 category: introduction
+aliases: ['/docs/v3.1/overview/']
 ---
 
 # TiDB Introduction

--- a/partitioned-table.md
+++ b/partitioned-table.md
@@ -2,7 +2,7 @@
 title: Partitioning
 summary: Learn how to use partitioning in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/partitioning/']
+aliases: ['/docs/v3.1/partitioned-table/','/docs/v3.1/reference/sql/partitioning/']
 ---
 
 # Partitioning

--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -2,7 +2,7 @@
 title: PD Configuration File
 summary: Learn the PD configuration file.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/pd-server/configuration-file/']
+aliases: ['/docs/v3.1/pd-configuration-file/','/docs/v3.1/reference/configuration/pd-server/configuration-file/']
 ---
 
 # PD Configuration File

--- a/pd-control.md
+++ b/pd-control.md
@@ -2,7 +2,7 @@
 title: PD Control User Guide
 summary: Use PD Control to obtain the state information of a cluster and tune a cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/pd-control/']
+aliases: ['/docs/v3.1/pd-control/','/docs/v3.1/reference/tools/pd-control/']
 ---
 
 # PD Control User Guide

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -2,7 +2,7 @@
 title: PD Recover User Guide
 summary: Use PD Recover to recover a PD cluster which cannot start or provide services normally.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/pd-recover/']
+aliases: ['/docs/v3.1/pd-recover/','/docs/v3.1/reference/tools/pd-recover/']
 ---
 
 # PD Recover User Guide

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -2,7 +2,7 @@
 title: TiDB Pessimistic Transaction Model
 summary: Learn the pessimistic transaction model in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/transactions/transaction-pessimistic/']
+aliases: ['/docs/v3.1/pessimistic-transaction/','/docs/v3.1/reference/transactions/transaction-pessimistic/']
 ---
 
 # TiDB Pessimistic Transaction Model

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -2,7 +2,7 @@
 title: Privilege Management
 summary: Learn how to manage the privilege.
 category: reference
-aliases: ['/docs/v3.1/reference/security/privilege-system/']
+aliases: ['/docs/v3.1/privilege-management/','/docs/v3.1/reference/security/privilege-system/']
 ---
 
 # Privilege Management

--- a/production-deployment-from-binary-tarball.md
+++ b/production-deployment-from-binary-tarball.md
@@ -2,7 +2,7 @@
 title: Production Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/from-tarball/production-environment/']
+aliases: ['/docs/v3.1/production-deployment-from-binary-tarball/','/docs/v3.1/how-to/deploy/from-tarball/production-environment/']
 ---
 
 # Production Deployment from Binary Tarball

--- a/query-execution-plan.md
+++ b/query-execution-plan.md
@@ -2,7 +2,7 @@
 title: Understand the Query Execution Plan
 summary: Learn about the execution plan information returned by the `EXPLAIN` statement in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/understanding-the-query-execution-plan/']
+aliases: ['/docs/v3.1/query-execution-plan/','/docs/v3.1/reference/performance/understanding-the-query-execution-plan/']
 ---
 
 # Understand the Query Execution Plan

--- a/read-historical-data.md
+++ b/read-historical-data.md
@@ -2,7 +2,7 @@
 title: Read Historical Data
 summary: Learn about how TiDB reads data from history versions.
 category: how-to
-aliases: ['/docs/v3.1/how-to/get-started/read-historical-data/']
+aliases: ['/docs/v3.1/read-historical-data/','/docs/v3.1/how-to/get-started/read-historical-data/']
 ---
 
 # Read Historical Data

--- a/releases/release-1.0-ga.md
+++ b/releases/release-1.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0 release notes
 category: Releases
-aliases: ['/docs/v3.1/releases/ga/']
+aliases: ['/docs/v3.1/releases/release-1.0-ga/','/docs/v3.1/releases/ga/']
 ---
 
 # TiDB 1.0 Release Notes

--- a/releases/release-1.0.1.md
+++ b/releases/release-1.0.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/101/']
+aliases: ['/docs/v3.1/releases/release-1.0.1/','/docs/v3.1/releases/101/']
 ---
 
 # TiDB 1.0.1 Release Notes

--- a/releases/release-1.0.2.md
+++ b/releases/release-1.0.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/102/']
+aliases: ['/docs/v3.1/releases/release-1.0.2/','/docs/v3.1/releases/102/']
 ---
 
 # TiDB 1.0.2 Release Notes

--- a/releases/release-1.0.3.md
+++ b/releases/release-1.0.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/103/']
+aliases: ['/docs/v3.1/releases/release-1.0.3/','/docs/v3.1/releases/103/']
 ---
 
 # TiDB 1.0.3 Release Notes

--- a/releases/release-1.0.4.md
+++ b/releases/release-1.0.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/104/']
+aliases: ['/docs/v3.1/releases/release-1.0.4/','/docs/v3.1/releases/104/']
 ---
 
 # TiDB 1.0.4 Release Notes

--- a/releases/release-1.0.5.md
+++ b/releases/release-1.0.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/105/']
+aliases: ['/docs/v3.1/releases/release-1.0.5/','/docs/v3.1/releases/105/']
 ---
 
 # TiDB 1.0.5 Release Notes

--- a/releases/release-1.0.6.md
+++ b/releases/release-1.0.6.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.6 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/106/']
+aliases: ['/docs/v3.1/releases/release-1.0.6/','/docs/v3.1/releases/106/']
 ---
 
 # TiDB 1.0.6 Release Notes

--- a/releases/release-1.0.7.md
+++ b/releases/release-1.0.7.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.7 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/107/']
+aliases: ['/docs/v3.1/releases/release-1.0.7/','/docs/v3.1/releases/107/']
 ---
 
 # TiDB 1.0.7 Release Notes

--- a/releases/release-1.0.8.md
+++ b/releases/release-1.0.8.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.0.8 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/108/']
+aliases: ['/docs/v3.1/releases/release-1.0.8/','/docs/v3.1/releases/108/']
 ---
 
 # TiDB 1.0.8 Release Notes

--- a/releases/release-1.1-alpha.md
+++ b/releases/release-1.1-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.1 Alpha Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/11alpha/']
+aliases: ['/docs/v3.1/releases/release-1.1-alpha/','/docs/v3.1/releases/11alpha/']
 ---
 
 # TiDB 1.1 Alpha Release Notes

--- a/releases/release-1.1-beta.md
+++ b/releases/release-1.1-beta.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 1.1 Beta Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/11beta/']
+aliases: ['/docs/v3.1/releases/release-1.1-beta/','/docs/v3.1/releases/11beta/']
 ---
 
 # TiDB 1.1 Beta Release Notes

--- a/releases/release-2.0-ga.md
+++ b/releases/release-2.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.0ga/']
+aliases: ['/docs/v3.1/releases/release-2.0-ga/','/docs/v3.1/releases/2.0ga/']
 ---
 
 # TiDB 2.0 Release Notes

--- a/releases/release-2.0-rc.1.md
+++ b/releases/release-2.0-rc.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0 RC1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2rc1/']
+aliases: ['/docs/v3.1/releases/release-2.0-rc.1/','/docs/v3.1/releases/2rc1/']
 ---
 
 # TiDB 2.0 RC1 Release Notes

--- a/releases/release-2.0-rc.3.md
+++ b/releases/release-2.0-rc.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0 RC3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2rc3/']
+aliases: ['/docs/v3.1/releases/release-2.0-rc.3/','/docs/v3.1/releases/2rc3/']
 ---
 
 # TiDB 2.0 RC3 Release Notes

--- a/releases/release-2.0-rc.4.md
+++ b/releases/release-2.0-rc.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0 RC4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2rc4/']
+aliases: ['/docs/v3.1/releases/release-2.0-rc.4/','/docs/v3.1/releases/2rc4/']
 ---
 
 # TiDB 2.0 RC4 Release Notes

--- a/releases/release-2.0-rc.5.md
+++ b/releases/release-2.0-rc.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0 RC5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2rc5/']
+aliases: ['/docs/v3.1/releases/release-2.0-rc.5/','/docs/v3.1/releases/2rc5/']
 ---
 
 # TiDB 2.0 RC5 Release Notes

--- a/releases/release-2.0.1.md
+++ b/releases/release-2.0.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/201/']
+aliases: ['/docs/v3.1/releases/release-2.0.1/','/docs/v3.1/releases/201/']
 ---
 
 # TiDB 2.0.1 Release Notes

--- a/releases/release-2.0.10.md
+++ b/releases/release-2.0.10.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.10 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.0.10/']
+aliases: ['/docs/v3.1/releases/release-2.0.10/','/docs/v3.1/releases/2.0.10/']
 ---
 
 # TiDB 2.0.10 Release Notes

--- a/releases/release-2.0.11.md
+++ b/releases/release-2.0.11.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.11 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.0.11/']
+aliases: ['/docs/v3.1/releases/release-2.0.11/','/docs/v3.1/releases/2.0.11/']
 ---
 
 # TiDB 2.0.11 Release Notes

--- a/releases/release-2.0.2.md
+++ b/releases/release-2.0.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/202/']
+aliases: ['/docs/v3.1/releases/release-2.0.2/','/docs/v3.1/releases/202/']
 ---
 
 # TiDB 2.0.2 Release Notes

--- a/releases/release-2.0.3.md
+++ b/releases/release-2.0.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/203/']
+aliases: ['/docs/v3.1/releases/release-2.0.3/','/docs/v3.1/releases/203/']
 ---
 
 # TiDB 2.0.3 Release Notes

--- a/releases/release-2.0.4.md
+++ b/releases/release-2.0.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/204/']
+aliases: ['/docs/v3.1/releases/release-2.0.4/','/docs/v3.1/releases/204/']
 ---
 
 # TiDB 2.0.4 Release Notes

--- a/releases/release-2.0.5.md
+++ b/releases/release-2.0.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/205/']
+aliases: ['/docs/v3.1/releases/release-2.0.5/','/docs/v3.1/releases/205/']
 ---
 
 # TiDB 2.0.5 Release Notes

--- a/releases/release-2.0.6.md
+++ b/releases/release-2.0.6.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.6 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/206/']
+aliases: ['/docs/v3.1/releases/release-2.0.6/','/docs/v3.1/releases/206/']
 ---
 
 # TiDB 2.0.6 Release Notes

--- a/releases/release-2.0.7.md
+++ b/releases/release-2.0.7.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.7 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/207/']
+aliases: ['/docs/v3.1/releases/release-2.0.7/','/docs/v3.1/releases/207/']
 ---
 
 # TiDB 2.0.7 Release Notes

--- a/releases/release-2.0.8.md
+++ b/releases/release-2.0.8.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.8 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/208/']
+aliases: ['/docs/v3.1/releases/release-2.0.8/','/docs/v3.1/releases/208/']
 ---
 
 # TiDB 2.0.8 Release Notes

--- a/releases/release-2.0.9.md
+++ b/releases/release-2.0.9.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.0.9 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/209/']
+aliases: ['/docs/v3.1/releases/release-2.0.9/','/docs/v3.1/releases/209/']
 ---
 
 # TiDB 2.0.9 Release Notes

--- a/releases/release-2.1-beta.md
+++ b/releases/release-2.1-beta.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 Beta Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21beta/']
+aliases: ['/docs/v3.1/releases/release-2.1-beta/','/docs/v3.1/releases/21beta/']
 ---
 
 # TiDB 2.1 Beta Release Notes

--- a/releases/release-2.1-ga.md
+++ b/releases/release-2.1-ga.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 GA Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1ga/']
+aliases: ['/docs/v3.1/releases/release-2.1-ga/','/docs/v3.1/releases/2.1ga/']
 ---
 
 # TiDB 2.1 GA Release Notes

--- a/releases/release-2.1-rc.1.md
+++ b/releases/release-2.1-rc.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 RC1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21rc1/']
+aliases: ['/docs/v3.1/releases/release-2.1-rc.1/','/docs/v3.1/releases/21rc1/']
 ---
 
 # TiDB 2.1 RC1 Release Notes

--- a/releases/release-2.1-rc.2.md
+++ b/releases/release-2.1-rc.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 RC2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21rc2/']
+aliases: ['/docs/v3.1/releases/release-2.1-rc.2/','/docs/v3.1/releases/21rc2/']
 ---
 
 # TiDB 2.1 RC2 Release Notes

--- a/releases/release-2.1-rc.3.md
+++ b/releases/release-2.1-rc.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 RC3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21rc3/']
+aliases: ['/docs/v3.1/releases/release-2.1-rc.3/','/docs/v3.1/releases/21rc3/']
 ---
 
 # TiDB 2.1 RC3 Release Notes

--- a/releases/release-2.1-rc.4.md
+++ b/releases/release-2.1-rc.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 RC4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21rc4/']
+aliases: ['/docs/v3.1/releases/release-2.1-rc.4/','/docs/v3.1/releases/21rc4/']
 ---
 
 # TiDB 2.1 RC4 Release Notes

--- a/releases/release-2.1-rc.5.md
+++ b/releases/release-2.1-rc.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1 RC5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/21rc5/']
+aliases: ['/docs/v3.1/releases/release-2.1-rc.5/','/docs/v3.1/releases/21rc5/']
 ---
 
 <!-- markdownlint-disable MD032 -->

--- a/releases/release-2.1.1.md
+++ b/releases/release-2.1.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.1/']
+aliases: ['/docs/v3.1/releases/release-2.1.1/','/docs/v3.1/releases/2.1.1/']
 ---
 
 # TiDB 2.1.1 Release Notes

--- a/releases/release-2.1.10.md
+++ b/releases/release-2.1.10.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.10 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.10/']
+aliases: ['/docs/v3.1/releases/release-2.1.10/','/docs/v3.1/releases/2.1.10/']
 ---
 
 # TiDB 2.1.10 Release Notes

--- a/releases/release-2.1.11.md
+++ b/releases/release-2.1.11.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.11 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.11/']
+aliases: ['/docs/v3.1/releases/release-2.1.11/','/docs/v3.1/releases/2.1.11/']
 ---
 
 # TiDB 2.1.11 Release Notes

--- a/releases/release-2.1.12.md
+++ b/releases/release-2.1.12.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.12 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.12/']
+aliases: ['/docs/v3.1/releases/release-2.1.12/','/docs/v3.1/releases/2.1.12/']
 ---
 
 # TiDB 2.1.12 Release Notes

--- a/releases/release-2.1.13.md
+++ b/releases/release-2.1.13.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.13 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.13/']
+aliases: ['/docs/v3.1/releases/release-2.1.13/','/docs/v3.1/releases/2.1.13/']
 ---
 
 # TiDB 2.1.13 Release Notes

--- a/releases/release-2.1.14.md
+++ b/releases/release-2.1.14.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.14 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.14/']
+aliases: ['/docs/v3.1/releases/release-2.1.14/','/docs/v3.1/releases/2.1.14/']
 ---
 
 # TiDB 2.1.14 Release Notes

--- a/releases/release-2.1.15.md
+++ b/releases/release-2.1.15.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.15 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.15/']
+aliases: ['/docs/v3.1/releases/release-2.1.15/','/docs/v3.1/releases/2.1.15/']
 ---
 
 # TiDB 2.1.15 Release Notes

--- a/releases/release-2.1.16.md
+++ b/releases/release-2.1.16.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.16 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.16/']
+aliases: ['/docs/v3.1/releases/release-2.1.16/','/docs/v3.1/releases/2.1.16/']
 ---
 
 # TiDB 2.1.16 Release Notes

--- a/releases/release-2.1.17.md
+++ b/releases/release-2.1.17.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.17 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.17/']
+aliases: ['/docs/v3.1/releases/release-2.1.17/','/docs/v3.1/releases/2.1.17/']
 ---
 
 # TiDB 2.1.17 Release Notes

--- a/releases/release-2.1.18.md
+++ b/releases/release-2.1.18.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.18 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.18/']
+aliases: ['/docs/v3.1/releases/release-2.1.18/','/docs/v3.1/releases/2.1.18/']
 ---
 
 # TiDB 2.1.18 Release Notes

--- a/releases/release-2.1.19.md
+++ b/releases/release-2.1.19.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.19 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.19/']
+aliases: ['/docs/v3.1/releases/release-2.1.19/','/docs/v3.1/releases/2.1.19/']
 ---
 
 # TiDB 2.1.19 Release Notes

--- a/releases/release-2.1.2.md
+++ b/releases/release-2.1.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.2/']
+aliases: ['/docs/v3.1/releases/release-2.1.2/','/docs/v3.1/releases/2.1.2/']
 ---
 
 # TiDB 2.1.2 Release Notes

--- a/releases/release-2.1.3.md
+++ b/releases/release-2.1.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.3/']
+aliases: ['/docs/v3.1/releases/release-2.1.3/','/docs/v3.1/releases/2.1.3/']
 ---
 
 # TiDB 2.1.3 Release Notes

--- a/releases/release-2.1.4.md
+++ b/releases/release-2.1.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.4/']
+aliases: ['/docs/v3.1/releases/release-2.1.4/','/docs/v3.1/releases/2.1.4/']
 ---
 
 # TiDB 2.1.4 Release Notes

--- a/releases/release-2.1.5.md
+++ b/releases/release-2.1.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.5/']
+aliases: ['/docs/v3.1/releases/release-2.1.5/','/docs/v3.1/releases/2.1.5/']
 ---
 
 # TiDB 2.1.5 Release Notes

--- a/releases/release-2.1.6.md
+++ b/releases/release-2.1.6.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.6 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.6/']
+aliases: ['/docs/v3.1/releases/release-2.1.6/','/docs/v3.1/releases/2.1.6/']
 ---
 
 # TiDB 2.1.6 Release Notes

--- a/releases/release-2.1.7.md
+++ b/releases/release-2.1.7.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.7 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.7/']
+aliases: ['/docs/v3.1/releases/release-2.1.7/','/docs/v3.1/releases/2.1.7/']
 ---
 
 # TiDB 2.1.7 Release Notes

--- a/releases/release-2.1.8.md
+++ b/releases/release-2.1.8.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.8 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.8/']
+aliases: ['/docs/v3.1/releases/release-2.1.8/','/docs/v3.1/releases/2.1.8/']
 ---
 
 # TiDB 2.1.8 Release Notes

--- a/releases/release-2.1.9.md
+++ b/releases/release-2.1.9.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 2.1.9 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/2.1.9/']
+aliases: ['/docs/v3.1/releases/release-2.1.9/','/docs/v3.1/releases/2.1.9/']
 ---
 
 # TiDB 2.1.9 Release Notes

--- a/releases/release-3.0-beta.md
+++ b/releases/release-3.0-beta.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0 Beta Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0beta/']
+aliases: ['/docs/v3.1/releases/release-3.0-beta/','/docs/v3.1/releases/3.0beta/']
 ---
 
 # TiDB 3.0 Beta Release Notes

--- a/releases/release-3.0-ga.md
+++ b/releases/release-3.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0 GA Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0-ga/']
+aliases: ['/docs/v3.1/releases/release-3.0-ga/','/docs/v3.1/releases/3.0-ga/']
 ---
 
 # TiDB 3.0 GA Release Notes

--- a/releases/release-3.0.0-beta.1.md
+++ b/releases/release-3.0.0-beta.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.0 Beta.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.0-beta.1/']
+aliases: ['/docs/v3.1/releases/release-3.0.0-beta.1/','/docs/v3.1/releases/3.0.0-beta.1/']
 ---
 
 # TiDB 3.0.0 Beta.1 Release Notes

--- a/releases/release-3.0.0-rc.1.md
+++ b/releases/release-3.0.0-rc.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.0-rc.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.0-rc.1/']
+aliases: ['/docs/v3.1/releases/release-3.0.0-rc.1/','/docs/v3.1/releases/3.0.0-rc.1/']
 ---
 
 # TiDB 3.0.0-rc.1 Release Notes

--- a/releases/release-3.0.0-rc.2.md
+++ b/releases/release-3.0.0-rc.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.0-rc.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.0-rc.2/']
+aliases: ['/docs/v3.1/releases/release-3.0.0-rc.2/','/docs/v3.1/releases/3.0.0-rc.2/']
 ---
 
 # TiDB 3.0.0-rc.2 Release Notes

--- a/releases/release-3.0.0-rc.3.md
+++ b/releases/release-3.0.0-rc.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.0-rc.3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.0-rc.3/']
+aliases: ['/docs/v3.1/releases/release-3.0.0-rc.3/','/docs/v3.1/releases/3.0.0-rc.3/']
 ---
 
 # TiDB 3.0.0-rc.3 Release Notes

--- a/releases/release-3.0.1.md
+++ b/releases/release-3.0.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.1/']
+aliases: ['/docs/v3.1/releases/release-3.0.1/','/docs/v3.1/releases/3.0.1/']
 ---
 
 # TiDB 3.0.1 Release Notes

--- a/releases/release-3.0.10.md
+++ b/releases/release-3.0.10.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.10 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.10/']
+aliases: ['/docs/v3.1/releases/release-3.0.10/','/docs/v3.1/releases/3.0.10/']
 ---
 
 # TiDB 3.0.10 Release Notes

--- a/releases/release-3.0.11.md
+++ b/releases/release-3.0.11.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.11 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.11/']
+aliases: ['/docs/v3.1/releases/release-3.0.11/','/docs/v3.1/releases/3.0.11/']
 ---
 
 # TiDB 3.0.11 Release Notes

--- a/releases/release-3.0.12.md
+++ b/releases/release-3.0.12.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.12 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.12/']
+aliases: ['/docs/v3.1/releases/release-3.0.12/','/docs/v3.1/releases/3.0.12/']
 ---
 
 # TiDB 3.0.12 Release Notes

--- a/releases/release-3.0.13.md
+++ b/releases/release-3.0.13.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.13 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.13/']
+aliases: ['/docs/v3.1/releases/release-3.0.13/','/docs/v3.1/releases/3.0.13/']
 ---
 
 # TiDB 3.0.13 Release Notes

--- a/releases/release-3.0.14.md
+++ b/releases/release-3.0.14.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.14 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.14/']
+aliases: ['/docs/v3.1/releases/release-3.0.14/','/docs/v3.1/releases/3.0.14/']
 ---
 
 # TiDB 3.0.14 Release Notes

--- a/releases/release-3.0.15.md
+++ b/releases/release-3.0.15.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB 3.0.15 Release Notes
 category: Releases
+aliases: ['/docs/v3.1/releases/release-3.0.15/']
 ---
 
 # TiDB 3.0.15 Release Notes

--- a/releases/release-3.0.2.md
+++ b/releases/release-3.0.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.2/']
+aliases: ['/docs/v3.1/releases/release-3.0.2/','/docs/v3.1/releases/3.0.2/']
 ---
 
 # TiDB 3.0.2 Release Notes

--- a/releases/release-3.0.3.md
+++ b/releases/release-3.0.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.3 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.3/']
+aliases: ['/docs/v3.1/releases/release-3.0.3/','/docs/v3.1/releases/3.0.3/']
 ---
 
 # TiDB 3.0.3 Release Notes

--- a/releases/release-3.0.4.md
+++ b/releases/release-3.0.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.4 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.4/']
+aliases: ['/docs/v3.1/releases/release-3.0.4/','/docs/v3.1/releases/3.0.4/']
 ---
 
 # TiDB 3.0.4 Release Notes

--- a/releases/release-3.0.5.md
+++ b/releases/release-3.0.5.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.5 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.5/']
+aliases: ['/docs/v3.1/releases/release-3.0.5/','/docs/v3.1/releases/3.0.5/']
 ---
 
 # TiDB 3.0.5 Release Notes

--- a/releases/release-3.0.6.md
+++ b/releases/release-3.0.6.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.6 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.6/']
+aliases: ['/docs/v3.1/releases/release-3.0.6/','/docs/v3.1/releases/3.0.6/']
 ---
 
 # TiDB 3.0.6 Release Notes

--- a/releases/release-3.0.7.md
+++ b/releases/release-3.0.7.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.7 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.7/']
+aliases: ['/docs/v3.1/releases/release-3.0.7/','/docs/v3.1/releases/3.0.7/']
 ---
 
 # TiDB 3.0.7 Release Notes

--- a/releases/release-3.0.8.md
+++ b/releases/release-3.0.8.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.8 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.8/']
+aliases: ['/docs/v3.1/releases/release-3.0.8/','/docs/v3.1/releases/3.0.8/']
 ---
 
 # TiDB 3.0.8 Release Notes

--- a/releases/release-3.0.9.md
+++ b/releases/release-3.0.9.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.0.9 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.0.9/']
+aliases: ['/docs/v3.1/releases/release-3.0.9/','/docs/v3.1/releases/3.0.9/']
 ---
 
 # TiDB 3.0.9 Release Notes

--- a/releases/release-3.1.0-beta.1.md
+++ b/releases/release-3.1.0-beta.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1 Beta.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.0-beta.1/']
+aliases: ['/docs/v3.1/releases/release-3.1.0-beta.1/','/docs/v3.1/releases/3.1.0-beta.1/']
 ---
 
 # TiDB 3.1 Beta.1 Release Notes

--- a/releases/release-3.1.0-beta.2.md
+++ b/releases/release-3.1.0-beta.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1 Beta.2 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.0-beta.2/']
+aliases: ['/docs/v3.1/releases/release-3.1.0-beta.2/','/docs/v3.1/releases/3.1.0-beta.2/']
 ---
 
 # TiDB 3.1 Beta.2 Release Notes

--- a/releases/release-3.1.0-beta.md
+++ b/releases/release-3.1.0-beta.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1 Beta Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.0-beta/']
+aliases: ['/docs/v3.1/releases/release-3.1.0-beta/','/docs/v3.1/releases/3.1.0-beta/']
 ---
 
 # TiDB 3.1 Beta Release Notes

--- a/releases/release-3.1.0-ga.md
+++ b/releases/release-3.1.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1.0 GA Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.0-ga/']
+aliases: ['/docs/v3.1/releases/release-3.1.0-ga/','/docs/v3.1/releases/3.1.0-ga/']
 ---
 
 # TiDB 3.1.0 GA Release Notes

--- a/releases/release-3.1.0-rc.md
+++ b/releases/release-3.1.0-rc.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1 RC Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.0-rc/']
+aliases: ['/docs/v3.1/releases/release-3.1.0-rc/','/docs/v3.1/releases/3.1.0-rc/']
 ---
 
 # TiDB 3.1 RC Release Notes

--- a/releases/release-3.1.1.md
+++ b/releases/release-3.1.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB 3.1.1 Release Notes
 category: Releases
-aliases: ['/docs/v3.1/releases/3.1.1/']
+aliases: ['/docs/v3.1/releases/release-3.1.1/','/docs/v3.1/releases/3.1.1/']
 ---
 
 # TiDB 3.1.1 Release Notes

--- a/releases/release-3.1.2.md
+++ b/releases/release-3.1.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB 3.1.2 Release Notes
 category: Releases
+aliases: ['/docs/v3.1/releases/release-3.1.2/']
 ---
 
 # TiDB 3.1.2 Release Notes

--- a/releases/release-notes.md
+++ b/releases/release-notes.md
@@ -1,7 +1,7 @@
 ---
 title: Release Notes
 category: release
-aliases: ['/docs/v3.1/releases/rn/']
+aliases: ['/docs/v3.1/releases/release-notes/','/docs/v3.1/releases/rn/']
 ---
 
 # TiDB Release Notes

--- a/releases/release-pre-ga.md
+++ b/releases/release-pre-ga.md
@@ -1,7 +1,7 @@
 ---
 title: Pre-GA release notes
 category: releases
-aliases: ['/docs/v3.1/releases/prega/']
+aliases: ['/docs/v3.1/releases/release-pre-ga/','/docs/v3.1/releases/prega/']
 ---
 
 # Pre-GA Release Notes

--- a/releases/release-rc.1.md
+++ b/releases/release-rc.1.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB RC1 Release Notes
 category: releases
-aliases: ['/docs/v3.1/releases/rc1/']
+aliases: ['/docs/v3.1/releases/release-rc.1/','/docs/v3.1/releases/rc1/']
 ---
 
 # TiDB RC1 Release Notes

--- a/releases/release-rc.2.md
+++ b/releases/release-rc.2.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB RC2 Release Notes
 category: releases
-aliases: ['/docs/v3.1/releases/rc2/']
+aliases: ['/docs/v3.1/releases/release-rc.2/','/docs/v3.1/releases/rc2/']
 ---
 
 # TiDB RC2 Release Notes

--- a/releases/release-rc.3.md
+++ b/releases/release-rc.3.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB RC3 Release Notes
 category: releases
-aliases: ['/docs/v3.1/releases/rc3/']
+aliases: ['/docs/v3.1/releases/release-rc.3/','/docs/v3.1/releases/rc3/']
 ---
 
 # TiDB RC3 Release Notes

--- a/releases/release-rc.4.md
+++ b/releases/release-rc.4.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB RC4 Release Notes
 category: releases
-aliases: ['/docs/v3.1/releases/rc4/']
+aliases: ['/docs/v3.1/releases/release-rc.4/','/docs/v3.1/releases/rc4/']
 ---
 
 # TiDB RC4 Release Notes

--- a/report-issue.md
+++ b/report-issue.md
@@ -2,6 +2,7 @@
 title: Report an Issue
 summary: Report an issue with your TiDB installation.
 category: support
+aliases: ['/docs/v3.1/report-issue/']
 ---
 
 # Report an Issue

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,6 +2,7 @@
 title: TiDB v3.0 Roadmap
 summary: Learn about the v3.0 roadmap of TiDB.
 category: Roadmap
+aliases: ['/docs/v3.1/roadmap/']
 ---
 
 # TiDB v3.0 Roadmap

--- a/role-based-access-control.md
+++ b/role-based-access-control.md
@@ -2,7 +2,7 @@
 title: Role-Based Access Control
 summary: This document introduces TiDB RBAC operations and implementation.
 category: reference
-aliases: ['/docs/v3.1/reference/security/role-based-access-control/']
+aliases: ['/docs/v3.1/role-based-access-control/','/docs/v3.1/reference/security/role-based-access-control/']
 ---
 
 # Role-Based Access Control

--- a/scale-tidb-using-ansible.md
+++ b/scale-tidb-using-ansible.md
@@ -2,7 +2,7 @@
 title: Scale the TiDB Cluster Using TiDB Ansible
 summary: Use TiDB Ansible to increase/decrease the capacity of a TiDB/TiKV/PD node.
 category: how-to
-aliases: ['/docs/v3.1/how-to/scale/with-ansible/']
+aliases: ['/docs/v3.1/scale-tidb-using-ansible/','/docs/v3.1/how-to/scale/with-ansible/']
 ---
 
 # Scale the TiDB Cluster Using TiDB Ansible

--- a/schema-object-names.md
+++ b/schema-object-names.md
@@ -2,7 +2,7 @@
 title: Schema Object Names
 summary: Learn about the schema object names (identifiers) in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/schema-object-names/']
+aliases: ['/docs/v3.1/schema-object-names/','/docs/v3.1/reference/sql/language-structure/schema-object-names/']
 ---
 
 # Schema Object Names

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -2,7 +2,7 @@
 title: Security Compatibility with MySQL
 summary: Learn TiDB's security compatibilities with MySQL.
 category: reference
-aliases: ['/docs/v3.1/reference/security/compatibility/']
+aliases: ['/docs/v3.1/security-compatibility-with-mysql/','/docs/v3.1/reference/security/compatibility/']
 ---
 
 # Security Compatibility with MySQL

--- a/sql-mode.md
+++ b/sql-mode.md
@@ -2,7 +2,7 @@
 title: SQL Mode
 summary: Learn SQL mode.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/sql-mode/']
+aliases: ['/docs/v3.1/sql-mode/','/docs/v3.1/reference/sql/sql-mode/']
 ---
 
 # SQL Mode

--- a/sql-optimization-concepts.md
+++ b/sql-optimization-concepts.md
@@ -2,7 +2,7 @@
 title: SQL Optimization Process
 summary: Learn about the logical and physical optimization of SQL in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/sql-optimizer-overview/']
+aliases: ['/docs/v3.1/sql-optimization-concepts/','/docs/v3.1/reference/performance/sql-optimizer-overview/']
 ---
 
 # SQL Optimization Process

--- a/sql-statements/sql-statement-add-column.md
+++ b/sql-statements/sql-statement-add-column.md
@@ -2,7 +2,7 @@
 title: ADD COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of ADD COLUMN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/add-column/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-add-column/','/docs/v3.1/reference/sql/statements/add-column/']
 ---
 
 # ADD COLUMN

--- a/sql-statements/sql-statement-add-index.md
+++ b/sql-statements/sql-statement-add-index.md
@@ -2,7 +2,7 @@
 title: ADD INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of ADD INDEX for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/add-index/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-add-index/','/docs/v3.1/reference/sql/statements/add-index/']
 ---
 
 # ADD INDEX

--- a/sql-statements/sql-statement-admin.md
+++ b/sql-statements/sql-statement-admin.md
@@ -2,7 +2,7 @@
 title: ADMIN | TiDB SQL Statement Reference
 summary: An overview of the usage of ADMIN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/admin/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-admin/','/docs/v3.1/reference/sql/statements/admin/']
 ---
 
 # ADMIN

--- a/sql-statements/sql-statement-alter-database.md
+++ b/sql-statements/sql-statement-alter-database.md
@@ -2,7 +2,7 @@
 title: ALTER DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER DATABASE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/alter-database/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-database/','/docs/v3.1/reference/sql/statements/alter-database/']
 ---
 
 # ALTER DATABASE

--- a/sql-statements/sql-statement-alter-instance.md
+++ b/sql-statements/sql-statement-alter-instance.md
@@ -2,7 +2,7 @@
 title: ALTER INSTANCE
 summary: Learn the overview of the `ALTER INSTANCE` usage in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/alter-instance/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-instance/','/docs/v3.1/reference/sql/statements/alter-instance/']
 ---
 
 # ALTER INSTANCE

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -2,7 +2,7 @@
 title: ALTER TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/alter-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-table/','/docs/v3.1/reference/sql/statements/alter-table/']
 ---
 
 # ALTER TABLE

--- a/sql-statements/sql-statement-alter-user.md
+++ b/sql-statements/sql-statement-alter-user.md
@@ -2,7 +2,7 @@
 title: ALTER USER | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER USER for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/alter-user/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-user/','/docs/v3.1/reference/sql/statements/alter-user/']
 ---
 
 # ALTER USER

--- a/sql-statements/sql-statement-analyze-table.md
+++ b/sql-statements/sql-statement-analyze-table.md
@@ -2,7 +2,7 @@
 title: ANALYZE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of ANALYZE TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/analyze-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-analyze-table/','/docs/v3.1/reference/sql/statements/analyze-table/']
 ---
 
 # ANALYZE TABLE

--- a/sql-statements/sql-statement-begin.md
+++ b/sql-statements/sql-statement-begin.md
@@ -2,7 +2,7 @@
 title: BEGIN | TiDB SQL Statement Reference
 summary: An overview of the usage of BEGIN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/begin/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-begin/','/docs/v3.1/reference/sql/statements/begin/']
 ---
 
 # BEGIN

--- a/sql-statements/sql-statement-change-column.md
+++ b/sql-statements/sql-statement-change-column.md
@@ -2,7 +2,7 @@
 title: CHANGE COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of CHANGE COLUMN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/change-column/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-change-column/','/docs/v3.1/reference/sql/statements/change-column/']
 ---
 
 # CHANGE COLUMN

--- a/sql-statements/sql-statement-commit.md
+++ b/sql-statements/sql-statement-commit.md
@@ -2,7 +2,7 @@
 title: COMMIT | TiDB SQL Statement Reference
 summary: An overview of the usage of COMMIT for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/commit/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-commit/','/docs/v3.1/reference/sql/statements/commit/']
 ---
 
 # COMMIT

--- a/sql-statements/sql-statement-create-database.md
+++ b/sql-statements/sql-statement-create-database.md
@@ -2,7 +2,7 @@
 title: CREATE DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE DATABASE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-database/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-database/','/docs/v3.1/reference/sql/statements/create-database/']
 ---
 
 # CREATE DATABASE

--- a/sql-statements/sql-statement-create-index.md
+++ b/sql-statements/sql-statement-create-index.md
@@ -2,7 +2,7 @@
 title: CREATE INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE INDEX for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-index/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-index/','/docs/v3.1/reference/sql/statements/create-index/']
 ---
 
 # CREATE INDEX

--- a/sql-statements/sql-statement-create-table-like.md
+++ b/sql-statements/sql-statement-create-table-like.md
@@ -2,7 +2,7 @@
 title: CREATE TABLE LIKE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE TABLE LIKE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-table-like/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-table-like/','/docs/v3.1/reference/sql/statements/create-table-like/']
 ---
 
 # CREATE TABLE LIKE

--- a/sql-statements/sql-statement-create-table.md
+++ b/sql-statements/sql-statement-create-table.md
@@ -2,7 +2,7 @@
 title: CREATE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-table/','/docs/v3.1/reference/sql/statements/create-table/']
 ---
 
 # CREATE TABLE

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -2,7 +2,7 @@
 title: CREATE USER | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE USER for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-user/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-user/','/docs/v3.1/reference/sql/statements/create-user/']
 ---
 
 # CREATE USER

--- a/sql-statements/sql-statement-create-view.md
+++ b/sql-statements/sql-statement-create-view.md
@@ -2,7 +2,7 @@
 title: CREATE VIEW | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE VIEW for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/create-view/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-create-view/','/docs/v3.1/reference/sql/statements/create-view/']
 ---
 
 # CREATE VIEW

--- a/sql-statements/sql-statement-deallocate.md
+++ b/sql-statements/sql-statement-deallocate.md
@@ -2,7 +2,7 @@
 title: DEALLOCATE | TiDB SQL Statement Reference
 summary: An overview of the usage of DEALLOCATE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/deallocate/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-deallocate/','/docs/v3.1/reference/sql/statements/deallocate/']
 ---
 
 # DEALLOCATE

--- a/sql-statements/sql-statement-delete.md
+++ b/sql-statements/sql-statement-delete.md
@@ -2,7 +2,7 @@
 title: DELETE | TiDB SQL Statement Reference
 summary: An overview of the usage of DELETE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/delete/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-delete/','/docs/v3.1/reference/sql/statements/delete/']
 ---
 
 # DELETE

--- a/sql-statements/sql-statement-desc.md
+++ b/sql-statements/sql-statement-desc.md
@@ -2,7 +2,7 @@
 title: DESC | TiDB SQL Statement Reference
 summary: An overview of the usage of DESC for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/desc/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-desc/','/docs/v3.1/reference/sql/statements/desc/']
 ---
 
 # DESC

--- a/sql-statements/sql-statement-describe.md
+++ b/sql-statements/sql-statement-describe.md
@@ -2,7 +2,7 @@
 title: DESCRIBE | TiDB SQL Statement Reference
 summary: An overview of the usage of DESCRIBE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/describe/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-describe/','/docs/v3.1/reference/sql/statements/describe/']
 ---
 
 # DESCRIBE

--- a/sql-statements/sql-statement-do.md
+++ b/sql-statements/sql-statement-do.md
@@ -2,7 +2,7 @@
 title: DO | TiDB SQL Statement Reference
 summary: An overview of the usage of DO for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/do/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-do/','/docs/v3.1/reference/sql/statements/do/']
 ---
 
 # DO

--- a/sql-statements/sql-statement-drop-column.md
+++ b/sql-statements/sql-statement-drop-column.md
@@ -2,7 +2,7 @@
 title: DROP COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP COLUMN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-column/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-column/','/docs/v3.1/reference/sql/statements/drop-column/']
 ---
 
 # DROP COLUMN

--- a/sql-statements/sql-statement-drop-database.md
+++ b/sql-statements/sql-statement-drop-database.md
@@ -2,7 +2,7 @@
 title: DROP DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP DATABASE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-database/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-database/','/docs/v3.1/reference/sql/statements/drop-database/']
 ---
 
 # DROP DATABASE

--- a/sql-statements/sql-statement-drop-index.md
+++ b/sql-statements/sql-statement-drop-index.md
@@ -2,7 +2,7 @@
 title: DROP INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP INDEX for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-index/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-index/','/docs/v3.1/reference/sql/statements/drop-index/']
 ---
 
 # DROP INDEX

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -2,7 +2,7 @@
 title: DROP TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-table/','/docs/v3.1/reference/sql/statements/drop-table/']
 ---
 
 # DROP TABLE

--- a/sql-statements/sql-statement-drop-user.md
+++ b/sql-statements/sql-statement-drop-user.md
@@ -2,7 +2,7 @@
 title: DROP USER | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP USER for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-user/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-user/','/docs/v3.1/reference/sql/statements/drop-user/']
 ---
 
 # DROP USER

--- a/sql-statements/sql-statement-drop-view.md
+++ b/sql-statements/sql-statement-drop-view.md
@@ -2,7 +2,7 @@
 title: DROP VIEW | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP VIEW for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/drop-view/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-view/','/docs/v3.1/reference/sql/statements/drop-view/']
 ---
 
 # DROP VIEW

--- a/sql-statements/sql-statement-execute.md
+++ b/sql-statements/sql-statement-execute.md
@@ -2,7 +2,7 @@
 title: EXECUTE | TiDB SQL Statement Reference
 summary: An overview of the usage of EXECUTE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/execute/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-execute/','/docs/v3.1/reference/sql/statements/execute/']
 ---
 
 # EXECUTE

--- a/sql-statements/sql-statement-explain-analyze.md
+++ b/sql-statements/sql-statement-explain-analyze.md
@@ -2,7 +2,7 @@
 title: EXPLAIN ANALYZE | TiDB SQL Statement Reference
 summary: An overview of the usage of EXPLAIN ANALYZE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/explain-analyze/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-explain-analyze/','/docs/v3.1/reference/sql/statements/explain-analyze/']
 ---
 
 # EXPLAIN ANALYZE

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -2,7 +2,7 @@
 title: EXPLAIN | TiDB SQL Statement Reference
 summary: An overview of the usage of EXPLAIN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/explain/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-explain/','/docs/v3.1/reference/sql/statements/explain/']
 ---
 
 # EXPLAIN

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -2,7 +2,7 @@
 title: FLUSH PRIVILEGES | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/flush-privileges/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-privileges/','/docs/v3.1/reference/sql/statements/flush-privileges/']
 ---
 
 # FLUSH PRIVILEGES

--- a/sql-statements/sql-statement-flush-status.md
+++ b/sql-statements/sql-statement-flush-status.md
@@ -2,7 +2,7 @@
 title: FLUSH STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH STATUS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/flush-status/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-status/','/docs/v3.1/reference/sql/statements/flush-status/']
 ---
 
 # FLUSH STATUS

--- a/sql-statements/sql-statement-flush-tables.md
+++ b/sql-statements/sql-statement-flush-tables.md
@@ -2,7 +2,7 @@
 title: FLUSH TABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH TABLES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/flush-tables/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-tables/','/docs/v3.1/reference/sql/statements/flush-tables/']
 ---
 
 # FLUSH TABLES

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -2,7 +2,7 @@
 title: GRANT <privileges> | TiDB SQL Statement Reference
 summary: An overview of the usage of GRANT <privileges> for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/grant-privileges/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-grant-privileges/','/docs/v3.1/reference/sql/statements/grant-privileges/']
 ---
 
 # `GRANT <privileges>`

--- a/sql-statements/sql-statement-insert.md
+++ b/sql-statements/sql-statement-insert.md
@@ -2,7 +2,7 @@
 title: INSERT | TiDB SQL Statement Reference
 summary: An overview of the usage of INSERT for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/insert/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-insert/','/docs/v3.1/reference/sql/statements/insert/']
 ---
 
 # INSERT

--- a/sql-statements/sql-statement-kill.md
+++ b/sql-statements/sql-statement-kill.md
@@ -2,7 +2,7 @@
 title: KILL [TIDB] | TiDB SQL Statement Reference
 summary: An overview of the usage of KILL [TIDB] for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/kill/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-kill/','/docs/v3.1/reference/sql/statements/kill/']
 ---
 
 # KILL [TIDB]

--- a/sql-statements/sql-statement-load-data.md
+++ b/sql-statements/sql-statement-load-data.md
@@ -2,7 +2,7 @@
 title: LOAD DATA | TiDB SQL Statement Reference
 summary: An overview of the usage of LOAD DATA for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/load-data/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-load-data/','/docs/v3.1/reference/sql/statements/load-data/']
 ---
 
 # LOAD DATA

--- a/sql-statements/sql-statement-load-stats.md
+++ b/sql-statements/sql-statement-load-stats.md
@@ -2,6 +2,7 @@
 title: LOAD STATS
 summary: An overview of the usage of LOAD STATS for the TiDB database.
 category: reference
+aliases: ['/docs/v3.1/sql-statements/sql-statement-load-stats/']
 ---
 
 # LOAD STATS

--- a/sql-statements/sql-statement-modify-column.md
+++ b/sql-statements/sql-statement-modify-column.md
@@ -2,7 +2,7 @@
 title: MODIFY COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of MODIFY COLUMN for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/modify-column/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-modify-column/','/docs/v3.1/reference/sql/statements/modify-column/']
 ---
 
 # MODIFY COLUMN

--- a/sql-statements/sql-statement-prepare.md
+++ b/sql-statements/sql-statement-prepare.md
@@ -2,7 +2,7 @@
 title: PREPARE | TiDB SQL Statement Reference
 summary: An overview of the usage of PREPARE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/prepare/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-prepare/','/docs/v3.1/reference/sql/statements/prepare/']
 ---
 
 # PREPARE

--- a/sql-statements/sql-statement-recover-table.md
+++ b/sql-statements/sql-statement-recover-table.md
@@ -2,7 +2,7 @@
 title: RECOVER TABLE
 summary: An overview of the usage of RECOVER TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/recover-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-recover-table/','/docs/v3.1/reference/sql/statements/recover-table/']
 ---
 
 # RECOVER TABLE

--- a/sql-statements/sql-statement-rename-index.md
+++ b/sql-statements/sql-statement-rename-index.md
@@ -2,7 +2,7 @@
 title: RENAME INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of RENAME INDEX for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/rename-index/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-rename-index/','/docs/v3.1/reference/sql/statements/rename-index/']
 ---
 
 # RENAME INDEX

--- a/sql-statements/sql-statement-rename-table.md
+++ b/sql-statements/sql-statement-rename-table.md
@@ -2,7 +2,7 @@
 title: RENAME TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of RENAME TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/rename-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-rename-table/','/docs/v3.1/reference/sql/statements/rename-table/']
 ---
 
 # RENAME TABLE

--- a/sql-statements/sql-statement-replace.md
+++ b/sql-statements/sql-statement-replace.md
@@ -2,7 +2,7 @@
 title: REPLACE | TiDB SQL Statement Reference
 summary: An overview of the usage of REPLACE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/replace/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-replace/','/docs/v3.1/reference/sql/statements/replace/']
 ---
 
 # REPLACE

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -2,7 +2,7 @@
 title: REVOKE <privileges> | TiDB SQL Statement Reference
 summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/revoke-privileges/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-revoke-privileges/','/docs/v3.1/reference/sql/statements/revoke-privileges/']
 ---
 
 # `REVOKE <privileges>`

--- a/sql-statements/sql-statement-rollback.md
+++ b/sql-statements/sql-statement-rollback.md
@@ -2,7 +2,7 @@
 title: ROLLBACK | TiDB SQL Statement Reference
 summary: An overview of the usage of ROLLBACK for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/rollback/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-rollback/','/docs/v3.1/reference/sql/statements/rollback/']
 ---
 
 # ROLLBACK

--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -2,7 +2,7 @@
 title: SELECT | TiDB SQL Statement Reference
 summary: An overview of the usage of SELECT for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/select/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-select/','/docs/v3.1/reference/sql/statements/select/']
 ---
 
 # SELECT

--- a/sql-statements/sql-statement-set-names.md
+++ b/sql-statements/sql-statement-set-names.md
@@ -2,7 +2,7 @@
 title: SET [NAMES|CHARACTER SET] |  TiDB SQL Statement Reference
 summary: An overview of the usage of SET [NAMES|CHARACTER SET] for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/set-names/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-set-names/','/docs/v3.1/reference/sql/statements/set-names/']
 ---
 
 # SET [NAMES|CHARACTER SET]

--- a/sql-statements/sql-statement-set-password.md
+++ b/sql-statements/sql-statement-set-password.md
@@ -2,7 +2,7 @@
 title: SET PASSWORD | TiDB SQL Statement Reference
 summary: An overview of the usage of SET PASSWORD for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/set-password/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-set-password/','/docs/v3.1/reference/sql/statements/set-password/']
 ---
 
 # SET PASSWORD

--- a/sql-statements/sql-statement-set-role.md
+++ b/sql-statements/sql-statement-set-role.md
@@ -2,6 +2,7 @@
 title: SET ROLE | TiDB SQL Statement Reference
 summary: An overview of the usage of SET ROLE for the TiDB database.
 category: reference
+aliases: ['/docs/v3.1/sql-statements/sql-statement-set-role/']
 ---
 
 # SET ROLE

--- a/sql-statements/sql-statement-set-transaction.md
+++ b/sql-statements/sql-statement-set-transaction.md
@@ -2,7 +2,7 @@
 title: SET TRANSACTION | TiDB SQL Statement Reference
 summary: An overview of the usage of SET TRANSACTION for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/set-transaction/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-set-transaction/','/docs/v3.1/reference/sql/statements/set-transaction/']
 ---
 
 # SET TRANSACTION

--- a/sql-statements/sql-statement-set-variable.md
+++ b/sql-statements/sql-statement-set-variable.md
@@ -2,7 +2,7 @@
 title: SET [GLOBAL|SESSION] <variable> | TiDB SQL Statement Reference
 summary: An overview of the usage of SET [GLOBAL|SESSION] <variable> for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/set-variable/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-set-variable/','/docs/v3.1/reference/sql/statements/set-variable/']
 ---
 
 # `SET [GLOBAL|SESSION] <variable>`

--- a/sql-statements/sql-statement-show-analyze-status.md
+++ b/sql-statements/sql-statement-show-analyze-status.md
@@ -2,6 +2,7 @@
 title: SHOW ANALYZE STATUS
 summary: An overview of the usage of SHOW ANALYZE STATUS for the TiDB database。
 category: reference
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-analyze-status/']
 ---
 
 # SHOW ANALYZE STATUS

--- a/sql-statements/sql-statement-show-character-set.md
+++ b/sql-statements/sql-statement-show-character-set.md
@@ -2,7 +2,7 @@
 title: SHOW CHARACTER SET | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CHARACTER SET for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-character-set/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-character-set/','/docs/v3.1/reference/sql/statements/show-character-set/']
 ---
 
 # SHOW CHARACTER SET

--- a/sql-statements/sql-statement-show-collation.md
+++ b/sql-statements/sql-statement-show-collation.md
@@ -2,7 +2,7 @@
 title: SHOW COLLATION | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW COLLATION for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-collation/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-collation/','/docs/v3.1/reference/sql/statements/show-collation/']
 ---
 
 # SHOW COLLATION

--- a/sql-statements/sql-statement-show-columns-from.md
+++ b/sql-statements/sql-statement-show-columns-from.md
@@ -2,7 +2,7 @@
 title: SHOW [FULL] COLUMNS FROM | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] COLUMNS FROM for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-columns-from/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-columns-from/','/docs/v3.1/reference/sql/statements/show-columns-from/']
 ---
 
 # SHOW [FULL] COLUMNS FROM

--- a/sql-statements/sql-statement-show-create-table.md
+++ b/sql-statements/sql-statement-show-create-table.md
@@ -2,7 +2,7 @@
 title: SHOW CREATE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CREATE TABLE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-create-table/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-create-table/','/docs/v3.1/reference/sql/statements/show-create-table/']
 ---
 
 # SHOW CREATE TABLE

--- a/sql-statements/sql-statement-show-create-user.md
+++ b/sql-statements/sql-statement-show-create-user.md
@@ -2,7 +2,7 @@
 title: SHOW CREATE USER | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CREATE USER for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-create-user/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-create-user/','/docs/v3.1/reference/sql/statements/show-create-user/']
 ---
 
 # SHOW CREATE USER

--- a/sql-statements/sql-statement-show-databases.md
+++ b/sql-statements/sql-statement-show-databases.md
@@ -2,7 +2,7 @@
 title: SHOW DATABASES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW DATABASES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-databases/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-databases/','/docs/v3.1/reference/sql/statements/show-databases/']
 ---
 
 # SHOW DATABASES

--- a/sql-statements/sql-statement-show-engines.md
+++ b/sql-statements/sql-statement-show-engines.md
@@ -2,7 +2,7 @@
 title: SHOW ENGINES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW ENGINES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-engines/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-engines/','/docs/v3.1/reference/sql/statements/show-engines/']
 ---
 
 # SHOW ENGINES

--- a/sql-statements/sql-statement-show-errors.md
+++ b/sql-statements/sql-statement-show-errors.md
@@ -2,7 +2,7 @@
 title: SHOW ERRORS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW ERRORS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-errors/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-errors/','/docs/v3.1/reference/sql/statements/show-errors/']
 ---
 
 # SHOW ERRORS

--- a/sql-statements/sql-statement-show-fields-from.md
+++ b/sql-statements/sql-statement-show-fields-from.md
@@ -2,7 +2,7 @@
 title: SHOW [FULL] FIELDS FROM | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] FIELDS FROM for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-fields-from/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-fields-from/','/docs/v3.1/reference/sql/statements/show-fields-from/']
 ---
 
 # SHOW [FULL] FIELDS FROM

--- a/sql-statements/sql-statement-show-grants.md
+++ b/sql-statements/sql-statement-show-grants.md
@@ -2,7 +2,7 @@
 title: SHOW GRANTS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW GRANTS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-grants/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-grants/','/docs/v3.1/reference/sql/statements/show-grants/']
 ---
 
 # SHOW GRANTS

--- a/sql-statements/sql-statement-show-index.md
+++ b/sql-statements/sql-statement-show-index.md
@@ -2,7 +2,7 @@
 title: SHOW INDEX [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW INDEX [FROM|IN] for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-index/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-index/','/docs/v3.1/reference/sql/statements/show-index/']
 ---
 
 # SHOW INDEX [FROM|IN]

--- a/sql-statements/sql-statement-show-indexes.md
+++ b/sql-statements/sql-statement-show-indexes.md
@@ -2,7 +2,7 @@
 title: SHOW INDEXES [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW INDEXES [FROM|IN] for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-indexes/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-indexes/','/docs/v3.1/reference/sql/statements/show-indexes/']
 ---
 
 # SHOW INDEXES [FROM|IN]

--- a/sql-statements/sql-statement-show-keys.md
+++ b/sql-statements/sql-statement-show-keys.md
@@ -2,7 +2,7 @@
 title: SHOW KEYS [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW KEYS [FROM|IN] for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-keys/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-keys/','/docs/v3.1/reference/sql/statements/show-keys/']
 ---
 
 # SHOW KEYS [FROM|IN]

--- a/sql-statements/sql-statement-show-privileges.md
+++ b/sql-statements/sql-statement-show-privileges.md
@@ -2,7 +2,7 @@
 title: SHOW PRIVILEGES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW PRIVILEGES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-privileges/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-privileges/','/docs/v3.1/reference/sql/statements/show-privileges/']
 ---
 
 # SHOW PRIVILEGES

--- a/sql-statements/sql-statement-show-processlist.md
+++ b/sql-statements/sql-statement-show-processlist.md
@@ -2,7 +2,7 @@
 title: SHOW [FULL] PROCESSLIST | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] PROCESSLIST for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-processlist/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-processlist/','/docs/v3.1/reference/sql/statements/show-processlist/']
 ---
 
 # SHOW [FULL] PROCESSLIST

--- a/sql-statements/sql-statement-show-schemas.md
+++ b/sql-statements/sql-statement-show-schemas.md
@@ -2,7 +2,7 @@
 title: SHOW SCHEMAS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW SCHEMAS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-schemas/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-schemas/','/docs/v3.1/reference/sql/statements/show-schemas/']
 ---
 
 # SHOW SCHEMAS

--- a/sql-statements/sql-statement-show-status.md
+++ b/sql-statements/sql-statement-show-status.md
@@ -2,7 +2,7 @@
 title: SHOW [GLOBAL|SESSION] STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] STATUS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-status/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-status/','/docs/v3.1/reference/sql/statements/show-status/']
 ---
 
 # SHOW [GLOBAL|SESSION] STATUS

--- a/sql-statements/sql-statement-show-table-regions.md
+++ b/sql-statements/sql-statement-show-table-regions.md
@@ -2,7 +2,7 @@
 title: SHOW TABLE REGIONS
 summary: Learn how to use SHOW TABLE REGIONS in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-table-regions/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-table-regions/','/docs/v3.1/reference/sql/statements/show-table-regions/']
 ---
 
 # SHOW TABLE REGIONS

--- a/sql-statements/sql-statement-show-table-status.md
+++ b/sql-statements/sql-statement-show-table-status.md
@@ -2,7 +2,7 @@
 title: SHOW TABLE STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW TABLE STATUS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-table-status/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-table-status/','/docs/v3.1/reference/sql/statements/show-table-status/']
 ---
 
 # SHOW TABLE STATUS

--- a/sql-statements/sql-statement-show-tables.md
+++ b/sql-statements/sql-statement-show-tables.md
@@ -2,7 +2,7 @@
 title: SHOW [FULL] TABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] TABLES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-tables/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-tables/','/docs/v3.1/reference/sql/statements/show-tables/']
 ---
 
 # SHOW [FULL] TABLES

--- a/sql-statements/sql-statement-show-variables.md
+++ b/sql-statements/sql-statement-show-variables.md
@@ -2,7 +2,7 @@
 title: SHOW [GLOBAL|SESSION] VARIABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] VARIABLES for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-variables/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-variables/','/docs/v3.1/reference/sql/statements/show-variables/']
 ---
 
 # SHOW [GLOBAL|SESSION] VARIABLES

--- a/sql-statements/sql-statement-show-warnings.md
+++ b/sql-statements/sql-statement-show-warnings.md
@@ -2,7 +2,7 @@
 title: SHOW WARNINGS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW WARNINGS for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/show-warnings/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-show-warnings/','/docs/v3.1/reference/sql/statements/show-warnings/']
 ---
 
 # SHOW WARNINGS

--- a/sql-statements/sql-statement-split-region.md
+++ b/sql-statements/sql-statement-split-region.md
@@ -2,7 +2,7 @@
 title: Split Region
 summary: An overview of the usage of Split Region for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/split-region/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-split-region/','/docs/v3.1/reference/sql/statements/split-region/']
 ---
 
 # Split Region

--- a/sql-statements/sql-statement-start-transaction.md
+++ b/sql-statements/sql-statement-start-transaction.md
@@ -2,7 +2,7 @@
 title: START TRANSACTION | TiDB SQL Statement Reference
 summary: An overview of the usage of START TRANSACTION for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/start-transaction/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-start-transaction/','/docs/v3.1/reference/sql/statements/start-transaction/']
 ---
 
 # START TRANSACTION

--- a/sql-statements/sql-statement-trace.md
+++ b/sql-statements/sql-statement-trace.md
@@ -2,7 +2,7 @@
 title: TRACE | TiDB SQL Statement Reference
 summary: An overview of the usage of TRACE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/trace/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-trace/','/docs/v3.1/reference/sql/statements/trace/']
 ---
 
 # TRACE

--- a/sql-statements/sql-statement-truncate.md
+++ b/sql-statements/sql-statement-truncate.md
@@ -2,7 +2,7 @@
 title: TRUNCATE | TiDB SQL Statement Reference
 summary: An overview of the usage of TRUNCATE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/truncate/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-truncate/','/docs/v3.1/reference/sql/statements/truncate/']
 ---
 
 # TRUNCATE

--- a/sql-statements/sql-statement-update.md
+++ b/sql-statements/sql-statement-update.md
@@ -2,7 +2,7 @@
 title: UPDATE | TiDB SQL Statement Reference
 summary: An overview of the usage of UPDATE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/update/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-update/','/docs/v3.1/reference/sql/statements/update/']
 ---
 
 # UPDATE

--- a/sql-statements/sql-statement-use.md
+++ b/sql-statements/sql-statement-use.md
@@ -2,7 +2,7 @@
 title: USE | TiDB SQL Statement Reference
 summary: An overview of the usage of USE for the TiDB database.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/statements/use/']
+aliases: ['/docs/v3.1/sql-statements/sql-statement-use/','/docs/v3.1/reference/sql/statements/use/']
 ---
 
 # USE

--- a/statement-summary-tables.md
+++ b/statement-summary-tables.md
@@ -2,7 +2,7 @@
 title: Statement Summary Tables
 summary: Learn about Statement Summary Table in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/statement-summary/']
+aliases: ['/docs/v3.1/statement-summary-tables/','/docs/v3.1/reference/performance/statement-summary/']
 ---
 
 # Statement Summary Tables

--- a/statistics.md
+++ b/statistics.md
@@ -2,7 +2,7 @@
 title: Introduction to Statistics
 summary: Learn how the statistics collect table-level and column-level information.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/statistics/']
+aliases: ['/docs/v3.1/statistics/','/docs/v3.1/reference/performance/statistics/']
 ---
 
 # Introduction to Statistics

--- a/support.md
+++ b/support.md
@@ -2,7 +2,7 @@
 title: Support Resources
 summary: Find support resources for your TiDB installation.
 category: support
-aliases: ['/docs/v3.1/support-resources/']
+aliases: ['/docs/v3.1/support/','/docs/v3.1/support-resources/']
 ---
 
 # Support Resources

--- a/sync-diff-inspector/route-diff.md
+++ b/sync-diff-inspector/route-diff.md
@@ -2,7 +2,7 @@
 title: Data Check for Tables with Different Schema or Table Names
 summary: Learn the data check for different database names or table names.
 category: tools
-aliases: ['/docs/v3.1/reference/tools/sync-diff-inspector/route-diff/']
+aliases: ['/docs/v3.1/sync-diff-inspector/route-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/route-diff/']
 ---
 
 # Data Check for Tables with Different Schema or Table Names

--- a/sync-diff-inspector/shard-diff.md
+++ b/sync-diff-inspector/shard-diff.md
@@ -2,7 +2,7 @@
 title: Data Check in the Sharding Scenario
 summary: Learn the data check in the sharding scenario.
 category: tools
-aliases: ['/docs/v3.1/reference/tools/sync-diff-inspector/shard-diff/']
+aliases: ['/docs/v3.1/sync-diff-inspector/shard-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/shard-diff/']
 ---
 
 # Data Check in the Sharding Scenario

--- a/sync-diff-inspector/sync-diff-inspector-overview.md
+++ b/sync-diff-inspector/sync-diff-inspector-overview.md
@@ -2,7 +2,7 @@
 title: sync-diff-inspector User Guide
 summary: Use sync-diff-inspector to compare data and repair inconsistent data.
 category: tools
-aliases: ['/docs/v3.1/reference/tools/sync-diff-inspector/overview/']
+aliases: ['/docs/v3.1/sync-diff-inspector/sync-diff-inspector-overview/','/docs/v3.1/reference/tools/sync-diff-inspector/overview/']
 ---
 
 # sync-diff-inspector User Guide

--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -2,7 +2,7 @@
 title: Data Check for TiDB Upstream and Downstream Clusters
 summary: Learn how to check data for TiDB upstream and downstream clusters.
 category: tools
-aliases: ['/docs/v3.1/reference/tools/sync-diff-inspector/tidb-diff/']
+aliases: ['/docs/v3.1/sync-diff-inspector/upstream-downstream-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/tidb-diff/']
 ---
 
 # Data Check for TiDB Upstream and Downstream Clusters

--- a/syncer-overview.md
+++ b/syncer-overview.md
@@ -2,7 +2,7 @@
 title: Syncer User Guide
 summary: Use Syncer to import data incrementally to TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/syncer/']
+aliases: ['/docs/v3.1/syncer-overview/','/docs/v3.1/reference/tools/syncer/']
 ---
 
 # Syncer User Guide

--- a/system-tables/system-table-information-schema.md
+++ b/system-tables/system-table-information-schema.md
@@ -2,7 +2,7 @@
 title: Information Schema
 summary: Learn how to use Information Schema in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/system-databases/information-schema/']
+aliases: ['/docs/v3.1/system-tables/system-table-information-schema/','/docs/v3.1/reference/system-databases/information-schema/']
 ---
 
 # Information Schema

--- a/system-tables/system-table-overview.md
+++ b/system-tables/system-table-overview.md
@@ -2,7 +2,7 @@
 title: TiDB System Tables
 summary: Learn the TiDB system tables.
 category: reference
-aliases: ['/docs/v3.1/reference/system-databases/mysql/']
+aliases: ['/docs/v3.1/system-tables/system-table-overview/','/docs/v3.1/reference/system-databases/mysql/']
 ---
 
 # TiDB System Tables

--- a/system-variables.md
+++ b/system-variables.md
@@ -2,7 +2,7 @@
 title: The System Variables
 summary: Learn how to use the system variables in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/tidb-server/mysql-variables/']
+aliases: ['/docs/v3.1/system-variables/','/docs/v3.1/reference/configuration/tidb-server/mysql-variables/']
 ---
 
 # The System Variables

--- a/technical-writing-project-ideas.md
+++ b/technical-writing-project-ideas.md
@@ -1,6 +1,7 @@
 ---
 title: Technical Writing Project Ideas
 summary: Learn about the project ideas of TiDB documentation.
+aliases: ['/docs/v3.1/technical-writing-project-ideas/']
 ---
 
 # Technical Writing Project Ideas

--- a/test-deployment-from-binary-tarball.md
+++ b/test-deployment-from-binary-tarball.md
@@ -2,7 +2,7 @@
 title: Testing Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/from-tarball/testing-environment/']
+aliases: ['/docs/v3.1/test-deployment-from-binary-tarball/','/docs/v3.1/how-to/deploy/from-tarball/testing-environment/']
 ---
 
 # Testing Deployment from Binary Tarball

--- a/test-deployment-using-docker.md
+++ b/test-deployment-using-docker.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB Using Docker
 summary: Use Docker to manually deploy a multi-node TiDB cluster on multiple machines.
 category: how-to
-aliases: ['/docs/v3.1/how-to/deploy/orchestrated/docker/']
+aliases: ['/docs/v3.1/test-deployment-using-docker/','/docs/v3.1/how-to/deploy/orchestrated/docker/']
 ---
 
 # Deploy TiDB Using Docker

--- a/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
+++ b/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
@@ -2,7 +2,7 @@
 title: Bidirectional Replication Between TiDB Clusters
 summary: Learn how to perform the bidirectional replication between TiDB clusters.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/bidirectional-replication/']
+aliases: ['/docs/v3.1/tidb-binlog/bidirectional-replication-between-tidb-clusters/','/docs/v3.1/reference/tidb-binlog/bidirectional-replication/']
 ---
 
 # Bidirectional Replication Between TiDB Clusters

--- a/tidb-binlog/binlog-slave-client.md
+++ b/tidb-binlog/binlog-slave-client.md
@@ -2,7 +2,7 @@
 title: Binlog Slave Client User Guide
 summary: Use Binlog Slave Client to consume TiDB slave binlog data from Kafka and output the data in a specific format.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/binlog-slave-client/']
+aliases: ['/docs/v3.1/tidb-binlog/binlog-slave-client/','/docs/v3.1/reference/tidb-binlog/binlog-slave-client/']
 ---
 
 # Binlog Slave Client User Guide

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/deploy/']
+aliases: ['/docs/v3.1/tidb-binlog/deploy-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/deploy/']
 ---
 
 # TiDB Binlog Cluster Deployment

--- a/tidb-binlog/handle-tidb-binlog-errors.md
+++ b/tidb-binlog/handle-tidb-binlog-errors.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Error Handling
 summary: Learn how to handle TiDB Binlog errors.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/troubleshoot/error-handling/']
+aliases: ['/docs/v3.1/tidb-binlog/handle-tidb-binlog-errors/','/docs/v3.1/reference/tidb-binlog/troubleshoot/error-handling/']
 ---
 
 # TiDB Binlog Error Handling

--- a/tidb-binlog/maintain-tidb-binlog-cluster.md
+++ b/tidb-binlog/maintain-tidb-binlog-cluster.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/maintain/']
+aliases: ['/docs/v3.1/tidb-binlog/maintain-tidb-binlog-cluster/','/docs/v3.1/reference/tidb-binlog/maintain/']
 ---
 
 # TiDB Binlog Cluster Operations

--- a/tidb-binlog/monitor-tidb-binlog-cluster.md
+++ b/tidb-binlog/monitor-tidb-binlog-cluster.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/monitor/']
+aliases: ['/docs/v3.1/tidb-binlog/monitor-tidb-binlog-cluster/','/docs/v3.1/reference/tidb-binlog/monitor/']
 ---
 
 # TiDB Binlog Monitoring

--- a/tidb-binlog/tidb-binlog-configuration-file.md
+++ b/tidb-binlog/tidb-binlog-configuration-file.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Configuration File
 summary: Learn the configuration items of TiDB Binlog.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/config/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-configuration-file/','/docs/v3.1/reference/tidb-binlog/config/']
 ---
 
 # TiDB Binlog Configuration File

--- a/tidb-binlog/tidb-binlog-faq.md
+++ b/tidb-binlog/tidb-binlog-faq.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog FAQ
 summary: Learn about the frequently asked questions (FAQs) and answers about TiDB Binlog.
 category: faq
-aliases: ['/docs/v3.1/reference/tidb-binlog/faq/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-faq/','/docs/v3.1/reference/tidb-binlog/faq/']
 ---
 
 # TiDB Binlog FAQ

--- a/tidb-binlog/tidb-binlog-glossary.md
+++ b/tidb-binlog/tidb-binlog-glossary.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Glossary
 summary: Learn the terms used in TiDB Binlog.
 category: glossary
-aliases: ['/docs/v3.1/reference/tidb-binlog/glossary/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-glossary/','/docs/v3.1/reference/tidb-binlog/glossary/']
 ---
 
 # TiDB Binlog Glossary

--- a/tidb-binlog/tidb-binlog-overview.md
+++ b/tidb-binlog/tidb-binlog-overview.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Overview
 summary: Learn overview of the cluster version of TiDB Binlog.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/overview/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-overview/','/docs/v3.1/reference/tidb-binlog/overview/']
 ---
 
 # TiDB Binlog Cluster Overview

--- a/tidb-binlog/tidb-binlog-relay-log.md
+++ b/tidb-binlog/tidb-binlog-relay-log.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Relay Log
 summary: Learn how to use relay log to maintain data consistency in extreme cases.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/relay-log/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-relay-log/','/docs/v3.1/reference/tidb-binlog/relay-log/']
 ---
 
 # TiDB Binlog Relay Log

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -2,7 +2,7 @@
 title: Reparo User Guide
 summary: Learn to use Reparo.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/reparo/']
+aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-reparo/','/docs/v3.1/reference/tidb-binlog/reparo/']
 ---
 
 # Reparo User Guide

--- a/tidb-binlog/troubleshoot-tidb-binlog.md
+++ b/tidb-binlog/troubleshoot-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Troubleshooting
 summary: Learn the troubleshooting process of TiDB Binlog.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/troubleshoot/binlog/','/docs/v3.1/how-to/troubleshoot/tidb-binlog/']
+aliases: ['/docs/v3.1/tidb-binlog/troubleshoot-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/troubleshoot/binlog/','/docs/v3.1/how-to/troubleshoot/tidb-binlog/']
 ---
 
 # TiDB Binlog Troubleshooting

--- a/tidb-binlog/upgrade-tidb-binlog.md
+++ b/tidb-binlog/upgrade-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: Upgrade TiDB Binlog
 summary: Learn how to upgrade TiDB Binlog to the latest cluster version.
 category: reference
-aliases: ['/docs/v3.1/reference/tidb-binlog/upgrade/']
+aliases: ['/docs/v3.1/tidb-binlog/upgrade-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/upgrade/']
 ---
 
 # Upgrade TiDB Binlog

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -2,7 +2,7 @@
 title: TiDB Configuration File
 summary: Learn the TiDB configuration file options that are not involved in command line options.
 category: deployment
-aliases: ['/docs/v3.1/reference/configuration/tidb-server/configuration-file/']
+aliases: ['/docs/v3.1/tidb-configuration-file/','/docs/v3.1/reference/configuration/tidb-server/configuration-file/']
 ---
 
 <!-- markdownlint-disable MD001 -->

--- a/tidb-control.md
+++ b/tidb-control.md
@@ -2,7 +2,7 @@
 title: TiDB Control User Guide
 summary: Use TiDB Control to obtain TiDB status information for debugging.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-control/']
+aliases: ['/docs/v3.1/tidb-control/','/docs/v3.1/reference/tools/tidb-control/']
 ---
 
 # TiDB Control User Guide

--- a/tidb-lightning/deploy-tidb-lightning.md
+++ b/tidb-lightning/deploy-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Deployment
 summary: Deploy TiDB Lightning to quickly import large amounts of new data.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/deployment/']
+aliases: ['/docs/v3.1/tidb-lightning/deploy-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/deployment/']
 ---
 
 # TiDB Lightning Deployment

--- a/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
+++ b/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning CSV Support
 summary: Learn how to import CSV files via TiDB Lightning.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/csv/']
+aliases: ['/docs/v3.1/tidb-lightning/migrate-from-csv-using-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/csv/']
 ---
 
 # TiDB Lightning CSV Support

--- a/tidb-lightning/monitor-tidb-lightning.md
+++ b/tidb-lightning/monitor-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Monitoring
 summary: Learn about the monitor configuration and monitoring metrics of TiDB Lightning.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/monitor/']
+aliases: ['/docs/v3.1/tidb-lightning/monitor-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/monitor/']
 ---
 
 # TiDB Lightning Monitoring

--- a/tidb-lightning/tidb-lightning-checkpoints.md
+++ b/tidb-lightning/tidb-lightning-checkpoints.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Checkpoints
 summary: Use checkpoints to avoid redoing the previously completed tasks before the crash.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/checkpoints/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-checkpoints/','/docs/v3.1/reference/tools/tidb-lightning/checkpoints/']
 ---
 
 # TiDB Lightning Checkpoints

--- a/tidb-lightning/tidb-lightning-configuration.md
+++ b/tidb-lightning/tidb-lightning-configuration.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Configuration
 summary: Learn about the CLI usage and sample configuration in TiDB Lightning.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/config/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-configuration/','/docs/v3.1/reference/tools/tidb-lightning/config/']
 ---
 
 # TiDB Lightning Configuration

--- a/tidb-lightning/tidb-lightning-faq.md
+++ b/tidb-lightning/tidb-lightning-faq.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning FAQ
 summary: Learn about the frequently asked questions (FAQs) and answers about TiDB Lightning.
 category: faq
-aliases: ['/docs/v3.1/faq/tidb-lightning/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-faq/','/docs/v3.1/faq/tidb-lightning/']
 ---
 
 # TiDB Lightning FAQ

--- a/tidb-lightning/tidb-lightning-glossary.md
+++ b/tidb-lightning/tidb-lightning-glossary.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Glossary
 summary: List of special terms used in TiDB Lightning.
 category: glossary
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/glossary/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-glossary/','/docs/v3.1/reference/tools/tidb-lightning/glossary/']
 ---
 
 # TiDB Lightning Glossary

--- a/tidb-lightning/tidb-lightning-misuse-handling.md
+++ b/tidb-lightning/tidb-lightning-misuse-handling.md
@@ -1,7 +1,7 @@
 ---
 title: Common Misuses of TiDB Lightning
 category: reference
-aliases: ['/docs/v3.1/reference/tools/error-case-handling/lightning-misuse-handling/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-misuse-handling/','/docs/v3.1/reference/tools/error-case-handling/lightning-misuse-handling/']
 ---
 
 # Common Misuses of TiDB Lightning

--- a/tidb-lightning/tidb-lightning-overview.md
+++ b/tidb-lightning/tidb-lightning-overview.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Overview
 summary: Learn about Lightning and the whole architecture.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/overview/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-overview/','/docs/v3.1/reference/tools/tidb-lightning/overview/']
 ---
 
 # TiDB Lightning Overview

--- a/tidb-lightning/tidb-lightning-table-filter.md
+++ b/tidb-lightning/tidb-lightning-table-filter.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Table Filter
 summary: Use black and white lists to filter out tables, ignoring them during import.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/table-filter/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-table-filter/','/docs/v3.1/reference/tools/tidb-lightning/table-filter/']
 ---
 
 # TiDB Lightning Table Filter

--- a/tidb-lightning/tidb-lightning-tidb-backend.md
+++ b/tidb-lightning/tidb-lightning-tidb-backend.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning TiDB-backend
 summary: Choose how to write data into the TiDB cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/tidb-backend/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-tidb-backend/','/docs/v3.1/reference/tools/tidb-lightning/tidb-backend/']
 ---
 
 # TiDB Lightning TiDB-backend

--- a/tidb-lightning/tidb-lightning-web-interface.md
+++ b/tidb-lightning/tidb-lightning-web-interface.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Web Interface
 summary: Control TiDB Lightning through the web interface.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tidb-lightning/web/']
+aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-web-interface/','/docs/v3.1/reference/tools/tidb-lightning/web/']
 ---
 
 # TiDB Lightning Web Interface

--- a/tidb-monitoring-framework.md
+++ b/tidb-monitoring-framework.md
@@ -2,7 +2,7 @@
 title: TiDB Monitoring Framework Overview
 summary: Use Prometheus and Grafana to build the TiDB monitoring framework.
 category: how-to
-aliases: ['/docs/v3.1/how-to/monitor/overview/']
+aliases: ['/docs/v3.1/tidb-monitoring-framework/','/docs/v3.1/how-to/monitor/overview/']
 ---
 
 # TiDB Monitoring Framework Overview

--- a/tidb-specific-system-variables.md
+++ b/tidb-specific-system-variables.md
@@ -2,7 +2,7 @@
 title: TiDB Specific System Variables
 summary: Use system variables specific to TiDB to optimize performance.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/tidb-server/tidb-specific-variables/']
+aliases: ['/docs/v3.1/tidb-specific-system-variables/','/docs/v3.1/reference/configuration/tidb-server/tidb-specific-variables/']
 ---
 
 # TiDB Specific System Variables

--- a/tidb-troubleshooting-map.md
+++ b/tidb-troubleshooting-map.md
@@ -2,7 +2,7 @@
 title: TiDB Troubleshooting Map
 summary: Learn how to troubleshoot common errors in TiDB.
 category: how-to
-aliases: ['/docs/v3.1/how-to/troubleshoot/diagnose-map/']
+aliases: ['/docs/v3.1/tidb-troubleshooting-map/','/docs/v3.1/how-to/troubleshoot/diagnose-map/']
 ---
 
 # TiDB Troubleshooting Map

--- a/tiflash/deploy-tiflash.md
+++ b/tiflash/deploy-tiflash.md
@@ -2,7 +2,7 @@
 title: Deploy a TiFlash Cluster
 summary: Learn the requirements and methods of deploying a TiFlash cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/deploy/']
+aliases: ['/docs/v3.1/tiflash/deploy-tiflash/','/docs/v3.1/reference/tiflash/deploy/']
 ---
 
 # Deploy a TiFlash Cluster

--- a/tiflash/maintain-tiflash.md
+++ b/tiflash/maintain-tiflash.md
@@ -2,7 +2,7 @@
 title: Maintain a TiFlash Cluster
 summary: Learn common operations when you maintain a TiFlash cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/maintain/']
+aliases: ['/docs/v3.1/tiflash/maintain-tiflash/','/docs/v3.1/reference/tiflash/maintain/']
 ---
 
 # Maintain a TiFlash Cluster

--- a/tiflash/monitor-tiflash.md
+++ b/tiflash/monitor-tiflash.md
@@ -2,7 +2,7 @@
 title: Monitor the TiFlash Cluster
 summary: Learn the monitoring items of TiFlash.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/monitor/']
+aliases: ['/docs/v3.1/tiflash/monitor-tiflash/','/docs/v3.1/reference/tiflash/monitor/']
 ---
 
 # Monitor the TiFlash Cluster

--- a/tiflash/scale-tiflash.md
+++ b/tiflash/scale-tiflash.md
@@ -2,7 +2,7 @@
 title: Scale the TiFlash Cluster
 summary: Learn how to scale in and out nodes in the TiFlash cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/scale/']
+aliases: ['/docs/v3.1/tiflash/scale-tiflash/','/docs/v3.1/reference/tiflash/scale/']
 ---
 
 # Scale the TiFlash Cluster

--- a/tiflash/tiflash-alert-rules.md
+++ b/tiflash/tiflash-alert-rules.md
@@ -2,7 +2,7 @@
 title: TiFlash Alert Rules
 summary: Learn the alert rules of the TiFlash cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/alert-rules/']
+aliases: ['/docs/v3.1/tiflash/tiflash-alert-rules/','/docs/v3.1/reference/tiflash/alert-rules/']
 ---
 
 # TiFlash Alert Rules

--- a/tiflash/tiflash-command-line-flags.md
+++ b/tiflash/tiflash-command-line-flags.md
@@ -2,6 +2,7 @@
 title: TiFlash Command-line Flags
 summary: Learn the command-line startup flags of TiFlash.
 category: reference
+aliases: ['/docs/v3.1/tiflash/tiflash-command-line-flags/']
 ---
 
 # TiFlash Command-line Flags

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -2,7 +2,7 @@
 title: Configure TiFlash
 summary: Learn how to configure TiFlash.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/configuration/']
+aliases: ['/docs/v3.1/tiflash/tiflash-configuration/','/docs/v3.1/reference/tiflash/configuration/']
 ---
 
 # Configure TiFlash

--- a/tiflash/tiflash-faq.md
+++ b/tiflash/tiflash-faq.md
@@ -2,7 +2,7 @@
 title: TiFlash FAQ
 summary: Learn the frequently asked questions (FAQs) and answers about TiFlash.
 category: faq
-aliases: ['/docs/v3.1/reference/tiflash/faq/']
+aliases: ['/docs/v3.1/tiflash/tiflash-faq/','/docs/v3.1/reference/tiflash/faq/']
 ---
 
 # TiFlash FAQ

--- a/tiflash/tiflash-overview.md
+++ b/tiflash/tiflash-overview.md
@@ -2,7 +2,7 @@
 title: TiFlash Overview
 summary: Learn the architecture and key features of TiFlash.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/overview/']
+aliases: ['/docs/v3.1/tiflash/tiflash-overview/','/docs/v3.1/reference/tiflash/overview/']
 ---
 
 # TiFlash Overview

--- a/tiflash/tune-tiflash-performance.md
+++ b/tiflash/tune-tiflash-performance.md
@@ -2,7 +2,7 @@
 title: Tune TiFlash Performance
 summary: Learn how to tune the performance of TiFlash.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/tune-performance/']
+aliases: ['/docs/v3.1/tiflash/tune-tiflash-performance/','/docs/v3.1/reference/tiflash/tune-performance/']
 ---
 
 # Tune TiFlash Performance

--- a/tiflash/upgrade-tiflash.md
+++ b/tiflash/upgrade-tiflash.md
@@ -2,7 +2,7 @@
 title: Upgrade TiFlash Nodes
 summary: Learn how to upgrade TiFlash nodes.
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/upgrade/']
+aliases: ['/docs/v3.1/tiflash/upgrade-tiflash/','/docs/v3.1/reference/tiflash/upgrade/']
 ---
 
 # Upgrade TiFlash Nodes

--- a/tiflash/use-tiflash.md
+++ b/tiflash/use-tiflash.md
@@ -1,7 +1,7 @@
 ---
 title: Use TiFlash
 category: reference
-aliases: ['/docs/v3.1/reference/tiflash/use-tiflash/']
+aliases: ['/docs/v3.1/tiflash/use-tiflash/','/docs/v3.1/reference/tiflash/use-tiflash/']
 ---
 
 # Use TiFlash

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -2,7 +2,7 @@
 title: TiKV Configuration File
 summary: Learn the TiKV configuration file.
 category: reference
-aliases: ['/docs/v3.1/reference/configuration/tikv-server/configuration-file/']
+aliases: ['/docs/v3.1/tikv-configuration-file/','/docs/v3.1/reference/configuration/tikv-server/configuration-file/']
 ---
 
 # TiKV Configuration File

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -2,7 +2,7 @@
 title: TiKV Control User Guide
 summary: Use TiKV Control to manage a TiKV cluster.
 category: reference
-aliases: ['/docs/v3.1/reference/tools/tikv-control/']
+aliases: ['/docs/v3.1/tikv-control/','/docs/v3.1/reference/tools/tikv-control/']
 ---
 
 # TiKV Control User Guide

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -2,7 +2,7 @@
 title: TiSpark User Guide
 summary: Use TiSpark to provide an HTAP solution to serve as a one-stop solution for both online transactions and analysis.
 category: reference
-aliases: ['/docs/v3.1/reference/tispark/']
+aliases: ['/docs/v3.1/tispark-overview/','/docs/v3.1/reference/tispark/']
 ---
 
 # TiSpark User Guide

--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -2,7 +2,7 @@
 title: TiDB Transaction Isolation Levels
 summary: Learn about the transaction isolation levels in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/transactions/transaction-isolation/']
+aliases: ['/docs/v3.1/transaction-isolation-levels/','/docs/v3.1/reference/transactions/transaction-isolation/']
 ---
 
 # TiDB Transaction Isolation Levels

--- a/transaction-overview.md
+++ b/transaction-overview.md
@@ -2,7 +2,7 @@
 title: Transactions
 summary: Learn transactions in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/transactions/overview/']
+aliases: ['/docs/v3.1/transaction-overview/','/docs/v3.1/reference/transactions/overview/']
 ---
 
 # Transactions

--- a/troubleshoot-tidb-cluster.md
+++ b/troubleshoot-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: TiDB Cluster Troubleshooting Guide
 summary: Learn how to diagnose and resolve issues when you use TiDB.
 category: how-to
-aliases: ['/docs/v3.1/how-to/troubleshoot/cluster-setup/']
+aliases: ['/docs/v3.1/troubleshoot-tidb-cluster/','/docs/v3.1/how-to/troubleshoot/cluster-setup/']
 ---
 
 # TiDB Cluster Troubleshooting Guide

--- a/troubleshoot-tidb-lightning.md
+++ b/troubleshoot-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: TiDB Lightning Troubleshooting
 summary: Learn about common errors and solutions of TiDB Lightning.
 category: how-to
-aliases: ['/docs/v3.1/how-to/troubleshoot/tidb-lightning/']
+aliases: ['/docs/v3.1/troubleshoot-tidb-lightning/','/docs/v3.1/how-to/troubleshoot/tidb-lightning/']
 ---
 
 # TiDB Lightning Troubleshooting

--- a/tune-tikv-performance.md
+++ b/tune-tikv-performance.md
@@ -2,7 +2,7 @@
 title: Tune TiKV Performance
 summary: Learn how to tune the TiKV parameters for optimal performance.
 category: reference
-aliases: ['/docs/v3.1/reference/performance/tune-tikv/']
+aliases: ['/docs/v3.1/tune-tikv-performance/','/docs/v3.1/reference/performance/tune-tikv/']
 ---
 
 # Tune TiKV Performance

--- a/upgrade-tidb-using-ansible.md
+++ b/upgrade-tidb-using-ansible.md
@@ -2,7 +2,7 @@
 title: TiDB 3.1 Upgrade Guide
 summary: Learn how to upgrade to TiDB 3.1 versions.
 category: how-to
-aliases: ['/docs/v3.1/how-to/upgrade/from-previous-version/']
+aliases: ['/docs/v3.1/upgrade-tidb-using-ansible/','/docs/v3.1/how-to/upgrade/from-previous-version/']
 ---
 
 # TiDB 3.1 Upgrade Guide

--- a/user-account-management.md
+++ b/user-account-management.md
@@ -2,7 +2,7 @@
 title: TiDB User Account Management
 summary: Learn how to manage a TiDB user account.
 category: reference
-aliases: ['/docs/v3.1/reference/security/user-account-management/']
+aliases: ['/docs/v3.1/user-account-management/','/docs/v3.1/reference/security/user-account-management/']
 ---
 
 # TiDB User Account Management

--- a/user-defined-variables.md
+++ b/user-defined-variables.md
@@ -2,7 +2,7 @@
 title: User-Defined Variables
 summary: Learn how to use user-defined variables.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/language-structure/user-defined-variables/']
+aliases: ['/docs/v3.1/user-defined-variables/','/docs/v3.1/reference/sql/language-structure/user-defined-variables/']
 ---
 
 # User-Defined Variables

--- a/views.md
+++ b/views.md
@@ -2,7 +2,7 @@
 title: Views
 summary: Learn how to use views in TiDB.
 category: reference
-aliases: ['/docs/v3.1/reference/sql/views/']
+aliases: ['/docs/v3.1/views/','/docs/v3.1/reference/sql/views/']
 ---
 
 # Views


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
