### PR TITLE
optimistic-transaction: remove reference to being "default"

### DIFF
--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -9,7 +9,7 @@ aliases: ['/docs/dev/optimistic-transaction/','/docs/dev/reference/transactions/
 
 This document introduces the principles of TiDB's optimistic transaction model and related features.
 
-In TiDB's optimistic transaction model, for write-write conflicts, the two-phase commit begins only when the transaction is committed.
+In TiDB's optimistic transaction model, detecting the write-write conflicts only happens when committing the transaction via two-phase commit.
 
 > **Note:**
 >

--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -9,7 +9,7 @@ aliases: ['/docs/dev/optimistic-transaction/','/docs/dev/reference/transactions/
 
 This document introduces the principles of TiDB's optimistic transaction model and related features.
 
-TiDB uses the optimistic transaction model by default. In TiDB's optimistic transaction model, for write-write conflicts, the two-phase commit begins only when the transaction is committed.
+In TiDB's optimistic transaction model, for write-write conflicts, the two-phase commit begins only when the transaction is committed.
 
 > **Note:**
 >

--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -9,7 +9,7 @@ aliases: ['/docs/dev/optimistic-transaction/','/docs/dev/reference/transactions/
 
 This document introduces the principles of TiDB's optimistic transaction model and related features.
 
-In TiDB's optimistic transaction model, detecting the write-write conflicts only happens when committing the transaction via two-phase commit.
+In TiDB's optimistic transaction model, write-write conflicts are detected only at the two-phase transactional commit.
 
 > **Note:**
 >


### PR DESCRIPTION
# What is changed, added or deleted? (Required)

The documentation claimed optimistic transactions are the default. This is only true for v2.1.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
