### PR TITLE
Unify the calculation of defaultCF - block-cache-size

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -830,7 +830,7 @@ Configuration items related to `rocksdb.defaultcf`
 ### `block-cache-size`
 
 + The cache size of a RocksDB block
-+ Default value: `Total machine memory / 4`
++ Default value: `Total machine memory * 25%`
 + Minimum value: `0`
 + Unit: KB|MB|GB
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
Update the calculation of block-cache-size.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/4086, https://github.com/pingcap/docs-cn/pull/3420
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
