### PR TITLE
Added note about incompatibility between default collations in tidb a…

### DIFF
--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -31,7 +31,7 @@ SHOW CHARACTER SET;
 
 > **Note:**
 >
-> Each character set might correspond to multiple collations, but by default each character set corresponds to only one collation.
+> The default collations in TiDB (binary collations, with the suffix `_bin`) are different than [the default collations in MySQL](https://dev.mysql.com/doc/refman/8.0/en/charset-charsets.html) (typically general collations, with the suffix `_general_ci`). This can cause incompatible behavior when specifying an explicit character set but relying on the implicit default collation to be chosen.
 
 You can use the following statement to view the collations (under the [new framework for collations](#new-framework-for-collations)) that corresponds to the character set.
 


### PR DESCRIPTION
…nd mysql

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

A user noticed that we have different default collations than MySQL (when using the "new framework for collations"). The result of this is that there are different behaviors between MySQL and TiDB in some cases. For example:

```
mysql> show character set like 'utf8%';
+---------+---------------+--------------------+--------+
| Charset | Description   | Default collation  | Maxlen |
+---------+---------------+--------------------+--------+
| utf8    |               | utf8_general_ci    |      3 |
| utf8mb4 | UTF-8 Unicode | utf8mb4_general_ci |      4 |
+---------+---------------+--------------------+--------+
2 rows in set (0.00 sec)

mysql> create database db1 default character set utf8 collate utf8_general_ci;
Query OK, 1 row affected (0.00 sec)

mysql> use db1
Database changed

mysql> CREATE TABLE tbl (col VARCHAR(100));
Query OK, 0 rows affected (0.02 sec)

mysql> CREATE TABLE db1.tbl2 (col VARCHAR(100)) charset utf8;
Query OK, 0 rows affected (0.01 sec)

mysql> CREATE TABLE db1.tbl3 (col VARCHAR(100)) collate 'utf8_general_ci' charset utf8;
Query OK, 0 rows affected (0.02 sec)

mysql> select table_name, table_collation from INFORMATION_SCHEMA.tables WHERE table_name like 'tbl%';
+------------+-----------------+
| table_name | table_collation |
+------------+-----------------+
| tbl        | utf8_general_ci |
| tbl2       | utf8_general_ci |
| tbl3       | utf8_general_ci |
+------------+-----------------+
3 rows in set (0.00 sec)
```

```
tidb> show character set like 'utf8%';
+---------+---------------+-------------------+--------+
| Charset | Description   | Default collation | Maxlen |
+---------+---------------+-------------------+--------+
| utf8    | UTF-8 Unicode | utf8_bin          |      3 |
| utf8mb4 | UTF-8 Unicode | utf8mb4_bin       |      4 |
+---------+---------------+-------------------+--------+
2 rows in set (0.00 sec)

tidb> create database db1 default character set utf8 collate utf8_general_ci;
Query OK, 0 rows affected (0.03 sec)

tidb> CREATE TABLE db1.tbl (col VARCHAR(100));
Query OK, 0 rows affected (0.04 sec)

tidb> CREATE TABLE db1.tbl3 (col VARCHAR(100)) collate 'utf8_general_ci' charset utf8;
Query OK, 0 rows affected (0.03 sec)

tidb> select table_name, table_collation from INFORMATION_SCHEMA.tables WHERE table_name like 'tbl%';
+------------+-----------------+
| table_name | table_collation |
+------------+-----------------+
| tbl        | utf8_general_ci |
| tbl2       | utf8_bin        |
| tbl3       | utf8_general_ci |
+------------+-----------------+
3 rows in set (0.01 sec)
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
