### PR TITLE
Make bg_task_io_rate_limit setting experimental

### DIFF
--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -65,7 +65,7 @@ delta_index_cache_size = 0
 
 ## Storage paths settings take effect starting from v4.0.9
 [storage]
-    ## [Experimental] Limits the total write rate of background tasks in bytes per second. By default 0, means no limit.
+    ## [Experimental] Introduced in v5.0. Limits the total write rate of background tasks in bytes per second. By default 0, means no limit. It is not recommended to use this experimental feature in a production environment.
     bg_task_io_rate_limit = 0
 
     [storage.main]

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -65,7 +65,7 @@ delta_index_cache_size = 0
 
 ## Storage paths settings take effect starting from v4.0.9
 [storage]
-    ## [Experimental] Limits the total write rate of background tasks in bytes per second. 0 means no limit.
+    ## [Experimental] Limits the total write rate of background tasks in bytes per second. By default 0, means no limit.
     bg_task_io_rate_limit = 0
 
     [storage.main]

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -65,7 +65,7 @@ delta_index_cache_size = 0
 
 ## Storage paths settings take effect starting from v4.0.9
 [storage]
-    ## Limits the total write rate of background tasks in bytes per second. 0 means no limit.
+    ## [Experimental] Limits the total write rate of background tasks in bytes per second. 0 means no limit.
     bg_task_io_rate_limit = 0
 
     [storage.main]


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Make `bg_task_io_rate_limit` setting in tiflash.toml experimental. Since it is released as experimental feature in 5.0.0-rc.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5180
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
