### PR TITLE
tidb: update autocommit behavior description of pessimistic transactions

### DIFF
--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -97,9 +97,9 @@ Pessimistic transactions in TiDB behave similarly to those in MySQL. See the min
 
 5. The autocommit transactions prefer the optimistic locking.
 
-    When using the pessimistic transaction model, the autocommit transactions first commit using the optimistic transaction mode with less overhead. If a write conflict occurs, the autocommit transactions use pessimistic transaction mode when retrying. Thus, if `tidb_retry_limit = 0`, the autocommit transaction still reports the `Write Conflict` error when a write conflict occurs.
+    When using the pessimistic model, the autocommit transactions first try to commit the statement using the optimistic model that has less overhead. If a write conflict occurs, the pessimistic model is used for transaction retry. Therefore, if `tidb_retry_limit` is set to `0`, the autocommit transaction still reports the `Write Conflict` error when a write conflict occurs.
 
-    The autocommit `SELECT FOR UPDATE` statement does not wait for lock, either.
+    The autocommit `SELECT FOR UPDATE` statement does not wait for lock.
 
 6. The data read by `EMBEDDED SELECT` in the statement is not locked.
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -95,9 +95,9 @@ Pessimistic transactions in TiDB behave similarly to those in MySQL. See the min
 
 4. After executing `START TRANSACTION WITH CONSISTENT SNAPSHOT`, MySQL can still read the tables that are created later in other transactions, while TiDB cannot.
 
-5. The autocommit transactions do not support the pessimistic locking.
+5. The autocommit transactions prefer the optimistic locking.
 
-    None of the autocommit statements acquire the pessimistic lock. These statements do not display any difference in the user side, because the nature of pessimistic transactions is to turn the retry of the whole transaction into a single DML retry. The autocommit transactions automatically retry even when TiDB closes the retry, which has the same effect as pessimistic transactions.
+    When using the pessimistic transaction model, the autocommit transactions first commit using the optimistic transaction mode with less overhead. If a write conflict occurs, the autocommit transactions use pessimistic transaction mode when retrying. Thus, if `tidb_retry_limit = 0`, the autocommit transaction still reports the `Write Conflict` error when a write conflict occurs.
 
     The autocommit `SELECT FOR UPDATE` statement does not wait for lock, either.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
After TiDB v4.0.6, autocommit transactions will turn to use pessimistic transaction during retries.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4807
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [x] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
