### PR TITLE
system-variables: remove the useless memory quota variables

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -521,61 +521,12 @@ Constraint checking is always performed in place for pessimistic transactions (d
 - Default value: 1024
 - This variable is used to set the maximum number of schema versions (the table IDs modified for corresponding versions) allowed to be cached. The value range is 100 ~ 16384.
 
-### tidb_mem_quota_hashjoin
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `HashJoin` operator.
-- If the memory quota of the `HashJoin` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
-### tidb_mem_quota_indexlookupjoin
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `IndexLookupJoin` operator.
-- If the memory quota of the `IndexLookupJoin` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
-### tidb_mem_quota_indexlookupreader
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `IndexLookupReader` operator.
-- If the memory quota of the `IndexLookupReader` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
-### tidb_mem_quota_mergejoin
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `MergeJoin` operator.
-- If the memory quota of the `MergeJoin` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
-### tidb_mem_quota_nestedloopapply
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `NestedLoopApply` operator.
-- If the memory quota of the `NestedLoopApply` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
 ### tidb_mem_quota_query
 
 - Scope: SESSION
 - Default value: 1 GB
 - This variable is used to set the threshold value of memory quota for a query.
 - If the memory quota of a query during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file. The initial value of this variable is configured by [`mem-quota-query`](/tidb-configuration-file.md#mem-quota-query).
-
-### tidb_mem_quota_sort
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `Sort` operator.
-- If the memory quota of the `Sort` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
-
-### tidb_mem_quota_topn
-
-- Scope: SESSION
-- Default value: 32 GB
-- This variable is used to set the threshold value of memory quota for the `TopN` operator.
-- If the memory quota of the `TopN` operator during execution exceeds the threshold value, TiDB performs the operation designated by the OOMAction option in the configuration file.
 
 ### tidb_metric_query_range_duration <span class="version-mark">New in v4.0</span>
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

These variables do not take any effect, are deprecated in current version, and will be removed in the next major release.
So I remove them from the documentation now.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [x] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [x] Might cause conflicts
