### PR TITLE
en: Add operator version requirement for telemetry config

### DIFF
--- a/telemetry.md
+++ b/telemetry.md
@@ -148,7 +148,7 @@ See [Deploy TiDB Operator in Kubernetes](https://docs.pingcap.com/tidb-in-kubern
 
 > **Note:**
 >
-> This configration item requires at least TiDB Operator v1.1.2 to take effect.
+> This configuration item requires TiDB Operator v1.1.2 or later to take effect.
 
 </details>
 
@@ -261,7 +261,7 @@ See [Deploy TiDB Operator in Kubernetes](https://docs.pingcap.com/tidb-in-kubern
 
 > **Note:**
 >
-> This configration item requires at least TiDB Operator v1.1.2 to take effect.
+> This configuration item requires TiDB Operator v1.1.2 or later to take effect.
 
 </details>
 

--- a/telemetry.md
+++ b/telemetry.md
@@ -146,6 +146,10 @@ Configure `spec.tidb.config.enable-telemetry: false` in `tidb-cluster.yaml` or T
 
 See [Deploy TiDB Operator in Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator) for details.
 
+> **Note:**
+>
+> This configration item requires at least TiDB Operator v1.1.2 to take effect.
+
 </details>
 
 ### Disable TiDB telemetry for deployed TiDB clusters
@@ -254,6 +258,10 @@ See [Deploy TiDB Using TiDB Ansible](/online-deployment-using-ansible.md) for de
 Configure `spec.pd.config.dashboard.disable-telemetry: true` in `tidb-cluster.yaml` or TidbCluster Custom Resource.
 
 See [Deploy TiDB Operator in Kubernetes](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tidb-operator) for details.
+
+> **Note:**
+>
+> This configration item requires at least TiDB Operator v1.1.2 to take effect.
 
 </details>
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Add a note about TiDB Operator v1.1.2 requirement 

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/3842
- Other reference link(s):
