### PR TITLE
update document to use tiflash in tispark

### DIFF
--- a/tiflash/use-tiflash.md
+++ b/tiflash/use-tiflash.md
@@ -193,7 +193,7 @@ In the above three ways of reading TiFlash replicas, engine isolation specifies 
 
 ## Use TiSpark to read TiFlash replicas
 
-Currently, you can use TiSpark to read TiFlash replicas in a method similar to the engine isolation in TiDB. This method is to configure the `spark.tispark.isolation_read_engines` parameter. The parameter value defaults to `tikv,tiflash`, which means automatically reading data from TiFlash or TiKV according to CBO. If you set the parameter value to `tiflash`, it means that data is forcibly read from TiFlash.
+Currently, you can use TiSpark to read TiFlash replicas in a method similar to the engine isolation in TiDB. This method is to configure the `spark.tispark.isolation_read_engines` parameter. The parameter value defaults to `tikv,tiflash`, which means that TiDB reads data from TiFlash or from TiKV according to CBO's selection. If you set the parameter value to `tiflash`, it means that TiDB forcibly reads data from TiFlash.
 
 > **Notes**
 >

--- a/tiflash/use-tiflash.md
+++ b/tiflash/use-tiflash.md
@@ -193,7 +193,7 @@ In the above three ways of reading TiFlash replicas, engine isolation specifies 
 
 ## Use TiSpark to read TiFlash replicas
 
-Currently, you can use TiSpark to read TiFlash replicas in a method similar to the engine isolation in TiDB. This method is to configure the `spark.tispark.use.tiflash` parameter to `true` (or `false`).
+Currently, you can use TiSpark to read TiFlash replicas in a method similar to the engine isolation in TiDB. This method is to configure the `spark.tispark.isolation_read_engines` parameter. The parameter value defaults to `tikv,tiflash`, which means automatically reading data from TiFlash or TiKV according to CBO. If you set the parameter value to `tiflash`, it means that data is forcibly read from TiFlash.
 
 > **Notes**
 >
@@ -204,14 +204,14 @@ You can configure this parameter in either of the following ways:
 * Add the following item in the `spark-defaults.conf` file:
 
     ```
-    spark.tispark.use.tiflash true
+    spark.tispark.isolation_read_engines tiflash
     ```
 
-* Add `--conf spark.tispark.use.tiflash=true` in the initialization command when initializing Spark shell or Thrift server.
+* Add `--conf spark.tispark.isolation_read_engines=tiflash` in the initialization command when initializing Spark shell or Thrift server.
 
-* Set `spark.conf.set("spark.tispark.use.tiflash", true)` in Spark shell in a real-time manner.
+* Set `spark.conf.set("spark.tispark.isolation_read_engines", "tiflash")` in Spark shell in a real-time manner.
 
-* Set `set spark.tispark.use.tiflash=true` in Thrift server after the server is connected via beeline.
+* Set `set spark.tispark.isolation_read_engines=tiflash` in Thrift server after the server is connected via beeline.
 
 ## Supported push-down calculations
 

--- a/tiflash/use-tiflash.md
+++ b/tiflash/use-tiflash.md
@@ -199,7 +199,7 @@ Currently, you can use TiSpark to read TiFlash replicas in a method similar to t
 >
 > When this parameter is set to `true`, only the TiFlash replicas of all tables involved in the query are read and these tables must have TiFlash replicas; for tables that do not have TiFlash replicas, an error is reported. When this parameter is set to `false`, only the TiKV replica is read.
 
-You can configure this parameter in either of the following ways:
+You can configure this parameter in one of the following ways:
 
 * Add the following item in the `spark-defaults.conf` file:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
update document to use tiflash in tispark

parameter `spark.tispark.use.tiflash` is replaced with `spark.tispark.isolation_read_engines`.
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5030
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
