### PR TITLE
tiup: remove a false download link for tiup offline package

### DIFF
--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -42,7 +42,7 @@ To prepare the TiUP offline component package, manually pack an offline componen
         which tiup
         ```
 
-- Pull the mirror using TiUP
+2. Pull the mirror using TiUP
 
     1. Pull the needed components on a machine that has access to the Internet:
 

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -14,13 +14,7 @@ This document describes how to deploy a TiDB cluster offline using TiUP.
 
 ## Step 1: Prepare the TiUP offline component package
 
-### Option 1: Download the official TiUP offline component package
-
-Download the offline mirror package of the TiDB server (including the TiUP offline component package) from the [Download TiDB](https://pingcap.com/download/) page.
-
-### Option 2: Manually pack an offline component package using `tiup mirror clone`
-
-The steps are below.
+To prepare the TiUP offline component package, manually pack an offline component package using `tiup mirror clone`.
 
 - Install the TiUP package manager online.
 

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -42,7 +42,7 @@ To prepare the TiUP offline component package, manually pack an offline componen
         which tiup
         ```
 
-2. Pull the mirror using TiUP
+2. Pull the mirror using TiUP.
 
     1. Pull the needed components on a machine that has access to the Internet:
 

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -16,7 +16,7 @@ This document describes how to deploy a TiDB cluster offline using TiUP.
 
 To prepare the TiUP offline component package, manually pack an offline component package using `tiup mirror clone`.
 
-- Install the TiUP package manager online.
+1. Install the TiUP package manager online.
 
     1. Install the TiUP tool:
 

--- a/tiup/tiup-mirror.md
+++ b/tiup/tiup-mirror.md
@@ -87,4 +87,4 @@ This section introduces the usage examples of the `mirror` command.
 
 ### Deploy a TiDB Cluster offline using TiUP
 
-Refer to [Deploy a TiDB Cluster Offline Using TiUP](/production-offline-deployment-using-tiup.md#option-2-manually-pack-an-offline-component-package-using-tiup-mirror-clone) to install the TiUP offline mirror, deploy a TiDB cluster, and start it.
+Refer to [Deploy a TiDB Cluster Offline Using TiUP](/production-offline-deployment-using-tiup.md#step-1-prepare-the-tiup-offline-component-package) to install the TiUP offline mirror, deploy a TiDB cluster, and start it.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Remove the link of [Download TiDB | PingCAP](https://en.pingcap.com/download/) in `production-offline-deployment-using-tiup.md` because the [Download TiDB | PingCAP](https://en.pingcap.com/download/) page is designed not to provide the download link for TiUP offline package.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
