### PR TITLE
v3.1: remove `category` meta

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Introduction
 summary: Learn how to quickly start a TiDB cluster.
-category: introduction
 aliases: ['/docs/v3.1/']
 ---
 

--- a/adopters.md
+++ b/adopters.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Adopters
 summary: Learn about the list of TiDB adopters in various industries.
-category: adopters
 i18n_link: "https://pingcap.com/cases-cn/"
 aliases: ['/docs/v3.1/adopters/']
 ---

--- a/alert-rules.md
+++ b/alert-rules.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Cluster Alert Rules
 summary: Learn the alert rules in a TiDB cluster.
-category: reference
 aliases: ['/docs/v3.1/alert-rules/','/docs/v3.1/reference/alert-rules/']
 ---
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Architecture
 summary: The key architecture components of the TiDB platform
-category: introduction
 aliases: ['/docs/v3.1/architecture/']
 ---
 

--- a/auto-random.md
+++ b/auto-random.md
@@ -1,7 +1,6 @@
 ---
 title: AUTO_RANDOM
 summary: Learn the AUTO_RANDOM attribute.
-category: reference
 aliases: ['/docs/v3.1/auto-random/','/docs/v3.1/reference/sql/attributes/auto-random/']
 ---
 

--- a/backup-and-restore-using-mydumper-lightning.md
+++ b/backup-and-restore-using-mydumper-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: Use Mydumper and TiDB Lightning for Backup and Restoration
-category: how-to
 aliases: ['/docs/v3.1/backup-and-restore-using-mydumper-lightning/','/docs/v3.1/how-to/maintain/backup-and-restore/mydumper-lightning/','/docs/v3.1/how-to/maintain/backup-and-restore/']
 ---
 

--- a/basic-sql-operations.md
+++ b/basic-sql-operations.md
@@ -1,7 +1,6 @@
 ---
 title: Explore SQL with TiDB
 summary: Learn about the basic SQL statements for the TiDB database.
-category: how-to
 aliases: ['/docs/v3.1/basic-sql-operations/','/docs/v3.1/how-to/get-started/explore-sql/']
 ---
 

--- a/benchmark/benchmark-tidb-using-sysbench.md
+++ b/benchmark/benchmark-tidb-using-sysbench.md
@@ -1,6 +1,5 @@
 ---
 title: How to Test TiDB Using Sysbench
-category: benchmark
 aliases: ['/docs/v3.1/benchmark/benchmark-tidb-using-sysbench/','/docs/v3.1/benchmark/how-to-run-sysbench/']
 ---
 

--- a/benchmark/benchmark-tidb-using-tpcc.md
+++ b/benchmark/benchmark-tidb-using-tpcc.md
@@ -1,6 +1,5 @@
 ---
 title: How to Run TPC-C Test on TiDB
-category: benchmark
 aliases: ['/docs/v3.1/benchmark/benchmark-tidb-using-tpcc/','/docs/v3.1/benchmark/how-to-run-tpcc/']
 ---
 

--- a/benchmark/online-workloads-and-add-index-operations.md
+++ b/benchmark/online-workloads-and-add-index-operations.md
@@ -1,7 +1,6 @@
 ---
 title: Interaction Test on Online Workloads and ADD INDEX Operations
 summary: This document tests the interaction effects between online workloads and `ADD INDEX` operations.
-category: benchmark
 aliases: ['/docs/v3.1/benchmark/online-workloads-and-add-index-operations/','/docs/v3.1/benchmark/add-index-with-load/']
 ---
 

--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Sysbench Performance Test Report -- v3.0 vs. v2.1
-category: benchmark
 aliases: ['/docs/v3.1/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs/v3.1/benchmark/sysbench-v4/']
 ---
 

--- a/benchmark/v3.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v3.0-performance-benchmarking-with-tpcc.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB TPC-C Performance Test Report -- v3.0 vs. v2.1
-category: benchmark
 aliases: ['/docs/v3.1/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs/v3.1/benchmark/tpcc/']
 ---
 

--- a/best-practices/grafana-monitor-best-practices.md
+++ b/best-practices/grafana-monitor-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: Best Practices for Monitoring TiDB Using Grafana
 summary: Learn seven tips for efficiently using Grafana to monitor TiDB.
-category: reference
 aliases: ['/docs/v3.1/best-practices/grafana-monitor-best-practices/','/docs/v3.1/reference/best-practices/grafana-monitor/']
 ---
 

--- a/best-practices/haproxy-best-practices.md
+++ b/best-practices/haproxy-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: Best Practices for Using HAProxy in TiDB
 summary: This document describes best practices for configuration and usage of HAProxy in TiDB.
-category: reference
 aliases: ['/docs/v3.1/best-practices/haproxy-best-practices/','/docs/v3.1/reference/best-practices/haproxy/']
 ---
 

--- a/best-practices/high-concurrency-best-practices.md
+++ b/best-practices/high-concurrency-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: Highly Concurrent Write Best Practices
 summary: Learn best practices for highly-concurrent write-intensive workloads in TiDB.
-category: reference
 aliases: ['/docs/v3.1/best-practices/high-concurrency-best-practices/','/docs/v3.1/reference/best-practices/high-concurrency/']
 ---
 

--- a/best-practices/java-app-best-practices.md
+++ b/best-practices/java-app-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: Best Practices for Developing Java Applications with TiDB
 summary: Learn the best practices for developing Java applications with TiDB.
-category: reference
 aliases: ['/docs/v3.1/best-practices/java-app-best-practices/','/docs/v3.1/reference/best-practices/java-app/']
 ---
 

--- a/best-practices/massive-regions-best-practices.md
+++ b/best-practices/massive-regions-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: Best Practices for TiKV Performance Tuning with Massive Regions
 summary: Learn how to tune the performance of TiKV with a massive amount of Regions.
-category: reference
 aliases: ['/docs/v3.1/best-practices/massive-regions-best-practices/','/docs/v3.1/reference/best-practices/massive-regions/']
 ---
 

--- a/best-practices/pd-scheduling-best-practices.md
+++ b/best-practices/pd-scheduling-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: PD Scheduling Best Practices
 summary: Learn best practice and strategy for PD scheduling.
-category: reference
 aliases: ['/docs/v3.1/best-practices/pd-scheduling-best-practices/','/docs/v3.1/reference/best-practices/pd-scheduling/']
 ---
 

--- a/br/backup-and-restore-faq.md
+++ b/br/backup-and-restore-faq.md
@@ -1,7 +1,6 @@
 ---
 title: Backup & Restore FAQ
 summary: Learn about Frequently Asked Questions (FAQ) and the solutions of BR.
-category: FAQ
 aliases: ['/docs/v3.1/br/backup-and-restore-faq/']
 ---
 

--- a/br/backup-and-restore-tool.md
+++ b/br/backup-and-restore-tool.md
@@ -1,7 +1,6 @@
 ---
 title: Use BR to Back up and Restore Data
 summary: Learn how to back up and restore data of the TiDB cluster using BR.
-category: how-to
 aliases: ['/docs/v3.1/br/backup-and-restore-tool/','/docs/v3.1/reference/tools/br/br/','/docs/v3.1/how-to/maintain/backup-and-restore/br/']
 ---
 

--- a/br/backup-and-restore-use-cases.md
+++ b/br/backup-and-restore-use-cases.md
@@ -1,7 +1,6 @@
 ---
 title: BR Usage Scenarios
 summary: Learn the scenarios of backing up and restoring data using BR.
-category: how-to
 aliases: ['/docs/v3.1/br/backup-and-restore-use-cases/','/docs/v3.1/reference/tools/br/use-cases/']
 ---
 

--- a/certificate-authentication.md
+++ b/certificate-authentication.md
@@ -1,7 +1,6 @@
 ---
 title: Certificate-Based Authentication for Login
 summary: Learn the certificate-based authentication used for login.
-category: reference
 aliases: ['/docs/v3.1/certificate-authentication/','/docs/v3.1/reference/security/cert-based-authentication/']
 ---
 

--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -1,7 +1,6 @@
 ---
 title: Character Set Support
 summary: Learn about the supported character sets in TiDB.
-category: reference
 aliases: ['/docs/v3.1/character-set-and-collation/','/docs/v3.1/reference/sql/character-set/']
 ---
 

--- a/check-cluster-status-using-sql-statements.md
+++ b/check-cluster-status-using-sql-statements.md
@@ -1,7 +1,6 @@
 ---
 title: Check the TiDB Cluster Status Using SQL Statements
 summary: This document introduces that TiDB offers some SQL statements and system tables to check the TiDB cluster status.
-category: reference
 aliases: ['/docs/v3.1/check-cluster-status-using-sql-statements/','/docs/v3.1/reference/performance/check-cluster-status-using-sql-statements/']
 ---
 

--- a/command-line-flags-for-pd-configuration.md
+++ b/command-line-flags-for-pd-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: PD Configuration Flags
 summary: Learn some configuration flags of PD.
-category: reference
 aliases: ['/docs/v3.1/command-line-flags-for-pd-configuration/','/docs/v3.1/reference/configuration/pd-server/configuration/']
 ---
 

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Configuration Options
 summary: Learn some configuration options for TiDB
-category: reference
 aliases: ['/docs/v3.1/command-line-flags-for-tidb-configuration/','/docs/v3.1/reference/configuration/tidb-server/configuration/']
 ---
 

--- a/command-line-flags-for-tikv-configuration.md
+++ b/command-line-flags-for-tikv-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: TiKV Configuration Flags
 summary: Learn some configuration flags of TiKV.
-category: reference
 aliases: ['/docs/v3.1/command-line-flags-for-tikv-configuration/','/docs/v3.1/reference/configuration/tikv-server/configuration/']
 ---
 

--- a/comment-syntax.md
+++ b/comment-syntax.md
@@ -1,7 +1,6 @@
 ---
 title: Comment Syntax
 summary: Learn about the three comment styles in TiDB.
-category: reference
 aliases: ['/docs/v3.1/comment-syntax/','/docs/v3.1/reference/sql/language-structure/comment-syntax/']
 ---
 

--- a/community.md
+++ b/community.md
@@ -1,7 +1,6 @@
 ---
 title: Connect with us
 summary: Learn about how to connect with us.
-category: community
 aliases: ['/docs/v3.1/community/']
 ---
 

--- a/configure-memory-usage.md
+++ b/configure-memory-usage.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Memory Control
 summary: Learn how to configure the memory quota of a query and avoid OOM (out of memory).
-category: how-to
 aliases: ['/docs/v3.1/configure-memory-usage/','/docs/v3.1/how-to/configure/memory-control/']
 ---
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -1,7 +1,6 @@
 ---
 title: Placement Rules
 summary: Learn how to configure Placement Rules.
-category: how-to
 aliases: ['/docs/v3.1/configure-placement-rules/']
 ---
 

--- a/configure-store-limit.md
+++ b/configure-store-limit.md
@@ -1,7 +1,6 @@
 ---
 title: Store Limit
 summary: Learn the feature of Store Limit.
-category: how-to
 aliases: ['/docs/v3.1/configure-store-limit/']
 ---
 

--- a/configure-time-zone.md
+++ b/configure-time-zone.md
@@ -1,7 +1,6 @@
 ---
 title: Time Zone Support
 summary: Learn how to set the time zone and its format.
-category: how-to
 aliases: ['/docs/v3.1/configure-time-zone/','/docs/v3.1/how-to/configure/time-zone/']
 ---
 

--- a/connectors-and-apis.md
+++ b/connectors-and-apis.md
@@ -1,7 +1,6 @@
 ---
 title: Connectors and APIs
 summary: Learn about the connectors and APIs.
-category: reference
 aliases: ['/docs/v3.1/connectors-and-apis/','/docs/v3.1/reference/supported-clients/']
 ---
 

--- a/constraints.md
+++ b/constraints.md
@@ -1,7 +1,6 @@
 ---
 title: Constraints
 summary: Learn how SQL Constraints apply to TiDB.
-category: reference
 aliases: ['/docs/v3.1/constraints/','/docs/v3.1/reference/sql/constraints/']
 ---
 

--- a/contribute.md
+++ b/contribute.md
@@ -1,7 +1,6 @@
 ---
 title: Contribute
 summary: Learn how to contribute to the TiDB database.
-category: how-to
 aliases: ['/docs/v3.1/contribute/']
 ---
 

--- a/data-type-date-and-time.md
+++ b/data-type-date-and-time.md
@@ -1,7 +1,6 @@
 ---
 title: Date and Time Types
 summary: Learn about the supported date and time types.
-category: reference
 aliases: ['/docs/v3.1/data-type-date-and-time/','/docs/v3.1/reference/sql/data-types/date-and-time/']
 ---
 

--- a/data-type-default-values.md
+++ b/data-type-default-values.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Data Type
 summary: Learn about default values for data types in TiDB.
-category: reference
 aliases: ['/docs/v3.1/data-type-default-values/','/docs/v3.1/reference/sql/data-types/default-values/']
 ---
 

--- a/data-type-json.md
+++ b/data-type-json.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Data Type
 summary: Learn about the JSON data type in TiDB.
-category: reference
 aliases: ['/docs/v3.1/data-type-json/','/docs/v3.1/reference/sql/data-types/json/']
 ---
 

--- a/data-type-numeric.md
+++ b/data-type-numeric.md
@@ -1,7 +1,6 @@
 ---
 title: Numeric Types
 summary: Learn about numeric data types supported in TiDB.
-category: reference
 aliases: ['/docs/v3.1/data-type-numeric/','/docs/v3.1/reference/sql/data-types/numeric/']
 ---
 

--- a/data-type-overview.md
+++ b/data-type-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Data Types
 summary: Learn about the data types supported in TiDB.
-category: reference
 aliases: ['/docs/v3.1/data-type-overview/','/docs/v3.1/reference/sql/data-types/overview/']
 ---
 

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -1,7 +1,6 @@
 ---
 title: String types
 summary: Learn about the string types supported in TiDB.
-category: reference
 aliases: ['/docs/v3.1/data-type-string/','/docs/v3.1/reference/sql/data-types/string/']
 ---
 

--- a/deploy-tidb-from-binary.md
+++ b/deploy-tidb-from-binary.md
@@ -1,7 +1,6 @@
 ---
 title: Local Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/deploy-tidb-from-binary/','/docs/v3.1/how-to/get-started/deploy-tidb-from-binary/']
 ---
 

--- a/deploy-tidb-from-dbdeployer.md
+++ b/deploy-tidb-from-dbdeployer.md
@@ -1,7 +1,6 @@
 ---
 title: Install from DBdeployer
 summary: Install TiDB using the DBdeployer package manager.
-category: how-to
 aliases: ['/docs/v3.1/deploy-tidb-from-dbdeployer/','/docs/v3.1/how-to/get-started/deploy-tidb-from-dbdeployer/']
 ---
 

--- a/deploy-tidb-from-homebrew.md
+++ b/deploy-tidb-from-homebrew.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy a TiDB Cluster from Homebrew
 summary: Install TiDB using the Homebrew package manager.
-category: how-to
 aliases: ['/docs/v3.1/deploy-tidb-from-homebrew/','/docs/v3.1/how-to/get-started/deploy-tidb-from-homebrew/']
 ---
 

--- a/download-ecosystem-tools.md
+++ b/download-ecosystem-tools.md
@@ -1,7 +1,6 @@
 ---
 title: Download Tools
 summary: Download the most officially maintained versions of TiDB enterprise tools.
-category: reference
 aliases: ['/docs/v3.1/download-ecosystem-tools/','/docs/v3.1/reference/tools/download/']
 ---
 

--- a/ecosystem-tool-user-case.md
+++ b/ecosystem-tool-user-case.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Ecosystem Tools Use Cases
 summary: Learn the common use cases of TiDB ecosystem tools and how to choose the tools.
-category: reference
 aliases: ['/docs/v3.1/ecosystem-tool-user-case/']
 ---
 

--- a/ecosystem-tool-user-guide.md
+++ b/ecosystem-tool-user-guide.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Ecosystem Tools Overview
-category: reference
 aliases: ['/docs/v3.1/ecosystem-tool-user-guide/','/docs/v3.1/reference/tools/user-guide/','/docs/v3.1/how-to/migrate/from-mysql/','/docs/v3.1/how-to/migrate/incrementally-from-mysql/','/docs/v3.1/how-to/migrate/overview/']
 ---
 

--- a/enable-tls-between-components.md
+++ b/enable-tls-between-components.md
@@ -1,7 +1,6 @@
 ---
 title: Enable TLS Authentication and Encrypt the Stored Data
 summary: Learn how to enable TLS authentication and encrypt the stored data in a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/enable-tls-between-components/','/docs/v3.1/how-to/secure/enable-tls-between-components/']
 ---
 

--- a/encrypted-connections-with-tls-protocols.md
+++ b/encrypted-connections-with-tls-protocols.md
@@ -1,7 +1,6 @@
 ---
 title: Enable TLS for MySQL Clients
 summary: Use the encrypted connection to ensure data security.
-category: how-to
 aliases: ['/docs/v3.1/encrypted-connections-with-tls-protocols/','/docs/v3.1/how-to/secure/enable-tls-clients/']
 ---
 

--- a/error-codes.md
+++ b/error-codes.md
@@ -1,7 +1,6 @@
 ---
 title: Error Codes and Troubleshooting
 summary: Learn about the error codes and solutions in TiDB.
-category: reference
 aliases: ['/docs/v3.1/error-codes/','/docs/v3.1/reference/error-codes/']
 ---
 

--- a/execution-plan-binding.md
+++ b/execution-plan-binding.md
@@ -1,7 +1,6 @@
 ---
 title: Execution Plan Binding
 summary: Learn about execution plan binding operations in TiDB.
-category: reference
 aliases: ['/docs/v3.1/execution-plan-binding/','/docs/v3.1/reference/performance/execution-plan-bind/']
 ---
 

--- a/export-or-backup-using-dumpling.md
+++ b/export-or-backup-using-dumpling.md
@@ -1,7 +1,6 @@
 ---
 title: Export or Backup Data Using Dumpling
 summary: Use the Dumpling tool to export or backup data in TiDB.
-category: how-to
 aliases: ['/docs/v3.1/export-or-backup-using-dumpling/']
 ---
 

--- a/expression-syntax.md
+++ b/expression-syntax.md
@@ -1,7 +1,6 @@
 ---
 title: Expression Syntax
 summary: Learn about the expression syntax in TiDB.
-category: reference
 aliases: ['/docs/v3.1/expression-syntax/','/docs/v3.1/reference/sql/language-structure/expression-syntax/']
 ---
 

--- a/faq/tidb-faq.md
+++ b/faq/tidb-faq.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB FAQ
 summary: Learn about the most frequently asked questions (FAQs) relating to TiDB.
-category: faq
 aliases: ['/docs/v3.1/faq/tidb-faq/','/docs/v3.1/faq/tidb/']
 ---
 

--- a/faq/upgrade-faq.md
+++ b/faq/upgrade-faq.md
@@ -1,7 +1,6 @@
 ---
 title: FAQs After Upgrade
 summary: Learn about the FAQs after upgrading TiDB.
-category: faq
 aliases: ['/docs/v3.1/faq/upgrade-faq/','/docs/v3.1/faq/upgrade/']
 ---
 

--- a/follower-read.md
+++ b/follower-read.md
@@ -1,7 +1,6 @@
 ---
 title: Follower Read
 summary: This document describes the use and implementation of Follower Read.
-category: reference
 aliases: ['/docs/v3.1/follower-read/','/docs/v3.1/reference/performance/follower-read/']
 ---
 

--- a/functions-and-operators/aggregate-group-by-functions.md
+++ b/functions-and-operators/aggregate-group-by-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Aggregate (GROUP BY) Functions
 summary: Learn about the supported aggregate functions in TiDB.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/aggregate-group-by-functions/','/docs/v3.1/reference/sql/functions-and-operators/aggregate-group-by-functions/']
 ---
 

--- a/functions-and-operators/bit-functions-and-operators.md
+++ b/functions-and-operators/bit-functions-and-operators.md
@@ -1,7 +1,6 @@
 ---
 title: Bit Functions and Operators
 summary: Learn about the bit functions and operators.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/bit-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/bit-functions-and-operators/']
 ---
 

--- a/functions-and-operators/cast-functions-and-operators.md
+++ b/functions-and-operators/cast-functions-and-operators.md
@@ -1,7 +1,6 @@
 ---
 title: Cast Functions and Operators
 summary: Learn about the cast functions and operators.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/cast-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/cast-functions-and-operators/']
 ---
 

--- a/functions-and-operators/control-flow-functions.md
+++ b/functions-and-operators/control-flow-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Control Flow Functions
 summary: Learn about the Control Flow functions.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/control-flow-functions/','/docs/v3.1/reference/sql/functions-and-operators/control-flow-functions/']
 ---
 

--- a/functions-and-operators/date-and-time-functions.md
+++ b/functions-and-operators/date-and-time-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Date and Time Functions
 summary: Learn how to use the data and time functions.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/date-and-time-functions/','/docs/v3.1/reference/sql/functions-and-operators/date-and-time-functions/']
 ---
 

--- a/functions-and-operators/encryption-and-compression-functions.md
+++ b/functions-and-operators/encryption-and-compression-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Encryption and Compression Functions
 summary: Learn about the encryption and compression functions.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/encryption-and-compression-functions/','/docs/v3.1/reference/sql/functions-and-operators/encryption-and-compression-functions/']
 ---
 

--- a/functions-and-operators/expressions-pushed-down.md
+++ b/functions-and-operators/expressions-pushed-down.md
@@ -1,7 +1,6 @@
 ---
 title: List of Expressions for Pushdown
 summary: Learn a list of expressions that can be pushed down to TiKV and the related operations.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/expressions-pushed-down/','/docs/v3.1/reference/sql/functions-and-operators/expressions-pushed-down/']
 ---
 

--- a/functions-and-operators/functions-and-operators-overview.md
+++ b/functions-and-operators/functions-and-operators-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Function and Operator Reference
 summary: Learn how to use the functions and operators.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/functions-and-operators-overview/','/docs/v3.1/reference/sql/functions-and-operators/reference/']
 ---
 

--- a/functions-and-operators/information-functions.md
+++ b/functions-and-operators/information-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Information Functions
 summary: Learn about the information functions.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/information-functions/','/docs/v3.1/reference/sql/functions-and-operators/information-functions/']
 ---
 

--- a/functions-and-operators/json-functions.md
+++ b/functions-and-operators/json-functions.md
@@ -1,7 +1,6 @@
 ---
 title: JSON Functions
 summary: Learn about JSON functions.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/json-functions/','/docs/v3.1/reference/sql/functions-and-operators/json-functions/']
 ---
 

--- a/functions-and-operators/miscellaneous-functions.md
+++ b/functions-and-operators/miscellaneous-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Miscellaneous Functions
 summary: Learn about miscellaneous functions in TiDB.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/miscellaneous-functions/','/docs/v3.1/reference/sql/functions-and-operators/miscellaneous-functions/']
 ---
 

--- a/functions-and-operators/numeric-functions-and-operators.md
+++ b/functions-and-operators/numeric-functions-and-operators.md
@@ -1,7 +1,6 @@
 ---
 title: Numeric Functions and Operators
 summary: Learn about the numeric functions and operators.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/numeric-functions-and-operators/','/docs/v3.1/reference/sql/functions-and-operators/numeric-functions-and-operators/']
 ---
 

--- a/functions-and-operators/operators.md
+++ b/functions-and-operators/operators.md
@@ -1,7 +1,6 @@
 ---
 title: Operators
 summary: Learn about the operators precedence, comparison functions and operators, logical operators, and assignment operators.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/operators/','/docs/v3.1/reference/sql/functions-and-operators/operators/']
 ---
 

--- a/functions-and-operators/precision-math.md
+++ b/functions-and-operators/precision-math.md
@@ -1,7 +1,6 @@
 ---
 title: Precision Math
 summary: Learn about the precision math in TiDB.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/precision-math/','/docs/v3.1/reference/sql/functions-and-operators/precision-math/']
 ---
 

--- a/functions-and-operators/string-functions.md
+++ b/functions-and-operators/string-functions.md
@@ -1,7 +1,6 @@
 ---
 title: String Functions
 summary: Learn about the string functions in TiDB.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/string-functions/','/docs/v3.1/reference/sql/functions-and-operators/string-functions/']
 ---
 

--- a/functions-and-operators/type-conversion-in-expression-evaluation.md
+++ b/functions-and-operators/type-conversion-in-expression-evaluation.md
@@ -1,7 +1,6 @@
 ---
 title: Type Conversion in Expression Evaluation
 summary: Learn about the type conversion in expression evaluation.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/type-conversion-in-expression-evaluation/','/docs/v3.1/reference/sql/functions-and-operators/type-conversion/']
 ---
 

--- a/functions-and-operators/window-functions.md
+++ b/functions-and-operators/window-functions.md
@@ -1,7 +1,6 @@
 ---
 title: Window Functions
 summary: This document introduces window functions supported in TiDB.
-category: reference
 aliases: ['/docs/v3.1/functions-and-operators/window-functions/','/docs/v3.1/reference/sql/functions-and-operators/window-functions/']
 ---
 

--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: GC Configuration
 summary: Learn about GC configuration parameters.
-category: reference
 aliases: ['/docs/v3.1/garbage-collection-configuration/','/docs/v3.1/reference/garbage-collection/configuration/']
 ---
 

--- a/garbage-collection-overview.md
+++ b/garbage-collection-overview.md
@@ -1,7 +1,6 @@
 ---
 title: GC Overview
 summary: Learn about Garbage Collection in TiDB.
-category: reference
 aliases: ['/docs/v3.1/garbage-collection-overview/','/docs/v3.1/reference/garbage-collection/overview/']
 ---
 

--- a/generate-self-signed-certificates.md
+++ b/generate-self-signed-certificates.md
@@ -1,7 +1,6 @@
 ---
 title: Generate Self-signed Certificates
 summary: Use `cfssl` to generate self-signed certificates.
-category: how-to
 aliases: ['/docs/v3.1/generate-self-signed-certificates/','/docs/v3.1/how-to/secure/generate-self-signed-certificates/']
 ---
 

--- a/generated-columns.md
+++ b/generated-columns.md
@@ -1,7 +1,6 @@
 ---
 title: Generated Columns
 summary: Learn how to use generated columns.
-category: reference
 aliases: ['/docs/v3.1/generated-columns/','/docs/v3.1/reference/sql/generated-columns/']
 ---
 

--- a/geo-redundancy-deployment.md
+++ b/geo-redundancy-deployment.md
@@ -1,6 +1,5 @@
 ---
 title: Cross-DC Deployment Solutions
-category: how-to
 aliases: ['/docs/v3.1/geo-redundancy-deployment/','/docs/v3.1/how-to/deploy/geographic-redundancy/overview/']
 ---
 

--- a/get-started-with-tidb-binlog.md
+++ b/get-started-with-tidb-binlog.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Tutorial
 summary: Learn to deploy TiDB Binlog with a simple TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/get-started-with-tidb-binlog/','/docs/v3.1/how-to/get-started/tidb-binlog/']
 ---
 

--- a/get-started-with-tidb-lightning.md
+++ b/get-started-with-tidb-lightning.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Tutorial
 summary: Learn how to deploy TiDB Lightning and import full backup data to TiDB.
-category: how-to
 aliases: ['/docs/v3.1/get-started-with-tidb-lightning/','/docs/v3.1/how-to/get-started/tidb-lightning/']
 ---
 

--- a/get-started-with-tispark.md
+++ b/get-started-with-tispark.md
@@ -1,7 +1,6 @@
 ---
 title: TiSpark Quick Start Guide
 summary: Learn how to use TiSpark quickly.
-category: how-to
 aliases: ['/docs/v3.1/get-started-with-tispark/','/docs/v3.1/how-to/get-started/tispark/']
 ---
 

--- a/glossary.md
+++ b/glossary.md
@@ -1,7 +1,6 @@
 ---
 title: Glossary
 summary: Glossaries about TiDB.
-category: glossary
 aliases: ['/docs/v3.1/glossary/']
 ---
 

--- a/grafana-overview-dashboard.md
+++ b/grafana-overview-dashboard.md
@@ -1,7 +1,6 @@
 ---
 title: Key Metrics
 summary: Learn some key metrics displayed on the Grafana Overview dashboard.
-category: reference
 aliases: ['/docs/v3.1/grafana-overview-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/overview-dashboard/']
 ---
 

--- a/grafana-pd-dashboard.md
+++ b/grafana-pd-dashboard.md
@@ -1,7 +1,6 @@
 ---
 title: Key Monitoring Metrics of PD
 summary: Learn some key metrics displayed on the Grafana PD dashboard.
-category: reference
 aliases: ['/docs/v3.1/grafana-pd-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/pd-dashboard/']
 ---
 

--- a/grafana-tidb-dashboard.md
+++ b/grafana-tidb-dashboard.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Monitoring Metrics
 summary: Learn some key metrics displayed on the Grafana TiDB dashboard.
-category: reference
 aliases: ['/docs/v3.1/grafana-tidb-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/tidb-dashboard/']
 ---
 

--- a/grafana-tikv-dashboard.md
+++ b/grafana-tikv-dashboard.md
@@ -1,7 +1,6 @@
 ---
 title: Key Monitoring Metrics of TiKV
 summary: Learn some key metrics displayed on the Grafana TiKV dashboard.
-category: reference
 aliases: ['/docs/v3.1/grafana-tikv-dashboard/','/docs/v3.1/reference/key-monitoring-metrics/tikv-dashboard/']
 ---
 

--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -1,7 +1,6 @@
 ---
 title: Software and Hardware Recommendations
 summary: Learn the software and hardware recommendations for deploying and running TiDB.
-category: how-to
 aliases: ['/docs/v3.1/hardware-and-software-requirements/','/docs/v3.1/how-to/deploy/hardware-recommendations/']
 ---
 

--- a/identify-expensive-queries.md
+++ b/identify-expensive-queries.md
@@ -1,6 +1,5 @@
 ---
 title: Identify Expensive Queries
-category: how to
 aliases: ['/docs/v3.1/identify-expensive-queries/','/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-expensive-queries/']
 ---
 

--- a/identify-slow-queries.md
+++ b/identify-slow-queries.md
@@ -1,7 +1,6 @@
 ---
 title: Identify Slow Queries
 summary: Use the slow query log to identify problematic SQL statements.
-category: how-to
 aliases: ['/docs/v3.1/identify-slow-queries/','/docs/v3.1/how-to/maintain/identify-abnormal-queries/identify-slow-queries/','/docs-cn/v3.1/how-to/maintain/identify-slow-queries/']
 ---
 

--- a/import-example-data.md
+++ b/import-example-data.md
@@ -1,7 +1,6 @@
 ---
 title: Import Example Database
 summary: Install the Bikeshare example database.
-category: how-to
 aliases: ['/docs/v3.1/import-example-data/','/docs/v3.1/how-to/get-started/import-example-database/']
 ---
 

--- a/key-features.md
+++ b/key-features.md
@@ -1,7 +1,6 @@
 ---
 title: Key Features
 summary: Key features of the TiDB database platform.
-category: concepts
 aliases: ['/docs/v3.1/key-features/']
 ---
 

--- a/keywords-and-reserved-words.md
+++ b/keywords-and-reserved-words.md
@@ -1,7 +1,6 @@
 ---
 title: Keywords and Reserved Words
 summary: Learn about the keywords and reserved words in TiDB.
-category: reference
 aliases: ['/docs/v3.1/keywords-and-reserved-words/','/docs/v3.1/reference/sql/language-structure/keywords-and-reserved-words/']
 ---
 

--- a/literal-values.md
+++ b/literal-values.md
@@ -1,7 +1,6 @@
 ---
 title: Literal Values
 summary: This article introduces the literal values ​​of TiDB SQL statements.
-category: reference
 aliases: ['/docs/v3.1/literal-values/','/docs/v3.1/reference/sql/language-structure/literal-values/']
 ---
 

--- a/load-misuse-handling.md
+++ b/load-misuse-handling.md
@@ -1,6 +1,5 @@
 ---
 title: Common Misuses During Full Data Import
-category: reference
 aliases: ['/docs/v3.1/load-misuse-handling/','/docs/v3.1/reference/tools/error-case-handling/load-misuse-handling/']
 ---
 

--- a/loader-overview.md
+++ b/loader-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Loader Instructions
 summary: Use Loader to load data to TiDB.
-category: reference
 aliases: ['/docs/v3.1/loader-overview/','/docs/v3.1/reference/tools/loader/']
 ---
 

--- a/location-awareness.md
+++ b/location-awareness.md
@@ -1,7 +1,6 @@
 ---
 title: Cluster Topology Configuration
 summary: Learn to configure cluster topology to maximize the capacity for disaster recovery.
-category: how-to
 aliases: ['/docs/v3.1/location-awareness/','/docs/v3.1/how-to/deploy/geographic-redundancy/location-awareness/']
 ---
 

--- a/maintain-tidb-using-ansible.md
+++ b/maintain-tidb-using-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Ansible Common Operations
 summary: Learn some common operations when using TiDB Ansible to administer a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/maintain-tidb-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/ansible-operations/']
 ---
 

--- a/migrate-from-aurora-mysql-database.md
+++ b/migrate-from-aurora-mysql-database.md
@@ -1,7 +1,6 @@
 ---
 title: Migrate from MySQL (Amazon Aurora)
 summary: Learn how to migrate from MySQL (using a case of Amazon Aurora) to TiDB by using TiDB Data Migration (DM).
-category: how-to
 aliases: ['/docs/v3.1/migrate-from-aurora-mysql-database/','/docs/v3.1/how-to/migrate/from-mysql-aurora/','/docs/v3.1/how-to/migrate/from-aurora/']
 ---
 

--- a/migrate-from-mysql-mydumper-files.md
+++ b/migrate-from-mysql-mydumper-files.md
@@ -1,7 +1,6 @@
 ---
 title: Migrate Data from MySQL SQL Files
 summary: Learn how to migrate data from MySQL SQL files to TiDB using TiDB Lightning.
-category: how-to
 aliases: ['/docs/v3.1/migrate-from-mysql-mydumper-files/']
 ---
 

--- a/monitor-a-tidb-cluster.md
+++ b/monitor-a-tidb-cluster.md
@@ -1,7 +1,6 @@
 ---
 title: Monitor a TiDB Cluster
 summary: Learn how to monitor the state of a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/monitor-a-tidb-cluster/','/docs/v3.1/how-to/monitor/monitor-a-cluster/']
 ---
 

--- a/mydumper-overview.md
+++ b/mydumper-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Mydumper Instructions
 summary: Use Mydumper to export data from TiDB.
-category: reference
 aliases: ['/docs/v3.1/mydumper-overview/','/docs/v3.1/reference/tools/mydumper/']
 ---
 

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -1,7 +1,6 @@
 ---
 title: Compatibility with MySQL
 summary: Learn about the compatibility of TiDB with MySQL, and the unsupported and different features.
-category: reference
 aliases: ['/docs/v3.1/mysql-compatibility/','/docs/v3.1/reference/mysql-compatibility/']
 ---
 

--- a/offline-deployment-using-ansible.md
+++ b/offline-deployment-using-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy TiDB Offline Using TiDB Ansible
 summary: Use TiDB Ansible to deploy a TiDB cluster offline.
-category: how-to
 aliases: ['/docs/v3.1/offline-deployment-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/offline-ansible/']
 ---
 

--- a/online-deployment-using-ansible.md
+++ b/online-deployment-using-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy TiDB Using TiDB Ansible
 summary: Use TiDB Ansible to deploy a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/online-deployment-using-ansible/','/docs/v3.1/how-to/deploy/orchestrated/ansible/']
 ---
 

--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Optimistic Transaction Model
 summary: Learn the optimistic transaction model in TiDB.
-category: reference
 aliases: ['/docs/v3.1/optimistic-transaction/','/docs/v3.1/reference/transactions/transaction-optimistic/','/docs/v3.1/reference/transactions/transaction-model/']
 ---
 

--- a/optimizer-hints.md
+++ b/optimizer-hints.md
@@ -1,7 +1,6 @@
 ---
 title: Optimizer Hints
 summary: Use Optimizer Hints to influence query execution plans
-category: reference
 aliases: ['/docs/v3.1/optimizer-hints/','/docs/v3.1/reference/performance/optimizer-hints/']
 ---
 

--- a/overview.md
+++ b/overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Introduction
 summary: Learn how to quickly start a TiDB cluster.
-category: introduction
 aliases: ['/docs/v3.1/overview/']
 ---
 

--- a/partitioned-table.md
+++ b/partitioned-table.md
@@ -1,7 +1,6 @@
 ---
 title: Partitioning
 summary: Learn how to use partitioning in TiDB.
-category: reference
 aliases: ['/docs/v3.1/partitioned-table/','/docs/v3.1/reference/sql/partitioning/']
 ---
 

--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -1,7 +1,6 @@
 ---
 title: PD Configuration File
 summary: Learn the PD configuration file.
-category: reference
 aliases: ['/docs/v3.1/pd-configuration-file/','/docs/v3.1/reference/configuration/pd-server/configuration-file/']
 ---
 

--- a/pd-control.md
+++ b/pd-control.md
@@ -1,7 +1,6 @@
 ---
 title: PD Control User Guide
 summary: Use PD Control to obtain the state information of a cluster and tune a cluster.
-category: reference
 aliases: ['/docs/v3.1/pd-control/','/docs/v3.1/reference/tools/pd-control/']
 ---
 

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -1,7 +1,6 @@
 ---
 title: PD Recover User Guide
 summary: Use PD Recover to recover a PD cluster which cannot start or provide services normally.
-category: reference
 aliases: ['/docs/v3.1/pd-recover/','/docs/v3.1/reference/tools/pd-recover/']
 ---
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Pessimistic Transaction Model
 summary: Learn the pessimistic transaction model in TiDB.
-category: reference
 aliases: ['/docs/v3.1/pessimistic-transaction/','/docs/v3.1/reference/transactions/transaction-pessimistic/']
 ---
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -1,7 +1,6 @@
 ---
 title: Privilege Management
 summary: Learn how to manage the privilege.
-category: reference
 aliases: ['/docs/v3.1/privilege-management/','/docs/v3.1/reference/security/privilege-system/']
 ---
 

--- a/production-deployment-from-binary-tarball.md
+++ b/production-deployment-from-binary-tarball.md
@@ -1,7 +1,6 @@
 ---
 title: Production Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/production-deployment-from-binary-tarball/','/docs/v3.1/how-to/deploy/from-tarball/production-environment/']
 ---
 

--- a/query-execution-plan.md
+++ b/query-execution-plan.md
@@ -1,7 +1,6 @@
 ---
 title: Understand the Query Execution Plan
 summary: Learn about the execution plan information returned by the `EXPLAIN` statement in TiDB.
-category: reference
 aliases: ['/docs/v3.1/query-execution-plan/','/docs/v3.1/reference/performance/understanding-the-query-execution-plan/']
 ---
 

--- a/read-historical-data.md
+++ b/read-historical-data.md
@@ -1,7 +1,6 @@
 ---
 title: Read Historical Data
 summary: Learn about how TiDB reads data from history versions.
-category: how-to
 aliases: ['/docs/v3.1/read-historical-data/','/docs/v3.1/how-to/get-started/read-historical-data/']
 ---
 

--- a/releases/release-1.0-ga.md
+++ b/releases/release-1.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0 release notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0-ga/','/docs/v3.1/releases/ga/']
 ---
 

--- a/releases/release-1.0.1.md
+++ b/releases/release-1.0.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.1/','/docs/v3.1/releases/101/']
 ---
 

--- a/releases/release-1.0.2.md
+++ b/releases/release-1.0.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.2/','/docs/v3.1/releases/102/']
 ---
 

--- a/releases/release-1.0.3.md
+++ b/releases/release-1.0.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.3/','/docs/v3.1/releases/103/']
 ---
 

--- a/releases/release-1.0.4.md
+++ b/releases/release-1.0.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.4/','/docs/v3.1/releases/104/']
 ---
 

--- a/releases/release-1.0.5.md
+++ b/releases/release-1.0.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.5/','/docs/v3.1/releases/105/']
 ---
 

--- a/releases/release-1.0.6.md
+++ b/releases/release-1.0.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.6 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.6/','/docs/v3.1/releases/106/']
 ---
 

--- a/releases/release-1.0.7.md
+++ b/releases/release-1.0.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.7 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.7/','/docs/v3.1/releases/107/']
 ---
 

--- a/releases/release-1.0.8.md
+++ b/releases/release-1.0.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0.8 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.0.8/','/docs/v3.1/releases/108/']
 ---
 

--- a/releases/release-1.1-alpha.md
+++ b/releases/release-1.1-alpha.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.1 Alpha Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.1-alpha/','/docs/v3.1/releases/11alpha/']
 ---
 

--- a/releases/release-1.1-beta.md
+++ b/releases/release-1.1-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.1 Beta Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-1.1-beta/','/docs/v3.1/releases/11beta/']
 ---
 

--- a/releases/release-2.0-ga.md
+++ b/releases/release-2.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0-ga/','/docs/v3.1/releases/2.0ga/']
 ---
 

--- a/releases/release-2.0-rc.1.md
+++ b/releases/release-2.0-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0-rc.1/','/docs/v3.1/releases/2rc1/']
 ---
 

--- a/releases/release-2.0-rc.3.md
+++ b/releases/release-2.0-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0-rc.3/','/docs/v3.1/releases/2rc3/']
 ---
 

--- a/releases/release-2.0-rc.4.md
+++ b/releases/release-2.0-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0-rc.4/','/docs/v3.1/releases/2rc4/']
 ---
 

--- a/releases/release-2.0-rc.5.md
+++ b/releases/release-2.0-rc.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0-rc.5/','/docs/v3.1/releases/2rc5/']
 ---
 

--- a/releases/release-2.0.1.md
+++ b/releases/release-2.0.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.1/','/docs/v3.1/releases/201/']
 ---
 

--- a/releases/release-2.0.10.md
+++ b/releases/release-2.0.10.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.10 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.10/','/docs/v3.1/releases/2.0.10/']
 ---
 

--- a/releases/release-2.0.11.md
+++ b/releases/release-2.0.11.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.11 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.11/','/docs/v3.1/releases/2.0.11/']
 ---
 

--- a/releases/release-2.0.2.md
+++ b/releases/release-2.0.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.2/','/docs/v3.1/releases/202/']
 ---
 

--- a/releases/release-2.0.3.md
+++ b/releases/release-2.0.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.3/','/docs/v3.1/releases/203/']
 ---
 

--- a/releases/release-2.0.4.md
+++ b/releases/release-2.0.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.4/','/docs/v3.1/releases/204/']
 ---
 

--- a/releases/release-2.0.5.md
+++ b/releases/release-2.0.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.5/','/docs/v3.1/releases/205/']
 ---
 

--- a/releases/release-2.0.6.md
+++ b/releases/release-2.0.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.6 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.6/','/docs/v3.1/releases/206/']
 ---
 

--- a/releases/release-2.0.7.md
+++ b/releases/release-2.0.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.7 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.7/','/docs/v3.1/releases/207/']
 ---
 

--- a/releases/release-2.0.8.md
+++ b/releases/release-2.0.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.8 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.8/','/docs/v3.1/releases/208/']
 ---
 

--- a/releases/release-2.0.9.md
+++ b/releases/release-2.0.9.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.9 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.0.9/','/docs/v3.1/releases/209/']
 ---
 

--- a/releases/release-2.1-beta.md
+++ b/releases/release-2.1-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 Beta Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-beta/','/docs/v3.1/releases/21beta/']
 ---
 

--- a/releases/release-2.1-ga.md
+++ b/releases/release-2.1-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 GA Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-ga/','/docs/v3.1/releases/2.1ga/']
 ---
 

--- a/releases/release-2.1-rc.1.md
+++ b/releases/release-2.1-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-rc.1/','/docs/v3.1/releases/21rc1/']
 ---
 

--- a/releases/release-2.1-rc.2.md
+++ b/releases/release-2.1-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-rc.2/','/docs/v3.1/releases/21rc2/']
 ---
 

--- a/releases/release-2.1-rc.3.md
+++ b/releases/release-2.1-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-rc.3/','/docs/v3.1/releases/21rc3/']
 ---
 

--- a/releases/release-2.1-rc.4.md
+++ b/releases/release-2.1-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-rc.4/','/docs/v3.1/releases/21rc4/']
 ---
 

--- a/releases/release-2.1-rc.5.md
+++ b/releases/release-2.1-rc.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1-rc.5/','/docs/v3.1/releases/21rc5/']
 ---
 

--- a/releases/release-2.1.1.md
+++ b/releases/release-2.1.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.1/','/docs/v3.1/releases/2.1.1/']
 ---
 

--- a/releases/release-2.1.10.md
+++ b/releases/release-2.1.10.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.10 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.10/','/docs/v3.1/releases/2.1.10/']
 ---
 

--- a/releases/release-2.1.11.md
+++ b/releases/release-2.1.11.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.11 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.11/','/docs/v3.1/releases/2.1.11/']
 ---
 

--- a/releases/release-2.1.12.md
+++ b/releases/release-2.1.12.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.12 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.12/','/docs/v3.1/releases/2.1.12/']
 ---
 

--- a/releases/release-2.1.13.md
+++ b/releases/release-2.1.13.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.13 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.13/','/docs/v3.1/releases/2.1.13/']
 ---
 

--- a/releases/release-2.1.14.md
+++ b/releases/release-2.1.14.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.14 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.14/','/docs/v3.1/releases/2.1.14/']
 ---
 

--- a/releases/release-2.1.15.md
+++ b/releases/release-2.1.15.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.15 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.15/','/docs/v3.1/releases/2.1.15/']
 ---
 

--- a/releases/release-2.1.16.md
+++ b/releases/release-2.1.16.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.16 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.16/','/docs/v3.1/releases/2.1.16/']
 ---
 

--- a/releases/release-2.1.17.md
+++ b/releases/release-2.1.17.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.17 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.17/','/docs/v3.1/releases/2.1.17/']
 ---
 

--- a/releases/release-2.1.18.md
+++ b/releases/release-2.1.18.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.18 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.18/','/docs/v3.1/releases/2.1.18/']
 ---
 

--- a/releases/release-2.1.19.md
+++ b/releases/release-2.1.19.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.19 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.19/','/docs/v3.1/releases/2.1.19/']
 ---
 

--- a/releases/release-2.1.2.md
+++ b/releases/release-2.1.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.2/','/docs/v3.1/releases/2.1.2/']
 ---
 

--- a/releases/release-2.1.3.md
+++ b/releases/release-2.1.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.3/','/docs/v3.1/releases/2.1.3/']
 ---
 

--- a/releases/release-2.1.4.md
+++ b/releases/release-2.1.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.4/','/docs/v3.1/releases/2.1.4/']
 ---
 

--- a/releases/release-2.1.5.md
+++ b/releases/release-2.1.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.5/','/docs/v3.1/releases/2.1.5/']
 ---
 

--- a/releases/release-2.1.6.md
+++ b/releases/release-2.1.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.6 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.6/','/docs/v3.1/releases/2.1.6/']
 ---
 

--- a/releases/release-2.1.7.md
+++ b/releases/release-2.1.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.7 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.7/','/docs/v3.1/releases/2.1.7/']
 ---
 

--- a/releases/release-2.1.8.md
+++ b/releases/release-2.1.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.8 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.8/','/docs/v3.1/releases/2.1.8/']
 ---
 

--- a/releases/release-2.1.9.md
+++ b/releases/release-2.1.9.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.9 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-2.1.9/','/docs/v3.1/releases/2.1.9/']
 ---
 

--- a/releases/release-3.0-beta.md
+++ b/releases/release-3.0-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0 Beta Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0-beta/','/docs/v3.1/releases/3.0beta/']
 ---
 

--- a/releases/release-3.0-ga.md
+++ b/releases/release-3.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0 GA Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0-ga/','/docs/v3.1/releases/3.0-ga/']
 ---
 

--- a/releases/release-3.0.0-beta.1.md
+++ b/releases/release-3.0.0-beta.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0 Beta.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.0-beta.1/','/docs/v3.1/releases/3.0.0-beta.1/']
 ---
 

--- a/releases/release-3.0.0-rc.1.md
+++ b/releases/release-3.0.0-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.0-rc.1/','/docs/v3.1/releases/3.0.0-rc.1/']
 ---
 

--- a/releases/release-3.0.0-rc.2.md
+++ b/releases/release-3.0.0-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.0-rc.2/','/docs/v3.1/releases/3.0.0-rc.2/']
 ---
 

--- a/releases/release-3.0.0-rc.3.md
+++ b/releases/release-3.0.0-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.0-rc.3/','/docs/v3.1/releases/3.0.0-rc.3/']
 ---
 

--- a/releases/release-3.0.1.md
+++ b/releases/release-3.0.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.1/','/docs/v3.1/releases/3.0.1/']
 ---
 

--- a/releases/release-3.0.10.md
+++ b/releases/release-3.0.10.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.10 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.10/','/docs/v3.1/releases/3.0.10/']
 ---
 

--- a/releases/release-3.0.11.md
+++ b/releases/release-3.0.11.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.11 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.11/','/docs/v3.1/releases/3.0.11/']
 ---
 

--- a/releases/release-3.0.12.md
+++ b/releases/release-3.0.12.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.12 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.12/','/docs/v3.1/releases/3.0.12/']
 ---
 

--- a/releases/release-3.0.13.md
+++ b/releases/release-3.0.13.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.13 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.13/','/docs/v3.1/releases/3.0.13/']
 ---
 

--- a/releases/release-3.0.14.md
+++ b/releases/release-3.0.14.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.14 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.14/','/docs/v3.1/releases/3.0.14/']
 ---
 

--- a/releases/release-3.0.15.md
+++ b/releases/release-3.0.15.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.15 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.15/']
 ---
 

--- a/releases/release-3.0.16.md
+++ b/releases/release-3.0.16.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.16 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.16/']
 ---
 

--- a/releases/release-3.0.2.md
+++ b/releases/release-3.0.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.2/','/docs/v3.1/releases/3.0.2/']
 ---
 

--- a/releases/release-3.0.3.md
+++ b/releases/release-3.0.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.3 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.3/','/docs/v3.1/releases/3.0.3/']
 ---
 

--- a/releases/release-3.0.4.md
+++ b/releases/release-3.0.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.4 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.4/','/docs/v3.1/releases/3.0.4/']
 ---
 

--- a/releases/release-3.0.5.md
+++ b/releases/release-3.0.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.5 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.5/','/docs/v3.1/releases/3.0.5/']
 ---
 

--- a/releases/release-3.0.6.md
+++ b/releases/release-3.0.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.6 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.6/','/docs/v3.1/releases/3.0.6/']
 ---
 

--- a/releases/release-3.0.7.md
+++ b/releases/release-3.0.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.7 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.7/','/docs/v3.1/releases/3.0.7/']
 ---
 

--- a/releases/release-3.0.8.md
+++ b/releases/release-3.0.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.8 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.8/','/docs/v3.1/releases/3.0.8/']
 ---
 

--- a/releases/release-3.0.9.md
+++ b/releases/release-3.0.9.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.9 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.0.9/','/docs/v3.1/releases/3.0.9/']
 ---
 

--- a/releases/release-3.1.0-beta.1.md
+++ b/releases/release-3.1.0-beta.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1 Beta.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.0-beta.1/','/docs/v3.1/releases/3.1.0-beta.1/']
 ---
 

--- a/releases/release-3.1.0-beta.2.md
+++ b/releases/release-3.1.0-beta.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1 Beta.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.0-beta.2/','/docs/v3.1/releases/3.1.0-beta.2/']
 ---
 

--- a/releases/release-3.1.0-beta.md
+++ b/releases/release-3.1.0-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1 Beta Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.0-beta/','/docs/v3.1/releases/3.1.0-beta/']
 ---
 

--- a/releases/release-3.1.0-ga.md
+++ b/releases/release-3.1.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1.0 GA Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.0-ga/','/docs/v3.1/releases/3.1.0-ga/']
 ---
 

--- a/releases/release-3.1.0-rc.md
+++ b/releases/release-3.1.0-rc.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1 RC Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.0-rc/','/docs/v3.1/releases/3.1.0-rc/']
 ---
 

--- a/releases/release-3.1.1.md
+++ b/releases/release-3.1.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1.1 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.1/','/docs/v3.1/releases/3.1.1/']
 ---
 

--- a/releases/release-3.1.2.md
+++ b/releases/release-3.1.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.1.2 Release Notes
-category: Releases
 aliases: ['/docs/v3.1/releases/release-3.1.2/']
 ---
 

--- a/releases/release-notes.md
+++ b/releases/release-notes.md
@@ -1,6 +1,5 @@
 ---
 title: Release Notes
-category: release
 aliases: ['/docs/v3.1/releases/release-notes/','/docs/v3.1/releases/rn/']
 ---
 

--- a/releases/release-pre-ga.md
+++ b/releases/release-pre-ga.md
@@ -1,6 +1,5 @@
 ---
 title: Pre-GA release notes
-category: releases
 aliases: ['/docs/v3.1/releases/release-pre-ga/','/docs/v3.1/releases/prega/']
 ---
 

--- a/releases/release-rc.1.md
+++ b/releases/release-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC1 Release Notes
-category: releases
 aliases: ['/docs/v3.1/releases/release-rc.1/','/docs/v3.1/releases/rc1/']
 ---
 

--- a/releases/release-rc.2.md
+++ b/releases/release-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC2 Release Notes
-category: releases
 aliases: ['/docs/v3.1/releases/release-rc.2/','/docs/v3.1/releases/rc2/']
 ---
 

--- a/releases/release-rc.3.md
+++ b/releases/release-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC3 Release Notes
-category: releases
 aliases: ['/docs/v3.1/releases/release-rc.3/','/docs/v3.1/releases/rc3/']
 ---
 

--- a/releases/release-rc.4.md
+++ b/releases/release-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC4 Release Notes
-category: releases
 aliases: ['/docs/v3.1/releases/release-rc.4/','/docs/v3.1/releases/rc4/']
 ---
 

--- a/report-issue.md
+++ b/report-issue.md
@@ -1,7 +1,6 @@
 ---
 title: Report an Issue
 summary: Report an issue with your TiDB installation.
-category: support
 aliases: ['/docs/v3.1/report-issue/']
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB v3.0 Roadmap
 summary: Learn about the v3.0 roadmap of TiDB.
-category: Roadmap
 aliases: ['/docs/v3.1/roadmap/']
 ---
 

--- a/role-based-access-control.md
+++ b/role-based-access-control.md
@@ -1,7 +1,6 @@
 ---
 title: Role-Based Access Control
 summary: This document introduces TiDB RBAC operations and implementation.
-category: reference
 aliases: ['/docs/v3.1/role-based-access-control/','/docs/v3.1/reference/security/role-based-access-control/']
 ---
 

--- a/scale-tidb-using-ansible.md
+++ b/scale-tidb-using-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: Scale the TiDB Cluster Using TiDB Ansible
 summary: Use TiDB Ansible to increase/decrease the capacity of a TiDB/TiKV/PD node.
-category: how-to
 aliases: ['/docs/v3.1/scale-tidb-using-ansible/','/docs/v3.1/how-to/scale/with-ansible/']
 ---
 

--- a/schema-object-names.md
+++ b/schema-object-names.md
@@ -1,7 +1,6 @@
 ---
 title: Schema Object Names
 summary: Learn about the schema object names (identifiers) in TiDB.
-category: reference
 aliases: ['/docs/v3.1/schema-object-names/','/docs/v3.1/reference/sql/language-structure/schema-object-names/']
 ---
 

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -1,7 +1,6 @@
 ---
 title: Security Compatibility with MySQL
 summary: Learn TiDB's security compatibilities with MySQL.
-category: reference
 aliases: ['/docs/v3.1/security-compatibility-with-mysql/','/docs/v3.1/reference/security/compatibility/']
 ---
 

--- a/sql-mode.md
+++ b/sql-mode.md
@@ -1,7 +1,6 @@
 ﻿---
 title: SQL Mode
 summary: Learn SQL mode.
-category: reference
 aliases: ['/docs/v3.1/sql-mode/','/docs/v3.1/reference/sql/sql-mode/']
 ---
 

--- a/sql-optimization-concepts.md
+++ b/sql-optimization-concepts.md
@@ -1,7 +1,6 @@
 ---
 title: SQL Optimization Process
 summary: Learn about the logical and physical optimization of SQL in TiDB.
-category: reference
 aliases: ['/docs/v3.1/sql-optimization-concepts/','/docs/v3.1/reference/performance/sql-optimizer-overview/']
 ---
 

--- a/sql-statements/sql-statement-add-column.md
+++ b/sql-statements/sql-statement-add-column.md
@@ -1,7 +1,6 @@
 ---
 title: ADD COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of ADD COLUMN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-add-column/','/docs/v3.1/reference/sql/statements/add-column/']
 ---
 

--- a/sql-statements/sql-statement-add-index.md
+++ b/sql-statements/sql-statement-add-index.md
@@ -1,7 +1,6 @@
 ---
 title: ADD INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of ADD INDEX for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-add-index/','/docs/v3.1/reference/sql/statements/add-index/']
 ---
 

--- a/sql-statements/sql-statement-admin.md
+++ b/sql-statements/sql-statement-admin.md
@@ -1,7 +1,6 @@
 ---
 title: ADMIN | TiDB SQL Statement Reference
 summary: An overview of the usage of ADMIN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-admin/','/docs/v3.1/reference/sql/statements/admin/']
 ---
 

--- a/sql-statements/sql-statement-alter-database.md
+++ b/sql-statements/sql-statement-alter-database.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER DATABASE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-database/','/docs/v3.1/reference/sql/statements/alter-database/']
 ---
 

--- a/sql-statements/sql-statement-alter-instance.md
+++ b/sql-statements/sql-statement-alter-instance.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER INSTANCE
 summary: Learn the overview of the `ALTER INSTANCE` usage in TiDB.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-instance/','/docs/v3.1/reference/sql/statements/alter-instance/']
 ---
 

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-table/','/docs/v3.1/reference/sql/statements/alter-table/']
 ---
 

--- a/sql-statements/sql-statement-alter-user.md
+++ b/sql-statements/sql-statement-alter-user.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER USER | TiDB SQL Statement Reference
 summary: An overview of the usage of ALTER USER for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-alter-user/','/docs/v3.1/reference/sql/statements/alter-user/']
 ---
 

--- a/sql-statements/sql-statement-analyze-table.md
+++ b/sql-statements/sql-statement-analyze-table.md
@@ -1,7 +1,6 @@
 ---
 title: ANALYZE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of ANALYZE TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-analyze-table/','/docs/v3.1/reference/sql/statements/analyze-table/']
 ---
 

--- a/sql-statements/sql-statement-begin.md
+++ b/sql-statements/sql-statement-begin.md
@@ -1,7 +1,6 @@
 ---
 title: BEGIN | TiDB SQL Statement Reference
 summary: An overview of the usage of BEGIN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-begin/','/docs/v3.1/reference/sql/statements/begin/']
 ---
 

--- a/sql-statements/sql-statement-change-column.md
+++ b/sql-statements/sql-statement-change-column.md
@@ -1,7 +1,6 @@
 ---
 title: CHANGE COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of CHANGE COLUMN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-change-column/','/docs/v3.1/reference/sql/statements/change-column/']
 ---
 

--- a/sql-statements/sql-statement-commit.md
+++ b/sql-statements/sql-statement-commit.md
@@ -1,7 +1,6 @@
 ---
 title: COMMIT | TiDB SQL Statement Reference
 summary: An overview of the usage of COMMIT for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-commit/','/docs/v3.1/reference/sql/statements/commit/']
 ---
 

--- a/sql-statements/sql-statement-create-database.md
+++ b/sql-statements/sql-statement-create-database.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE DATABASE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-database/','/docs/v3.1/reference/sql/statements/create-database/']
 ---
 

--- a/sql-statements/sql-statement-create-index.md
+++ b/sql-statements/sql-statement-create-index.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE INDEX for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-index/','/docs/v3.1/reference/sql/statements/create-index/']
 ---
 

--- a/sql-statements/sql-statement-create-role.md
+++ b/sql-statements/sql-statement-create-role.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE ROLE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE ROLE for the TiDB database.
-category: reference
 ---
 
 # CREATE ROLE

--- a/sql-statements/sql-statement-create-table-like.md
+++ b/sql-statements/sql-statement-create-table-like.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE TABLE LIKE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE TABLE LIKE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-table-like/','/docs/v3.1/reference/sql/statements/create-table-like/']
 ---
 

--- a/sql-statements/sql-statement-create-table.md
+++ b/sql-statements/sql-statement-create-table.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-table/','/docs/v3.1/reference/sql/statements/create-table/']
 ---
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE USER | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE USER for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-user/','/docs/v3.1/reference/sql/statements/create-user/']
 ---
 

--- a/sql-statements/sql-statement-create-view.md
+++ b/sql-statements/sql-statement-create-view.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE VIEW | TiDB SQL Statement Reference
 summary: An overview of the usage of CREATE VIEW for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-create-view/','/docs/v3.1/reference/sql/statements/create-view/']
 ---
 

--- a/sql-statements/sql-statement-deallocate.md
+++ b/sql-statements/sql-statement-deallocate.md
@@ -1,7 +1,6 @@
 ---
 title: DEALLOCATE | TiDB SQL Statement Reference
 summary: An overview of the usage of DEALLOCATE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-deallocate/','/docs/v3.1/reference/sql/statements/deallocate/']
 ---
 

--- a/sql-statements/sql-statement-delete.md
+++ b/sql-statements/sql-statement-delete.md
@@ -1,7 +1,6 @@
 ---
 title: DELETE | TiDB SQL Statement Reference
 summary: An overview of the usage of DELETE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-delete/','/docs/v3.1/reference/sql/statements/delete/']
 ---
 

--- a/sql-statements/sql-statement-desc.md
+++ b/sql-statements/sql-statement-desc.md
@@ -1,7 +1,6 @@
 ---
 title: DESC | TiDB SQL Statement Reference
 summary: An overview of the usage of DESC for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-desc/','/docs/v3.1/reference/sql/statements/desc/']
 ---
 

--- a/sql-statements/sql-statement-describe.md
+++ b/sql-statements/sql-statement-describe.md
@@ -1,7 +1,6 @@
 ---
 title: DESCRIBE | TiDB SQL Statement Reference
 summary: An overview of the usage of DESCRIBE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-describe/','/docs/v3.1/reference/sql/statements/describe/']
 ---
 

--- a/sql-statements/sql-statement-do.md
+++ b/sql-statements/sql-statement-do.md
@@ -1,7 +1,6 @@
 ---
 title: DO | TiDB SQL Statement Reference
 summary: An overview of the usage of DO for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-do/','/docs/v3.1/reference/sql/statements/do/']
 ---
 

--- a/sql-statements/sql-statement-drop-column.md
+++ b/sql-statements/sql-statement-drop-column.md
@@ -1,7 +1,6 @@
 ---
 title: DROP COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP COLUMN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-column/','/docs/v3.1/reference/sql/statements/drop-column/']
 ---
 

--- a/sql-statements/sql-statement-drop-database.md
+++ b/sql-statements/sql-statement-drop-database.md
@@ -1,7 +1,6 @@
 ---
 title: DROP DATABASE | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP DATABASE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-database/','/docs/v3.1/reference/sql/statements/drop-database/']
 ---
 

--- a/sql-statements/sql-statement-drop-index.md
+++ b/sql-statements/sql-statement-drop-index.md
@@ -1,7 +1,6 @@
 ---
 title: DROP INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP INDEX for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-index/','/docs/v3.1/reference/sql/statements/drop-index/']
 ---
 

--- a/sql-statements/sql-statement-drop-role.md
+++ b/sql-statements/sql-statement-drop-role.md
@@ -1,7 +1,6 @@
 ---
 title: DROP ROLE | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP ROLE for the TiDB database.
-category: reference
 ---
 
 # DROP ROLE

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -1,7 +1,6 @@
 ---
 title: DROP TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-table/','/docs/v3.1/reference/sql/statements/drop-table/']
 ---
 

--- a/sql-statements/sql-statement-drop-user.md
+++ b/sql-statements/sql-statement-drop-user.md
@@ -1,7 +1,6 @@
 ---
 title: DROP USER | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP USER for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-user/','/docs/v3.1/reference/sql/statements/drop-user/']
 ---
 

--- a/sql-statements/sql-statement-drop-view.md
+++ b/sql-statements/sql-statement-drop-view.md
@@ -1,7 +1,6 @@
 ---
 title: DROP VIEW | TiDB SQL Statement Reference
 summary: An overview of the usage of DROP VIEW for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-drop-view/','/docs/v3.1/reference/sql/statements/drop-view/']
 ---
 

--- a/sql-statements/sql-statement-execute.md
+++ b/sql-statements/sql-statement-execute.md
@@ -1,7 +1,6 @@
 ---
 title: EXECUTE | TiDB SQL Statement Reference
 summary: An overview of the usage of EXECUTE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-execute/','/docs/v3.1/reference/sql/statements/execute/']
 ---
 

--- a/sql-statements/sql-statement-explain-analyze.md
+++ b/sql-statements/sql-statement-explain-analyze.md
@@ -1,7 +1,6 @@
 ---
 title: EXPLAIN ANALYZE | TiDB SQL Statement Reference
 summary: An overview of the usage of EXPLAIN ANALYZE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-explain-analyze/','/docs/v3.1/reference/sql/statements/explain-analyze/']
 ---
 

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -1,7 +1,6 @@
 ---
 title: EXPLAIN | TiDB SQL Statement Reference
 summary: An overview of the usage of EXPLAIN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-explain/','/docs/v3.1/reference/sql/statements/explain/']
 ---
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH PRIVILEGES | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-privileges/','/docs/v3.1/reference/sql/statements/flush-privileges/']
 ---
 

--- a/sql-statements/sql-statement-flush-status.md
+++ b/sql-statements/sql-statement-flush-status.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH STATUS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-status/','/docs/v3.1/reference/sql/statements/flush-status/']
 ---
 

--- a/sql-statements/sql-statement-flush-tables.md
+++ b/sql-statements/sql-statement-flush-tables.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH TABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of FLUSH TABLES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-flush-tables/','/docs/v3.1/reference/sql/statements/flush-tables/']
 ---
 

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: GRANT <privileges> | TiDB SQL Statement Reference
 summary: An overview of the usage of GRANT <privileges> for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-grant-privileges/','/docs/v3.1/reference/sql/statements/grant-privileges/']
 ---
 

--- a/sql-statements/sql-statement-grant-role.md
+++ b/sql-statements/sql-statement-grant-role.md
@@ -1,7 +1,6 @@
 ---
 title: GRANT <role> | TiDB SQL Statement Reference
 summary: An overview of the usage of GRANT <role> for the TiDB database.
-category: reference
 ---
 
 # `GRANT <role>`

--- a/sql-statements/sql-statement-insert.md
+++ b/sql-statements/sql-statement-insert.md
@@ -1,7 +1,6 @@
 ---
 title: INSERT | TiDB SQL Statement Reference
 summary: An overview of the usage of INSERT for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-insert/','/docs/v3.1/reference/sql/statements/insert/']
 ---
 

--- a/sql-statements/sql-statement-kill.md
+++ b/sql-statements/sql-statement-kill.md
@@ -1,7 +1,6 @@
 ---
 title: KILL [TIDB] | TiDB SQL Statement Reference
 summary: An overview of the usage of KILL [TIDB] for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-kill/','/docs/v3.1/reference/sql/statements/kill/']
 ---
 

--- a/sql-statements/sql-statement-load-data.md
+++ b/sql-statements/sql-statement-load-data.md
@@ -1,7 +1,6 @@
 ---
 title: LOAD DATA | TiDB SQL Statement Reference
 summary: An overview of the usage of LOAD DATA for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-load-data/','/docs/v3.1/reference/sql/statements/load-data/']
 ---
 

--- a/sql-statements/sql-statement-load-stats.md
+++ b/sql-statements/sql-statement-load-stats.md
@@ -1,7 +1,6 @@
 ---
 title: LOAD STATS
 summary: An overview of the usage of LOAD STATS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-load-stats/']
 ---
 

--- a/sql-statements/sql-statement-modify-column.md
+++ b/sql-statements/sql-statement-modify-column.md
@@ -1,7 +1,6 @@
 ---
 title: MODIFY COLUMN | TiDB SQL Statement Reference
 summary: An overview of the usage of MODIFY COLUMN for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-modify-column/','/docs/v3.1/reference/sql/statements/modify-column/']
 ---
 

--- a/sql-statements/sql-statement-prepare.md
+++ b/sql-statements/sql-statement-prepare.md
@@ -1,7 +1,6 @@
 ---
 title: PREPARE | TiDB SQL Statement Reference
 summary: An overview of the usage of PREPARE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-prepare/','/docs/v3.1/reference/sql/statements/prepare/']
 ---
 

--- a/sql-statements/sql-statement-recover-table.md
+++ b/sql-statements/sql-statement-recover-table.md
@@ -1,7 +1,6 @@
 ---
 title: RECOVER TABLE
 summary: An overview of the usage of RECOVER TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-recover-table/','/docs/v3.1/reference/sql/statements/recover-table/']
 ---
 

--- a/sql-statements/sql-statement-rename-index.md
+++ b/sql-statements/sql-statement-rename-index.md
@@ -1,7 +1,6 @@
 ---
 title: RENAME INDEX | TiDB SQL Statement Reference
 summary: An overview of the usage of RENAME INDEX for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-rename-index/','/docs/v3.1/reference/sql/statements/rename-index/']
 ---
 

--- a/sql-statements/sql-statement-rename-table.md
+++ b/sql-statements/sql-statement-rename-table.md
@@ -1,7 +1,6 @@
 ---
 title: RENAME TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of RENAME TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-rename-table/','/docs/v3.1/reference/sql/statements/rename-table/']
 ---
 

--- a/sql-statements/sql-statement-replace.md
+++ b/sql-statements/sql-statement-replace.md
@@ -1,7 +1,6 @@
 ---
 title: REPLACE | TiDB SQL Statement Reference
 summary: An overview of the usage of REPLACE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-replace/','/docs/v3.1/reference/sql/statements/replace/']
 ---
 

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: REVOKE <privileges> | TiDB SQL Statement Reference
 summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-revoke-privileges/','/docs/v3.1/reference/sql/statements/revoke-privileges/']
 ---
 

--- a/sql-statements/sql-statement-revoke-role.md
+++ b/sql-statements/sql-statement-revoke-role.md
@@ -1,7 +1,6 @@
 ---
 title: REVOKE <role> | TiDB SQL Statement Reference
 summary: An overview of the usage of REVOKE <role> for the TiDB database.
-category: reference
 ---
 
 # `REVOKE <role>`

--- a/sql-statements/sql-statement-rollback.md
+++ b/sql-statements/sql-statement-rollback.md
@@ -1,7 +1,6 @@
 ---
 title: ROLLBACK | TiDB SQL Statement Reference
 summary: An overview of the usage of ROLLBACK for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-rollback/','/docs/v3.1/reference/sql/statements/rollback/']
 ---
 

--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -1,7 +1,6 @@
 ---
 title: SELECT | TiDB SQL Statement Reference
 summary: An overview of the usage of SELECT for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-select/','/docs/v3.1/reference/sql/statements/select/']
 ---
 

--- a/sql-statements/sql-statement-set-default-role.md
+++ b/sql-statements/sql-statement-set-default-role.md
@@ -1,7 +1,6 @@
 ---
 title: SET DEFAULT ROLE | TiDB SQL Statement Reference
 summary: An overview of the usage of SET DEFAULT ROLE for the TiDB database.
-category: reference
 ---
 
 # `SET DEFAULT ROLE`

--- a/sql-statements/sql-statement-set-names.md
+++ b/sql-statements/sql-statement-set-names.md
@@ -1,7 +1,6 @@
 ---
 title: SET [NAMES|CHARACTER SET] |  TiDB SQL Statement Reference
 summary: An overview of the usage of SET [NAMES|CHARACTER SET] for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-set-names/','/docs/v3.1/reference/sql/statements/set-names/']
 ---
 

--- a/sql-statements/sql-statement-set-password.md
+++ b/sql-statements/sql-statement-set-password.md
@@ -1,7 +1,6 @@
 ---
 title: SET PASSWORD | TiDB SQL Statement Reference
 summary: An overview of the usage of SET PASSWORD for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-set-password/','/docs/v3.1/reference/sql/statements/set-password/']
 ---
 

--- a/sql-statements/sql-statement-set-role.md
+++ b/sql-statements/sql-statement-set-role.md
@@ -1,7 +1,6 @@
 ---
 title: SET ROLE | TiDB SQL Statement Reference
 summary: An overview of the usage of SET ROLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-set-role/']
 ---
 

--- a/sql-statements/sql-statement-set-transaction.md
+++ b/sql-statements/sql-statement-set-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: SET TRANSACTION | TiDB SQL Statement Reference
 summary: An overview of the usage of SET TRANSACTION for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-set-transaction/','/docs/v3.1/reference/sql/statements/set-transaction/']
 ---
 

--- a/sql-statements/sql-statement-set-variable.md
+++ b/sql-statements/sql-statement-set-variable.md
@@ -1,7 +1,6 @@
 ---
 title: SET [GLOBAL|SESSION] <variable> | TiDB SQL Statement Reference
 summary: An overview of the usage of SET [GLOBAL|SESSION] <variable> for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-set-variable/','/docs/v3.1/reference/sql/statements/set-variable/']
 ---
 

--- a/sql-statements/sql-statement-show-analyze-status.md
+++ b/sql-statements/sql-statement-show-analyze-status.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW ANALYZE STATUS
 summary: An overview of the usage of SHOW ANALYZE STATUS for the TiDB database。
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-analyze-status/']
 ---
 

--- a/sql-statements/sql-statement-show-character-set.md
+++ b/sql-statements/sql-statement-show-character-set.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW CHARACTER SET | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CHARACTER SET for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-character-set/','/docs/v3.1/reference/sql/statements/show-character-set/']
 ---
 

--- a/sql-statements/sql-statement-show-collation.md
+++ b/sql-statements/sql-statement-show-collation.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW COLLATION | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW COLLATION for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-collation/','/docs/v3.1/reference/sql/statements/show-collation/']
 ---
 

--- a/sql-statements/sql-statement-show-columns-from.md
+++ b/sql-statements/sql-statement-show-columns-from.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] COLUMNS FROM | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] COLUMNS FROM for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-columns-from/','/docs/v3.1/reference/sql/statements/show-columns-from/']
 ---
 

--- a/sql-statements/sql-statement-show-create-table.md
+++ b/sql-statements/sql-statement-show-create-table.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW CREATE TABLE | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CREATE TABLE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-create-table/','/docs/v3.1/reference/sql/statements/show-create-table/']
 ---
 

--- a/sql-statements/sql-statement-show-create-user.md
+++ b/sql-statements/sql-statement-show-create-user.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW CREATE USER | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW CREATE USER for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-create-user/','/docs/v3.1/reference/sql/statements/show-create-user/']
 ---
 

--- a/sql-statements/sql-statement-show-databases.md
+++ b/sql-statements/sql-statement-show-databases.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW DATABASES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW DATABASES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-databases/','/docs/v3.1/reference/sql/statements/show-databases/']
 ---
 

--- a/sql-statements/sql-statement-show-engines.md
+++ b/sql-statements/sql-statement-show-engines.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW ENGINES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW ENGINES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-engines/','/docs/v3.1/reference/sql/statements/show-engines/']
 ---
 

--- a/sql-statements/sql-statement-show-errors.md
+++ b/sql-statements/sql-statement-show-errors.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW ERRORS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW ERRORS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-errors/','/docs/v3.1/reference/sql/statements/show-errors/']
 ---
 

--- a/sql-statements/sql-statement-show-fields-from.md
+++ b/sql-statements/sql-statement-show-fields-from.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] FIELDS FROM | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] FIELDS FROM for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-fields-from/','/docs/v3.1/reference/sql/statements/show-fields-from/']
 ---
 

--- a/sql-statements/sql-statement-show-grants.md
+++ b/sql-statements/sql-statement-show-grants.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW GRANTS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW GRANTS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-grants/','/docs/v3.1/reference/sql/statements/show-grants/']
 ---
 

--- a/sql-statements/sql-statement-show-index.md
+++ b/sql-statements/sql-statement-show-index.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW INDEX [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW INDEX [FROM|IN] for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-index/','/docs/v3.1/reference/sql/statements/show-index/']
 ---
 

--- a/sql-statements/sql-statement-show-indexes.md
+++ b/sql-statements/sql-statement-show-indexes.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW INDEXES [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW INDEXES [FROM|IN] for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-indexes/','/docs/v3.1/reference/sql/statements/show-indexes/']
 ---
 

--- a/sql-statements/sql-statement-show-keys.md
+++ b/sql-statements/sql-statement-show-keys.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW KEYS [FROM|IN] | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW KEYS [FROM|IN] for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-keys/','/docs/v3.1/reference/sql/statements/show-keys/']
 ---
 

--- a/sql-statements/sql-statement-show-privileges.md
+++ b/sql-statements/sql-statement-show-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW PRIVILEGES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW PRIVILEGES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-privileges/','/docs/v3.1/reference/sql/statements/show-privileges/']
 ---
 

--- a/sql-statements/sql-statement-show-processlist.md
+++ b/sql-statements/sql-statement-show-processlist.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] PROCESSLIST | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] PROCESSLIST for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-processlist/','/docs/v3.1/reference/sql/statements/show-processlist/']
 ---
 

--- a/sql-statements/sql-statement-show-schemas.md
+++ b/sql-statements/sql-statement-show-schemas.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW SCHEMAS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW SCHEMAS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-schemas/','/docs/v3.1/reference/sql/statements/show-schemas/']
 ---
 

--- a/sql-statements/sql-statement-show-status.md
+++ b/sql-statements/sql-statement-show-status.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [GLOBAL|SESSION] STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] STATUS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-status/','/docs/v3.1/reference/sql/statements/show-status/']
 ---
 

--- a/sql-statements/sql-statement-show-table-regions.md
+++ b/sql-statements/sql-statement-show-table-regions.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW TABLE REGIONS
 summary: Learn how to use SHOW TABLE REGIONS in TiDB.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-table-regions/','/docs/v3.1/reference/sql/statements/show-table-regions/']
 ---
 

--- a/sql-statements/sql-statement-show-table-status.md
+++ b/sql-statements/sql-statement-show-table-status.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW TABLE STATUS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW TABLE STATUS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-table-status/','/docs/v3.1/reference/sql/statements/show-table-status/']
 ---
 

--- a/sql-statements/sql-statement-show-tables.md
+++ b/sql-statements/sql-statement-show-tables.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] TABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [FULL] TABLES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-tables/','/docs/v3.1/reference/sql/statements/show-tables/']
 ---
 

--- a/sql-statements/sql-statement-show-variables.md
+++ b/sql-statements/sql-statement-show-variables.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [GLOBAL|SESSION] VARIABLES | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW [GLOBAL|SESSION] VARIABLES for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-variables/','/docs/v3.1/reference/sql/statements/show-variables/']
 ---
 

--- a/sql-statements/sql-statement-show-warnings.md
+++ b/sql-statements/sql-statement-show-warnings.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW WARNINGS | TiDB SQL Statement Reference
 summary: An overview of the usage of SHOW WARNINGS for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-show-warnings/','/docs/v3.1/reference/sql/statements/show-warnings/']
 ---
 

--- a/sql-statements/sql-statement-split-region.md
+++ b/sql-statements/sql-statement-split-region.md
@@ -1,7 +1,6 @@
 ---
 title: Split Region
 summary: An overview of the usage of Split Region for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-split-region/','/docs/v3.1/reference/sql/statements/split-region/']
 ---
 

--- a/sql-statements/sql-statement-start-transaction.md
+++ b/sql-statements/sql-statement-start-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: START TRANSACTION | TiDB SQL Statement Reference
 summary: An overview of the usage of START TRANSACTION for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-start-transaction/','/docs/v3.1/reference/sql/statements/start-transaction/']
 ---
 

--- a/sql-statements/sql-statement-trace.md
+++ b/sql-statements/sql-statement-trace.md
@@ -1,7 +1,6 @@
 ---
 title: TRACE | TiDB SQL Statement Reference
 summary: An overview of the usage of TRACE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-trace/','/docs/v3.1/reference/sql/statements/trace/']
 ---
 

--- a/sql-statements/sql-statement-truncate.md
+++ b/sql-statements/sql-statement-truncate.md
@@ -1,7 +1,6 @@
 ---
 title: TRUNCATE | TiDB SQL Statement Reference
 summary: An overview of the usage of TRUNCATE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-truncate/','/docs/v3.1/reference/sql/statements/truncate/']
 ---
 

--- a/sql-statements/sql-statement-update.md
+++ b/sql-statements/sql-statement-update.md
@@ -1,7 +1,6 @@
 ---
 title: UPDATE | TiDB SQL Statement Reference
 summary: An overview of the usage of UPDATE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-update/','/docs/v3.1/reference/sql/statements/update/']
 ---
 

--- a/sql-statements/sql-statement-use.md
+++ b/sql-statements/sql-statement-use.md
@@ -1,7 +1,6 @@
 ---
 title: USE | TiDB SQL Statement Reference
 summary: An overview of the usage of USE for the TiDB database.
-category: reference
 aliases: ['/docs/v3.1/sql-statements/sql-statement-use/','/docs/v3.1/reference/sql/statements/use/']
 ---
 

--- a/statement-summary-tables.md
+++ b/statement-summary-tables.md
@@ -1,7 +1,6 @@
 ---
 title: Statement Summary Tables
 summary: Learn about Statement Summary Table in TiDB.
-category: reference
 aliases: ['/docs/v3.1/statement-summary-tables/','/docs/v3.1/reference/performance/statement-summary/']
 ---
 

--- a/statistics.md
+++ b/statistics.md
@@ -1,7 +1,6 @@
 ---
 title: Introduction to Statistics
 summary: Learn how the statistics collect table-level and column-level information.
-category: reference
 aliases: ['/docs/v3.1/statistics/','/docs/v3.1/reference/performance/statistics/']
 ---
 

--- a/support.md
+++ b/support.md
@@ -1,7 +1,6 @@
 ---
 title: Support Resources
 summary: Find support resources for your TiDB installation.
-category: support
 aliases: ['/docs/v3.1/support/','/docs/v3.1/support-resources/']
 ---
 

--- a/sync-diff-inspector/route-diff.md
+++ b/sync-diff-inspector/route-diff.md
@@ -1,7 +1,6 @@
 ---
 title: Data Check for Tables with Different Schema or Table Names
 summary: Learn the data check for different database names or table names.
-category: tools
 aliases: ['/docs/v3.1/sync-diff-inspector/route-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/route-diff/']
 ---
 

--- a/sync-diff-inspector/shard-diff.md
+++ b/sync-diff-inspector/shard-diff.md
@@ -1,7 +1,6 @@
 ---
 title: Data Check in the Sharding Scenario
 summary: Learn the data check in the sharding scenario.
-category: tools
 aliases: ['/docs/v3.1/sync-diff-inspector/shard-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/shard-diff/']
 ---
 

--- a/sync-diff-inspector/sync-diff-inspector-overview.md
+++ b/sync-diff-inspector/sync-diff-inspector-overview.md
@@ -1,7 +1,6 @@
 ---
 title: sync-diff-inspector User Guide
 summary: Use sync-diff-inspector to compare data and repair inconsistent data.
-category: tools
 aliases: ['/docs/v3.1/sync-diff-inspector/sync-diff-inspector-overview/','/docs/v3.1/reference/tools/sync-diff-inspector/overview/']
 ---
 

--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -1,7 +1,6 @@
 ---
 title: Data Check for TiDB Upstream and Downstream Clusters
 summary: Learn how to check data for TiDB upstream and downstream clusters.
-category: tools
 aliases: ['/docs/v3.1/sync-diff-inspector/upstream-downstream-diff/','/docs/v3.1/reference/tools/sync-diff-inspector/tidb-diff/']
 ---
 

--- a/syncer-overview.md
+++ b/syncer-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Syncer User Guide
 summary: Use Syncer to import data incrementally to TiDB.
-category: reference
 aliases: ['/docs/v3.1/syncer-overview/','/docs/v3.1/reference/tools/syncer/']
 ---
 

--- a/system-tables/system-table-information-schema.md
+++ b/system-tables/system-table-information-schema.md
@@ -1,7 +1,6 @@
 ---
 title: Information Schema
 summary: Learn how to use Information Schema in TiDB.
-category: reference
 aliases: ['/docs/v3.1/system-tables/system-table-information-schema/','/docs/v3.1/reference/system-databases/information-schema/']
 ---
 

--- a/system-tables/system-table-overview.md
+++ b/system-tables/system-table-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB System Tables
 summary: Learn the TiDB system tables.
-category: reference
 aliases: ['/docs/v3.1/system-tables/system-table-overview/','/docs/v3.1/reference/system-databases/mysql/']
 ---
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1,7 +1,6 @@
 ---
 title: The System Variables
 summary: Learn how to use the system variables in TiDB.
-category: reference
 aliases: ['/docs/v3.1/system-variables/','/docs/v3.1/reference/configuration/tidb-server/mysql-variables/']
 ---
 

--- a/table-filter.md
+++ b/table-filter.md
@@ -1,7 +1,6 @@
 ---
 title: Table Filter
 summary: Usage of table filter feature in TiDB tools.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-table-filter/','/docs/v3.1/reference/tools/tidb-lightning/table-filter/','/tidb/v3.1/tidb-lightning-table-filter/']
 ---
 

--- a/test-deployment-from-binary-tarball.md
+++ b/test-deployment-from-binary-tarball.md
@@ -1,7 +1,6 @@
 ---
 title: Testing Deployment from Binary Tarball
 summary: Use the binary to deploy a TiDB cluster.
-category: how-to
 aliases: ['/docs/v3.1/test-deployment-from-binary-tarball/','/docs/v3.1/how-to/deploy/from-tarball/testing-environment/']
 ---
 

--- a/test-deployment-using-docker.md
+++ b/test-deployment-using-docker.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy TiDB Using Docker
 summary: Use Docker to manually deploy a multi-node TiDB cluster on multiple machines.
-category: how-to
 aliases: ['/docs/v3.1/test-deployment-using-docker/','/docs/v3.1/how-to/deploy/orchestrated/docker/']
 ---
 

--- a/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
+++ b/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
@@ -1,7 +1,6 @@
 ---
 title: Bidirectional Replication Between TiDB Clusters
 summary: Learn how to perform the bidirectional replication between TiDB clusters.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/bidirectional-replication-between-tidb-clusters/','/docs/v3.1/reference/tidb-binlog/bidirectional-replication/']
 ---
 

--- a/tidb-binlog/binlog-slave-client.md
+++ b/tidb-binlog/binlog-slave-client.md
@@ -1,7 +1,6 @@
 ---
 title: Binlog Slave Client User Guide
 summary: Use Binlog Slave Client to consume TiDB slave binlog data from Kafka and output the data in a specific format.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/binlog-slave-client/','/docs/v3.1/reference/tidb-binlog/binlog-slave-client/']
 ---
 

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/deploy-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/deploy/']
 ---
 

--- a/tidb-binlog/handle-tidb-binlog-errors.md
+++ b/tidb-binlog/handle-tidb-binlog-errors.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Error Handling
 summary: Learn how to handle TiDB Binlog errors.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/handle-tidb-binlog-errors/','/docs/v3.1/reference/tidb-binlog/troubleshoot/error-handling/']
 ---
 

--- a/tidb-binlog/maintain-tidb-binlog-cluster.md
+++ b/tidb-binlog/maintain-tidb-binlog-cluster.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/maintain-tidb-binlog-cluster/','/docs/v3.1/reference/tidb-binlog/maintain/']
 ---
 

--- a/tidb-binlog/monitor-tidb-binlog-cluster.md
+++ b/tidb-binlog/monitor-tidb-binlog-cluster.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/monitor-tidb-binlog-cluster/','/docs/v3.1/reference/tidb-binlog/monitor/']
 ---
 

--- a/tidb-binlog/tidb-binlog-configuration-file.md
+++ b/tidb-binlog/tidb-binlog-configuration-file.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Configuration File
 summary: Learn the configuration items of TiDB Binlog.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-configuration-file/','/docs/v3.1/reference/tidb-binlog/config/']
 ---
 

--- a/tidb-binlog/tidb-binlog-faq.md
+++ b/tidb-binlog/tidb-binlog-faq.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog FAQ
 summary: Learn about the frequently asked questions (FAQs) and answers about TiDB Binlog.
-category: faq
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-faq/','/docs/v3.1/reference/tidb-binlog/faq/']
 ---
 

--- a/tidb-binlog/tidb-binlog-glossary.md
+++ b/tidb-binlog/tidb-binlog-glossary.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Glossary
 summary: Learn the terms used in TiDB Binlog.
-category: glossary
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-glossary/','/docs/v3.1/reference/tidb-binlog/glossary/']
 ---
 

--- a/tidb-binlog/tidb-binlog-overview.md
+++ b/tidb-binlog/tidb-binlog-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Overview
 summary: Learn overview of the cluster version of TiDB Binlog.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-overview/','/docs/v3.1/reference/tidb-binlog/overview/']
 ---
 

--- a/tidb-binlog/tidb-binlog-relay-log.md
+++ b/tidb-binlog/tidb-binlog-relay-log.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Relay Log
 summary: Learn how to use relay log to maintain data consistency in extreme cases.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-relay-log/','/docs/v3.1/reference/tidb-binlog/relay-log/']
 ---
 

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -1,7 +1,6 @@
 ---
 title: Reparo User Guide
 summary: Learn to use Reparo.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/tidb-binlog-reparo/','/docs/v3.1/reference/tidb-binlog/reparo/']
 ---
 

--- a/tidb-binlog/troubleshoot-tidb-binlog.md
+++ b/tidb-binlog/troubleshoot-tidb-binlog.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog Troubleshooting
 summary: Learn the troubleshooting process of TiDB Binlog.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/troubleshoot-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/troubleshoot/binlog/','/docs/v3.1/how-to/troubleshoot/tidb-binlog/']
 ---
 

--- a/tidb-binlog/upgrade-tidb-binlog.md
+++ b/tidb-binlog/upgrade-tidb-binlog.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrade TiDB Binlog
 summary: Learn how to upgrade TiDB Binlog to the latest cluster version.
-category: reference
 aliases: ['/docs/v3.1/tidb-binlog/upgrade-tidb-binlog/','/docs/v3.1/reference/tidb-binlog/upgrade/']
 ---
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Configuration File
 summary: Learn the TiDB configuration file options that are not involved in command line options.
-category: deployment
 aliases: ['/docs/v3.1/tidb-configuration-file/','/docs/v3.1/reference/configuration/tidb-server/configuration-file/']
 ---
 

--- a/tidb-control.md
+++ b/tidb-control.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Control User Guide
 summary: Use TiDB Control to obtain TiDB status information for debugging.
-category: reference
 aliases: ['/docs/v3.1/tidb-control/','/docs/v3.1/reference/tools/tidb-control/']
 ---
 

--- a/tidb-lightning/deploy-tidb-lightning.md
+++ b/tidb-lightning/deploy-tidb-lightning.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Deployment
 summary: Deploy TiDB Lightning to quickly import large amounts of new data.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/deploy-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/deployment/']
 ---
 

--- a/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
+++ b/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning CSV Support
 summary: Learn how to import CSV files via TiDB Lightning.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/migrate-from-csv-using-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/csv/']
 ---
 

--- a/tidb-lightning/monitor-tidb-lightning.md
+++ b/tidb-lightning/monitor-tidb-lightning.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Monitoring
 summary: Learn about the monitor configuration and monitoring metrics of TiDB Lightning.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/monitor-tidb-lightning/','/docs/v3.1/reference/tools/tidb-lightning/monitor/']
 ---
 

--- a/tidb-lightning/tidb-lightning-checkpoints.md
+++ b/tidb-lightning/tidb-lightning-checkpoints.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Checkpoints
 summary: Use checkpoints to avoid redoing the previously completed tasks before the crash.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-checkpoints/','/docs/v3.1/reference/tools/tidb-lightning/checkpoints/']
 ---
 

--- a/tidb-lightning/tidb-lightning-configuration.md
+++ b/tidb-lightning/tidb-lightning-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Configuration
 summary: Learn about the CLI usage and sample configuration in TiDB Lightning.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-configuration/','/docs/v3.1/reference/tools/tidb-lightning/config/']
 ---
 

--- a/tidb-lightning/tidb-lightning-faq.md
+++ b/tidb-lightning/tidb-lightning-faq.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning FAQ
 summary: Learn about the frequently asked questions (FAQs) and answers about TiDB Lightning.
-category: faq
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-faq/','/docs/v3.1/faq/tidb-lightning/']
 ---
 

--- a/tidb-lightning/tidb-lightning-glossary.md
+++ b/tidb-lightning/tidb-lightning-glossary.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Glossary
 summary: List of special terms used in TiDB Lightning.
-category: glossary
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-glossary/','/docs/v3.1/reference/tools/tidb-lightning/glossary/']
 ---
 

--- a/tidb-lightning/tidb-lightning-misuse-handling.md
+++ b/tidb-lightning/tidb-lightning-misuse-handling.md
@@ -1,6 +1,5 @@
 ---
 title: Common Misuses of TiDB Lightning
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-misuse-handling/','/docs/v3.1/reference/tools/error-case-handling/lightning-misuse-handling/']
 ---
 

--- a/tidb-lightning/tidb-lightning-overview.md
+++ b/tidb-lightning/tidb-lightning-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Overview
 summary: Learn about Lightning and the whole architecture.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-overview/','/docs/v3.1/reference/tools/tidb-lightning/overview/']
 ---
 

--- a/tidb-lightning/tidb-lightning-table-filter.md
+++ b/tidb-lightning/tidb-lightning-table-filter.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Table Filter
 summary: Use black and white lists to filter out tables, ignoring them during import.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-table-filter/','/docs/v3.1/reference/tools/tidb-lightning/table-filter/']
 ---
 

--- a/tidb-lightning/tidb-lightning-tidb-backend.md
+++ b/tidb-lightning/tidb-lightning-tidb-backend.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning TiDB-backend
 summary: Choose how to write data into the TiDB cluster.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-tidb-backend/','/docs/v3.1/reference/tools/tidb-lightning/tidb-backend/']
 ---
 

--- a/tidb-lightning/tidb-lightning-web-interface.md
+++ b/tidb-lightning/tidb-lightning-web-interface.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Web Interface
 summary: Control TiDB Lightning through the web interface.
-category: reference
 aliases: ['/docs/v3.1/tidb-lightning/tidb-lightning-web-interface/','/docs/v3.1/reference/tools/tidb-lightning/web/']
 ---
 

--- a/tidb-monitoring-framework.md
+++ b/tidb-monitoring-framework.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Monitoring Framework Overview
 summary: Use Prometheus and Grafana to build the TiDB monitoring framework.
-category: how-to
 aliases: ['/docs/v3.1/tidb-monitoring-framework/','/docs/v3.1/how-to/monitor/overview/']
 ---
 

--- a/tidb-specific-system-variables.md
+++ b/tidb-specific-system-variables.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Specific System Variables
 summary: Use system variables specific to TiDB to optimize performance.
-category: reference
 aliases: ['/docs/v3.1/tidb-specific-system-variables/','/docs/v3.1/reference/configuration/tidb-server/tidb-specific-variables/']
 ---
 

--- a/tidb-troubleshooting-map.md
+++ b/tidb-troubleshooting-map.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Troubleshooting Map
 summary: Learn how to troubleshoot common errors in TiDB.
-category: how-to
 aliases: ['/docs/v3.1/tidb-troubleshooting-map/','/docs/v3.1/how-to/troubleshoot/diagnose-map/']
 ---
 

--- a/tiflash/deploy-tiflash.md
+++ b/tiflash/deploy-tiflash.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy a TiFlash Cluster
 summary: Learn the requirements and methods of deploying a TiFlash cluster.
-category: reference
 aliases: ['/docs/v3.1/tiflash/deploy-tiflash/','/docs/v3.1/reference/tiflash/deploy/']
 ---
 

--- a/tiflash/maintain-tiflash.md
+++ b/tiflash/maintain-tiflash.md
@@ -1,7 +1,6 @@
 ---
 title: Maintain a TiFlash Cluster
 summary: Learn common operations when you maintain a TiFlash cluster.
-category: reference
 aliases: ['/docs/v3.1/tiflash/maintain-tiflash/','/docs/v3.1/reference/tiflash/maintain/']
 ---
 

--- a/tiflash/monitor-tiflash.md
+++ b/tiflash/monitor-tiflash.md
@@ -1,7 +1,6 @@
 ---
 title: Monitor the TiFlash Cluster
 summary: Learn the monitoring items of TiFlash.
-category: reference
 aliases: ['/docs/v3.1/tiflash/monitor-tiflash/','/docs/v3.1/reference/tiflash/monitor/']
 ---
 

--- a/tiflash/scale-tiflash.md
+++ b/tiflash/scale-tiflash.md
@@ -1,7 +1,6 @@
 ---
 title: Scale the TiFlash Cluster
 summary: Learn how to scale in and out nodes in the TiFlash cluster.
-category: reference
 aliases: ['/docs/v3.1/tiflash/scale-tiflash/','/docs/v3.1/reference/tiflash/scale/']
 ---
 

--- a/tiflash/tiflash-alert-rules.md
+++ b/tiflash/tiflash-alert-rules.md
@@ -1,7 +1,6 @@
 ---
 title: TiFlash Alert Rules
 summary: Learn the alert rules of the TiFlash cluster.
-category: reference
 aliases: ['/docs/v3.1/tiflash/tiflash-alert-rules/','/docs/v3.1/reference/tiflash/alert-rules/']
 ---
 

--- a/tiflash/tiflash-command-line-flags.md
+++ b/tiflash/tiflash-command-line-flags.md
@@ -1,7 +1,6 @@
 ---
 title: TiFlash Command-line Flags
 summary: Learn the command-line startup flags of TiFlash.
-category: reference
 aliases: ['/docs/v3.1/tiflash/tiflash-command-line-flags/']
 ---
 

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Configure TiFlash
 summary: Learn how to configure TiFlash.
-category: reference
 aliases: ['/docs/v3.1/tiflash/tiflash-configuration/','/docs/v3.1/reference/tiflash/configuration/']
 ---
 

--- a/tiflash/tiflash-faq.md
+++ b/tiflash/tiflash-faq.md
@@ -1,7 +1,6 @@
 ---
 title: TiFlash FAQ
 summary: Learn the frequently asked questions (FAQs) and answers about TiFlash.
-category: faq
 aliases: ['/docs/v3.1/tiflash/tiflash-faq/','/docs/v3.1/reference/tiflash/faq/']
 ---
 

--- a/tiflash/tiflash-overview.md
+++ b/tiflash/tiflash-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiFlash Overview
 summary: Learn the architecture and key features of TiFlash.
-category: reference
 aliases: ['/docs/v3.1/tiflash/tiflash-overview/','/docs/v3.1/reference/tiflash/overview/']
 ---
 

--- a/tiflash/tune-tiflash-performance.md
+++ b/tiflash/tune-tiflash-performance.md
@@ -1,7 +1,6 @@
 ---
 title: Tune TiFlash Performance
 summary: Learn how to tune the performance of TiFlash.
-category: reference
 aliases: ['/docs/v3.1/tiflash/tune-tiflash-performance/','/docs/v3.1/reference/tiflash/tune-performance/']
 ---
 

--- a/tiflash/upgrade-tiflash.md
+++ b/tiflash/upgrade-tiflash.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrade TiFlash Nodes
 summary: Learn how to upgrade TiFlash nodes.
-category: reference
 aliases: ['/docs/v3.1/tiflash/upgrade-tiflash/','/docs/v3.1/reference/tiflash/upgrade/']
 ---
 

--- a/tiflash/use-tiflash.md
+++ b/tiflash/use-tiflash.md
@@ -1,6 +1,5 @@
 ---
 title: Use TiFlash
-category: reference
 aliases: ['/docs/v3.1/tiflash/use-tiflash/','/docs/v3.1/reference/tiflash/use-tiflash/']
 ---
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1,7 +1,6 @@
 ﻿---
 title: TiKV Configuration File
 summary: Learn the TiKV configuration file.
-category: reference
 aliases: ['/docs/v3.1/tikv-configuration-file/','/docs/v3.1/reference/configuration/tikv-server/configuration-file/']
 ---
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -1,7 +1,6 @@
 ---
 title: TiKV Control User Guide
 summary: Use TiKV Control to manage a TiKV cluster.
-category: reference
 aliases: ['/docs/v3.1/tikv-control/','/docs/v3.1/reference/tools/tikv-control/']
 ---
 

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiSpark User Guide
 summary: Use TiSpark to provide an HTAP solution to serve as a one-stop solution for both online transactions and analysis.
-category: reference
 aliases: ['/docs/v3.1/tispark-overview/','/docs/v3.1/reference/tispark/']
 ---
 

--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Transaction Isolation Levels
 summary: Learn about the transaction isolation levels in TiDB.
-category: reference
 aliases: ['/docs/v3.1/transaction-isolation-levels/','/docs/v3.1/reference/transactions/transaction-isolation/']
 ---
 

--- a/transaction-overview.md
+++ b/transaction-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Transactions
 summary: Learn transactions in TiDB.
-category: reference
 aliases: ['/docs/v3.1/transaction-overview/','/docs/v3.1/reference/transactions/overview/']
 ---
 

--- a/troubleshoot-tidb-cluster.md
+++ b/troubleshoot-tidb-cluster.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Cluster Troubleshooting Guide
 summary: Learn how to diagnose and resolve issues when you use TiDB.
-category: how-to
 aliases: ['/docs/v3.1/troubleshoot-tidb-cluster/','/docs/v3.1/how-to/troubleshoot/cluster-setup/']
 ---
 

--- a/troubleshoot-tidb-lightning.md
+++ b/troubleshoot-tidb-lightning.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Troubleshooting
 summary: Learn about common errors and solutions of TiDB Lightning.
-category: how-to
 aliases: ['/docs/v3.1/troubleshoot-tidb-lightning/','/docs/v3.1/how-to/troubleshoot/tidb-lightning/']
 ---
 

--- a/tune-operating-system.md
+++ b/tune-operating-system.md
@@ -1,7 +1,6 @@
 ---
 title: Operating System Tuning
 summary: Learn how to tune the parameters of the operating system.
-category: tuning
 aliases: ['/docs/v3.1/tune-operating-system/']
 ---
 

--- a/tune-tikv-performance.md
+++ b/tune-tikv-performance.md
@@ -1,7 +1,6 @@
 ---
 title: Tune TiKV Performance
 summary: Learn how to tune the TiKV parameters for optimal performance.
-category: reference
 aliases: ['/docs/v3.1/tune-tikv-performance/','/docs/v3.1/reference/performance/tune-tikv/']
 ---
 

--- a/upgrade-tidb-using-ansible.md
+++ b/upgrade-tidb-using-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 3.1 Upgrade Guide
 summary: Learn how to upgrade to TiDB 3.1 versions.
-category: how-to
 aliases: ['/docs/v3.1/upgrade-tidb-using-ansible/','/docs/v3.1/how-to/upgrade/from-previous-version/']
 ---
 

--- a/user-account-management.md
+++ b/user-account-management.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB User Account Management
 summary: Learn how to manage a TiDB user account.
-category: reference
 aliases: ['/docs/v3.1/user-account-management/','/docs/v3.1/reference/security/user-account-management/']
 ---
 

--- a/user-defined-variables.md
+++ b/user-defined-variables.md
@@ -1,7 +1,6 @@
 ---
 title: User-Defined Variables
 summary: Learn how to use user-defined variables.
-category: reference
 aliases: ['/docs/v3.1/user-defined-variables/','/docs/v3.1/reference/sql/language-structure/user-defined-variables/']
 ---
 

--- a/views.md
+++ b/views.md
@@ -1,7 +1,6 @@
 ---
 title: Views
 summary: Learn how to use views in TiDB.
-category: reference
 aliases: ['/docs/v3.1/views/','/docs/v3.1/reference/sql/views/']
 ---
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Remove category in metadata.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/3938
- Other reference link(s):
