### PR TITLE
Fix wrong default value in tiflash config doc

### DIFF
--- a/partitioned-table.md
+++ b/partitioned-table.md
@@ -955,7 +955,7 @@ For a table partitioned by `RANGE COLUMNS`, currently TiDB only supports using a
 
 With regard to partition management, any operation that requires moving data in the bottom implementation is not supported currently, including but not limited to: adjust the number of partitions in a Hash partitioned table, modify the Range of a Range partitioned table, merge partitions and exchange partitions.
 
-For the unsupported partitioning types, when you create a table in TiDB, the partitioning information is ignored and the table is created in the regular form with a warning reported. `INFORMATION_SCHEMA.PARTITION` tables are not supported currently in TiDB.
+For the unsupported partitioning types, when you create a table in TiDB, the partitioning information is ignored and the table is created in the regular form with a warning reported.
 
 The `LOAD DATA` syntax does not support partition selection currently in TiDB.
 

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -25,7 +25,7 @@ You can adjust the PD scheduling parameters using [pd-ctl](/pd-control.md). Note
     > Since v4.0.2, the `store-balance-rate` parameter has been deprecated and changes have been made to the `store limit` command. See [store-limit](/configure-store-limit.md) for details.
 
     - Execute the `pd-ctl -u <pd_ip:pd_port> store limit <store_id> <value>` command to set the scheduling rate of a specified store. (To get `store_id`, you can execute the `pd-ctl -u <pd_ip:pd_port> store` command. 
-    - If you do not set the scheduling rate for Regions of a specified store, this store inherits the setting of `store-balance-rate`. 
+    - If you do not set the scheduling rate for Regions of a specified store, this store inherits the setting of `store-balance-rate`.
     - You can execute the `pd-ctl -u <pd_ip:pd_port> store limit` command to view the current setting value of `store-balance-rate`.
 
 ## TiFlash configuration parameters
@@ -34,7 +34,7 @@ This section introduces the configuration parameters of TiFlash.
 
 ### Configure the `tiflash.toml` file
 
-```
+```toml
 tmp_path = The path in which the TiFlash temporary files are stored.
 path = The TiFlash data storage path.     # If there are multiple directories, separate each directory with a comma.
 path_realtime_mode = false # The default value is `false`. If you set it to `true` and multiple directories are deployed in the path, the latest data is stored in the first directory and older data is stored in the rest directories.
@@ -45,7 +45,7 @@ mark_cache_size = 5368709120 # The cache size limit of the metadata of a data bl
 minmax_index_cache_size = 5368709120 # The cache size limit of the min-max index of a data block. Generally, you do not need to change this value.
 ```
 
-```
+```toml
 [flash]
     tidb_status_addr = TiDB status port and address. # Multiple addresses are separated with commas.
     service_addr = The listening address of TiFlash Raft services and coprocessor services.
@@ -53,7 +53,7 @@ minmax_index_cache_size = 5368709120 # The cache size limit of the min-max index
 
 Multiple TiFlash nodes elect a master to add or delete placement rules to PD, and you need three parameters to control this process.
 
-```
+```toml
 [flash.flash_cluster]
     refresh_interval = Master regularly refreshes the valid period.
     update_rule_interval = Master regularly gets the status of TiFlash replicas and interacts with PD.
@@ -84,7 +84,7 @@ Multiple TiFlash nodes elect a master to add or delete placement rules to PD, an
 [profiles]
 [profiles.default]
     dt_enable_logical_split = true # The default value is `true`. This parameter determines whether the segment of DeltaTree Storage Engine uses logical split. Using the logical split can reduce the write amplification, and improve the write speed. However, these are at the cost of disk space waste.
-    max_memory_usage = 10000000000 # The memory usage limit for the generated intermediate data when a single coprocessor query is executed. The default value is 10,000,000,000 (in bytes). If set to 0, it means no limit.
+    max_memory_usage = 0 # The memory usage limit for the generated intermediate data when a single coprocessor query is executed. The default value is 0, which means no limit.
     max_memory_usage_for_all_queries = 0 # The memory usage limit for the generated intermediate data when all queries are executed. The default value is 0 (in bytes), which means no limit.
 ```
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

+ Support `INFORMATION_SCHEMA.PARTITION` since 4.0.8
+ Fix wrong default value in tiflash config doc
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/4916 https://github.com/pingcap/docs-cn/pull/4911
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
