### PR TITLE
Add aliases for 3.0 sysbench docs

### DIFF
--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1
 category: benchmark
-aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.0/benchmark/sysbench-v4/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v4.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/stable/benchmark/sysbench-v4/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/tidb/v4.0/v3.0-performance-benchmarking-with-tpcc']
+aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.0/benchmark/sysbench-v4/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v4.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/stable/benchmark/sysbench-v4/','/tidb/v4.0/v3.0-performance-benchmarking-with-tpcc']
 ---
 
 # TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1
 category: benchmark
-aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.0/benchmark/sysbench-v4/']
+aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.0/benchmark/sysbench-v4/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v4.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/stable/benchmark/sysbench-v4/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/tidb/v4.0/v3.0-performance-benchmarking-with-tpcc']
 ---
 
 # TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v3.0-performance-benchmarking-with-tpcc.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB TPC-C Performance Test Report -- v3.0 vs. v2.1
 category: benchmark
-aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/v3.0/benchmark/tpcc/']
+aliases: ['/docs/v3.0/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/v3.0/benchmark/tpcc/','/docs/stable/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/v4.0/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/stable/benchmark/tpcc/','/tidb/v4.0/v3.0-performance-benchmarking-with-tpcc']
 ---
 
 # TiDB TPC-C Performance Test Report -- v3.0 vs. v2.1


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Add aliases for `benchmark/v3.0-performance-benchmarking-with-sysbench.md` and `benchmark/v3.0-performance-benchmarking-with-tpcc.md` deleted in `release-4.0` branch.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs/pull/3181
