### PR TITLE
Add `enable-disk-spill-encrypt.md` to decrypt the usage of the `spilled-file-encryption-method`

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -224,7 +224,7 @@
     + [Enable TLS Between TiDB Components](/enable-tls-between-components.md)
     + [Generate Self-signed Certificates](/generate-self-signed-certificates.md)
     + [Encryption at Rest](/encryption-at-rest.md)
-    + [Enable Disk Spill Encrypt](/enable-disk-spill-encrypt.md)
+    + [Enable Encryption for Disk Spill](/enable-disk-spill-encrypt.md)
   + Privileges
     + [Security Compatibility with MySQL](/security-compatibility-with-mysql.md)
     + [Privilege Management](/privilege-management.md)

--- a/TOC.md
+++ b/TOC.md
@@ -224,6 +224,7 @@
     + [Enable TLS Between TiDB Components](/enable-tls-between-components.md)
     + [Generate Self-signed Certificates](/generate-self-signed-certificates.md)
     + [Encryption at Rest](/encryption-at-rest.md)
+    + [Enable Disk Spill Encrypt](/enable-disk-spill-encrypt.md)
   + Privileges
     + [Security Compatibility with MySQL](/security-compatibility-with-mysql.md)
     + [Privilege Management](/privilege-management.md)

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Disk Spill Encrypt
+title: Enable Encryption for Disk Spill
 summary: Learn how to enable disk spill encrypt for TiDB.
 ---
 

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -7,7 +7,7 @@ summary: Learn how to enable encryption for disk spill in TiDB.
 
 When the `oom-use-tmp-storage` configuration item is set to `true`, if the memory usage of a single SQL statement exceeds the limit of `mem-quota-query` setting, some operators can save the intermediate results during execution as a temporary file to the disk and delete the file after the query is completed.
 
-Users can enable the disk spill encrypt to prevent attackers from accessing data by reading the temporary files.
+You can enable encryption for disk spill to prevent attackers from accessing data by reading these temporary files.
 
 ## Configure
 

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -11,7 +11,7 @@ You can enable encryption for disk spill to prevent attackers from accessing dat
 
 ## Configure
 
-To enable the encryption of the disk spill files, we can configure the item [`spilled-file-encryption-method`](/tidb-configuration-file.md#spilled-file-encryption-method) in the `[security]` section of the TiDB configuration file
+To enable encryption for the disk spill files, you can configure the item [`spilled-file-encryption-method`](/tidb-configuration-file.md#spilled-file-encryption-method) in the `[security]` section of the TiDB configuration file.
 
 ```toml
 [security]

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -18,4 +18,4 @@ To enable encryption for the disk spill files, you can configure the item [`spil
 spilled-file-encryption-method = "aes128-ctr"
 ```
 
-Possible values for `spilled-file-encryption-method` are `aes128-ctr` and `plaintext`. The default value is `plaintext`, which means encryption is disable.
+Value options for `spilled-file-encryption-method` are `aes128-ctr` and `plaintext`. The default value is `plaintext`, which means that encryption is disabled.

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -1,0 +1,21 @@
+---
+title: Enable Disk Spill Encrypt
+summary: Learn how to enable disk spill encrypt for TiDB.
+---
+
+# Enable disk spill encrypt for TiDB
+
+When the configuration item `oom-use-tmp-storage` is `true`, if the memory usage of a single SQL statement exceeds the limit of `mem-quota-query` setting, some operators can save the intermediate results during execution as a temporary file to the disk and delete them after the query is completed.
+
+Users can enable the disk spill encrypt to prevent attackers from accessing data by reading the temporary files.
+
+## Configure
+
+To enable the encryption of the disk spill files, we can configure the item [`spilled-file-encryption-method`](/tidb-configuration-file.md#spilled-file-encryption-method) in the `[security]` section of the TiDB configuration file
+
+```toml
+[security]
+spilled-file-encryption-method = "aes128-ctr"
+```
+
+Possible values for `spilled-file-encryption-method` are `aes128-ctr` and `plaintext`. The default value is `plaintext`, which means encryption is disable.

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -1,6 +1,6 @@
 ---
 title: Enable Encryption for Disk Spill
-summary: Learn how to enable disk spill encrypt for TiDB.
+summary: Learn how to enable encryption for disk spill in TiDB.
 ---
 
 # Enable disk spill encrypt for TiDB

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -3,7 +3,7 @@ title: Enable Encryption for Disk Spill
 summary: Learn how to enable encryption for disk spill in TiDB.
 ---
 
-# Enable disk spill encrypt for TiDB
+# Enable Encryption for Disk Spill
 
 When the configuration item `oom-use-tmp-storage` is `true`, if the memory usage of a single SQL statement exceeds the limit of `mem-quota-query` setting, some operators can save the intermediate results during execution as a temporary file to the disk and delete them after the query is completed.
 

--- a/enable-disk-spill-encrypt.md
+++ b/enable-disk-spill-encrypt.md
@@ -5,7 +5,7 @@ summary: Learn how to enable encryption for disk spill in TiDB.
 
 # Enable Encryption for Disk Spill
 
-When the configuration item `oom-use-tmp-storage` is `true`, if the memory usage of a single SQL statement exceeds the limit of `mem-quota-query` setting, some operators can save the intermediate results during execution as a temporary file to the disk and delete them after the query is completed.
+When the `oom-use-tmp-storage` configuration item is set to `true`, if the memory usage of a single SQL statement exceeds the limit of `mem-quota-query` setting, some operators can save the intermediate results during execution as a temporary file to the disk and delete the file after the query is completed.
 
 Users can enable the disk spill encrypt to prevent attackers from accessing data by reading the temporary files.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

add the `enable-disk-spill-encrypt.md` to descript the usage of the `spilled-file-encryption-method`.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [X] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4557
- Other reference link(s): https://github.com/pingcap/tidb/pull/19070 https://github.com/pingcap/docs/pull/3700 

