### PR TITLE
auth: Remove note about MySQL 8.0 auth plugin

### DIFF
--- a/connectors-and-apis.md
+++ b/connectors-and-apis.md
@@ -28,10 +28,6 @@ TiDB is compatible with all Connectors and APIs of MySQL (5.6, 5.7), including:
 
 Oracle develops the following APIs and TiDB is compatible with all of them:
 
-> **Note:**
->
-> + To connect to TiDB using a MySQL Connector from MySQL 8.0, you must explicitly specify `default-auth=mysql_native_password`, because `mysql_native_password` is [no longer the default plugin](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password).
-
 - [MySQL Connector/C++](https://dev.mysql.com/doc/refman/5.7/en/connector-cpp-info.html)：to enable C++ applications to connect to MySQL
 - [MySQL Connector/J](https://dev.mysql.com/doc/refman/5.7/en/connector-j-info.html)：to enable Java applications to connect to MySQL using the standard JDBC API
 - [MySQL Connector/Net](https://dev.mysql.com/doc/refman/5.7/en/connector-net-info.html)：to enable .Net applications to connect to MySQL; [MySQL for Visual Studio](https://dev.mysql.com/doc/visual-studio/en/) uses this; support Microsoft Visual Studio 2012, 2013, 2015 and 2017 versions

--- a/faq/tidb-faq.md
+++ b/faq/tidb-faq.md
@@ -38,17 +38,7 @@ Yes, it is. When all the required services are started, you can use TiDB as easi
 
 #### How is TiDB compatible with MySQL?
 
-Currently, TiDB supports the majority of MySQL 5.7 syntax, but does not support trigger, stored procedures, user-defined functions, and foreign keys. For more details, see [Compatibility with MySQL](/mysql-compatibility.md).
-
-If you use the MySQL 8.0 client and it fails to connect to TiDB, try to add the `default-auth` and `default-character-set` options:
-
-{{< copyable "shell-regular" >}}
-
-```shell
-mysql -h 127.0.0.1 -u root -P 4000 --default-auth=mysql_native_password --default-character-set=utf8
-```
-
-This problem occurs because MySQL 8.0 changes the [authentication plugin](/security-compatibility-with-mysql.md) default in MySQL 5.7. To solve this problem, you need to add the options above to specify using the old encryption method.
+Currently, TiDB supports the majority of MySQL 5.7 syntax, but does not support triggers, stored procedures, user-defined functions, and foreign keys. For more details, see [Compatibility with MySQL](/mysql-compatibility.md).
 
 #### Does TiDB support distributed transactions?
 

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -9,7 +9,6 @@ aliases: ['/docs/dev/security-compatibility-with-mysql/','/docs/dev/reference/se
 TiDB supports similar security functionality to MySQL 5.7, with the following exceptions:
 
 - Only the `mysql_native_password` password-based and certificate-based authentication is supported
-    - In MySQL 8.0, `mysql_native_password` is [no longer the default/preferred plugin](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password). To connect to TiDB using a MySQL client from MySQL 8.0, you must explicitly specify `default-auth=mysql_native_password`.
 - External authentication (such as with LDAP) is not currently supported
 - Column level permissions are not supported
 - Password expiry, as well as password last-changed tracking and password lifetime are not supported [#9709](https://github.com/pingcap/tidb/issues/9709)

--- a/user-account-management.md
+++ b/user-account-management.md
@@ -24,10 +24,6 @@ Or use the abbreviation of command line parameters:
 shell> mysql -P 4000 -u xxx -p
 ```
 
-> **Note:**
->
-> + To connect to TiDB using a MySQL client from MySQL 8.0, you must explicitly specify `--default-auth=mysql_native_password`, because `mysql_native_password` is [no longer the default plugin](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password).
-
 ## Add user accounts
 
 You can create TiDB accounts in two ways:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Documentation for my patch in https://github.com/pingcap/tidb/pull/19603

It can be backported to 4.0 once https://github.com/pingcap/tidb/pull/19959 merges

Because TiDB now supports MySQL 8.0 connectors, the warnings on these pages are no longer required.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
