### PR TITLE
ticdc: fix some typos in the open protocol 

### DIFF
--- a/ticdc/ticdc-open-protocol.md
+++ b/ticdc/ticdc-open-protocol.md
@@ -296,17 +296,17 @@ Currently, TiCDC does not provide the standard parsing library for TiCDC Open Pr
 | TIME                  | 11   | {"t":11,"v":"23:59:59"} | |
 | DATETIME              | 12   | {"t":12,"v":"2015-12-20 23:58:58"} | |
 | YEAR                  | 13   | {"t":13,"v":1970} | |
-| VARCHAR/VARBINARY     | 15/253   | {"t":15,"v":"test"} / {"t":15,"v":"\\x89PNG\\r\\n\\x1a\\n"} |  The value is encoded in UTF-8. When the upstream type is VARBINARY, invisible ASCII characters are escaped. |
+| VARCHAR/VARBINARY     | 15/253   | {"t":15,"v":"test"} / {"t":15,"v":"\\\\x89PNG\\\\r\\\\n\\\\x1a\\\\n"} |  The value is encoded in UTF-8. When the upstream type is VARBINARY, invisible characters are escaped. |
 | BIT                   | 16   | {"t":16,"v":81} | |
 | JSON                  | 245  | {"t":245,"v":"{\\"key1\\": \\"value1\\"}"} | |
 | DECIMAL               | 246  | {"t":246,"v":"129012.1230000"} | |
 | ENUM                  | 247  | {"t":247,"v":1} | |
 | SET                   | 248  | {"t":248,"v":3} | |
-| TINTTEXT/TINTBLOB     | 249  | {"t":249,"v":"5rWL6K+VdGV4dA=="} | The value is encoded in Base64. |
+| TINYTEXT/TINYBLOB     | 249  | {"t":249,"v":"5rWL6K+VdGV4dA=="} | The value is encoded in Base64. |
 | MEDIUMTEXT/MEDIUMBLOB | 250  | {"t":250,"v":"5rWL6K+VdGV4dA=="} | The value is encoded in Base64. |
 | LONGTEXT/LONGBLOB     | 251  | {"t":251,"v":"5rWL6K+VdGV4dA=="} | The value is encoded in Base64. |
 | TEXT/BLOB             | 252  | {"t":252,"v":"5rWL6K+VdGV4dA=="} | The value is encoded in Base64. |
-| CHAR/BINARY           | 254  | {"t":254,"v":"test"} / {"t":254,"v":"\\x89PNG\\r\\n\\x1a\\n"} | The value is encoded in UTF-8. When the upstream type is BINARY, invisible ASCII characters are escaped. |
+| CHAR/BINARY           | 254  | {"t":254,"v":"test"} / {"t":254,"v":"\\\\x89PNG\\\\r\\\\n\\\\x1a\\\\n"} | The value is encoded in UTF-8. When the upstream type is BINARY, invisible characters are escaped. |
 | GEOMETRY              | 255  |  | Unsupported |
 
 ## DDL Type Code
@@ -386,5 +386,5 @@ If the value of a column is `46`, the column is a composite index column, a prim
 > **Note:**
 >
 > + This feature is still experimental. Do **NOT** use it in the production environment.
-> + `BinaryFlag` is meaningful only when the column type is Blob/Text (including Tiny Blob/Tiny Text and Long Blob/Long Text). When the upstream column is the Blob type, the `BinaryFlag` value is set to `1`. When the upstream column is the Text type, the `BinaryFlag` value is set to `0`.
+> + `BinaryFlag` is meaningful only when the column type is BLOB/TEXT (including TINYBLOB/TINYTEXT and BINARY/CHAR). When the upstream column is the BLOB type, the `BinaryFlag` value is set to `1`. When the upstream column is the TEXT type, the `BinaryFlag` value is set to `0`.
 > + To replicate a table from the upstream, TiCDC selects a [valid index](/ticdc/ticdc-overview.md#restrictions) as the Handle index. The `HandleKeyFlag` value of the Handle index column is set to `1`.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
Fixed some typos in the CDC open protocol.

TINTTEXT → TINYTEXT
Too little backslashes in the VARBINARY/BINARY examples, there should be two backslashes in the rendered JSON, and thus four backslashes in markdown.
\x80...\xFF are not ASCII, just don't mention ASCII.
BinaryFlag is used for VARBINARY/BINARY too, don't just mention the BLOB family.
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4741
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
