### PR TITLE
config: hide & deprecate enable-streaming

### DIFF
--- a/sql-statements/sql-statement-show-variables.md
+++ b/sql-statements/sql-statement-show-variables.md
@@ -64,7 +64,6 @@ mysql> SHOW GLOBAL VARIABLES LIKE 'tidb%';
 | tidb_enable_radix_join              | 0                   |
 | tidb_enable_slow_log                | 1                   |
 | tidb_enable_stmt_summary            | 1                   |
-| tidb_enable_streaming               | 0                   |
 | tidb_enable_table_partition         | on                  |
 | tidb_enable_vectorized_expression   | 1                   |
 | tidb_enable_window_function         | 1                   |

--- a/system-variables.md
+++ b/system-variables.md
@@ -350,12 +350,6 @@ Constraint checking is always performed in place for pessimistic transactions (d
 - Default value: 1 (the value of the default configuration file)
 - This variable is used to control whether to enable the statement summary feature. If enabled, SQL execution information like time consumption is recorded to the `information_schema.STATEMENTS_SUMMARY` system table to identify and troubleshoot SQL performance issues.
 
-### tidb_enable_streaming
-
-- Scope: SERVER
-- Default value: 0
-- This variable is used to set whether to enable streaming.
-
 ### tidb_enable_table_partition
 
 - Scope: SESSION | GLOBAL

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -54,11 +54,6 @@ The TiDB configuration file supports more options than command-line parameters. 
 - Default value: `"cancel"` (In TiDB v4.0.2 and earlier versions, the default value is `"log"`)
 - The valid options are `"log"` and `"cancel"`. When `oom-action="log"`, it prints the log only. When `oom-action="cancel"`, it cancels the operation and outputs the log.
 
-### `enable-streaming`
-
-- Determines whether to enable the data fetch mode of streaming in Coprocessor.
-- Default value: `false`
-
 ### `lower-case-table-names`
 
 - Configures the value of the `lower-case-table-names` system variable.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
`enable-streaming` is not well maintained because we are focusing on optimizing the non-streaming coprocessor API for its performance and resource usage and don’t have time to optimize streaming's currently, I propose to deprecate it temporarily until somebody has time to pick it up again and prove it could be GA in the future.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4781
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [x] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [x] Might cause conflicts
