### PR TITLE
TiFlash config: Add description for delta_index_cache_size

### DIFF
--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -43,6 +43,7 @@ tcp_port = The TiFlash TCP service port.
 http_port = The TiFlash HTTP service port.
 mark_cache_size = 5368709120 # The cache size limit of the metadata of a data block. Generally, you do not need to change this value.
 minmax_index_cache_size = 5368709120 # The cache size limit of the min-max index of a data block. Generally, you do not need to change this value.
+delta_index_cache_size = 0 # The cache size limit of the DeltaIndex. The default value is 0, which means no limit.
 
 [storage]
     bg_task_io_rate_limit = 0 # Limits the total write rate of background tasks in bytes per second. 0 means no limit.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
Add description of `delta_index_cache_size` configuration for TiFlash.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: [https://github.com/pingcap/docs-cn/pull/5086](https://github.com/pingcap/docs-cn/pull/5086)
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
