### PR TITLE
Change the default value of `feedback-probability`

### DIFF
--- a/statistics.md
+++ b/statistics.md
@@ -130,7 +130,7 @@ When the query is executed, TiDB collects feedback with the probability of `feed
 
 > **Note:**
 >
-> If you set `feedback-probability` to `0` in the configuration file, it causes a failure and reports an error. You need to set the value to `0.0` to disable `feedback-probability`.
+> If you set the value of `feedback-probability` to `0` in the configuration file, it causes a failure and reports an error. You need to set the value to `0.0` to disable `feedback-probability`.
 
 ### Control `ANALYZE` concurrency
 

--- a/statistics.md
+++ b/statistics.md
@@ -130,7 +130,7 @@ When the query is executed, TiDB collects feedback with the probability of `feed
 
 > **Note:**
 >
-> If you set the value of `feedback-probability` to `0` in the configuration file, it causes a failure and reports an error. You need to set the value to `0.0` to disable `feedback-probability`.
+> If you set the value of `feedback-probability` to `0` in the configuration file, a failure will occur and an error will be reported. To disable `feedback-probability`, you need to set the value to `0.0`.
 
 ### Control `ANALYZE` concurrency
 

--- a/statistics.md
+++ b/statistics.md
@@ -126,7 +126,11 @@ Three system variables related to automatic update of statistics are as follows:
 
 When the ratio of the number of modified rows to the total number of rows of `tbl` in a table is greater than `tidb_auto_analyze_ratio`, and the current time is between `tidb_auto_analyze_start_time` and `tidb_auto_analyze_end_time`, TiDB executes the `ANALYZE TABLE tbl` statement in the background to automatically update the statistics of this table.
 
-When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0.0`.
+When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0.05`. You can set the value to `0.0` to disable this feature.
+
+> **Note:**
+>
+> If you set `feedback-probability` to `0` in the configuration file, it causes a failure and reports an error. You need to set the value to `0.0` to disable `feedback-probability`.
 
 ### Control `ANALYZE` concurrency
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4331
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
