### PR TITLE
Remove notes & aliases for deprecated Ansible in TiUP docs

### DIFF
--- a/maintain-tidb-using-tiup.md
+++ b/maintain-tidb-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: TiUP Common Operations
 summary: Learn the common operations to operate and maintain a TiDB cluster using TiUP.
-aliases: ['/docs/dev/maintain-tidb-using-tiup/','/docs/dev/how-to/maintain/tiup-operations/','/docs/dev/maintain-tidb-using-ansible/','/docs/dev/how-to/deploy/orchestrated/ansible-operations/','/tidb/dev/maintain-tidb-using-ansible/']
+aliases: ['/docs/dev/maintain-tidb-using-tiup/','/docs/dev/how-to/maintain/tiup-operations/']
 ---
 
 # TiUP Common Operations
@@ -17,7 +17,7 @@ This document describes the following common operations when you operate and mai
 
 > **Note:**
 >
-> Since TiDB v4.0, PingCAP no longer provides support for TiDB Ansible. Since TiDB v5.0, PingCAP no longer provides TiDB Ansible documents. If you want to read the document that introduces how to maintain a TiDB cluster using TiDB Ansible, see [TiDB Ansible Common Operations (v4.0)](https://docs.pingcap.com/tidb/v4.0/maintain-tidb-using-ansible).
+> TiUP is the recommended method to maintain a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0..
 
 ## View the cluster list
 

--- a/maintain-tidb-using-tiup.md
+++ b/maintain-tidb-using-tiup.md
@@ -17,7 +17,7 @@ This document describes the following common operations when you operate and mai
 
 > **Note:**
 >
-> TiUP is the recommended method to maintain a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0..
+> TiUP is the recommended method to maintain a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
 
 ## View the cluster list
 

--- a/maintain-tidb-using-tiup.md
+++ b/maintain-tidb-using-tiup.md
@@ -15,10 +15,6 @@ This document describes the following common operations when you operate and mai
 - Stop the cluster
 - Destroy the cluster
 
-> **Note:**
->
-> TiUP is the recommended method to maintain a TiDB cluster. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
-
 ## View the cluster list
 
 You can manage multiple TiDB clusters using the TiUP cluster component. When a TiDB cluster is deployed, the cluster appears in the TiUP cluster list.

--- a/maintain-tidb-using-tiup.md
+++ b/maintain-tidb-using-tiup.md
@@ -17,7 +17,7 @@ This document describes the following common operations when you operate and mai
 
 > **Note:**
 >
-> TiUP is the recommended method to maintain a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
+> TiUP is the recommended method to maintain a TiDB cluster. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
 
 ## View the cluster list
 

--- a/production-deployment-using-tiup.md
+++ b/production-deployment-using-tiup.md
@@ -10,10 +10,6 @@ aliases: ['/docs/dev/production-deployment-using-tiup/','/docs/dev/how-to/deploy
 
 TiUP supports deploying TiDB, TiFlash, TiDB Binlog, TiCDC, and the monitoring system. This document introduces how to deploy TiDB clusters of different topologies.
 
-> **Note:**
->
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
-
 ## Step 1: Prerequisites and precheck
 
 Make sure that you have read the following documents:

--- a/production-deployment-using-tiup.md
+++ b/production-deployment-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a TiDB Cluster Using TiUP
 summary: Learn how to easily deploy a TiDB cluster using TiUP.
-aliases: ['/docs/dev/production-deployment-using-tiup/','/docs/dev/how-to/deploy/orchestrated/tiup/','/docs/dev/tiflash/deploy-tiflash/','/docs/dev/reference/tiflash/deploy/','/tidb/dev/deploy-tidb-from-dbdeployer/','/docs/dev/deploy-tidb-from-dbdeployer/','/docs/dev/how-to/get-started/deploy-tidb-from-dbdeployer/','/tidb/dev/deploy-tidb-from-homebrew/','/docs/dev/deploy-tidb-from-homebrew/','/docs/dev/how-to/get-started/deploy-tidb-from-homebrew/','/docs/dev/online-deployment-using-ansible/','/docs/dev/how-to/deploy/orchestrated/ansible/','/tidb/dev/online-deployment-using-ansible/']
+aliases: ['/docs/dev/production-deployment-using-tiup/','/docs/dev/how-to/deploy/orchestrated/tiup/','/docs/dev/tiflash/deploy-tiflash/','/docs/dev/reference/tiflash/deploy/','/tidb/dev/deploy-tidb-from-dbdeployer/','/docs/dev/deploy-tidb-from-dbdeployer/','/docs/dev/how-to/get-started/deploy-tidb-from-dbdeployer/','/tidb/dev/deploy-tidb-from-homebrew/','/docs/dev/deploy-tidb-from-homebrew/','/docs/dev/how-to/get-started/deploy-tidb-from-homebrew/']
 ---
 
 # Deploy a TiDB Cluster Using TiUP
@@ -12,7 +12,7 @@ TiUP supports deploying TiDB, TiFlash, TiDB Binlog, TiCDC, and the monitoring sy
 
 > **Note:**
 >
-> Since TiDB v4.0, PingCAP no longer provides support for TiDB Ansible. Since TiDB v5.0, PingCAP no longer provides TiDB Ansible documents. If you want to read the document that introduces how to deploy a TiDB cluster using TiDB Ansible, see [Deploy TiDB Using TiDB Ansible (v4.0)](https://docs.pingcap.com/tidb/v4.0/online-deployment-using-ansible).
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
 
 ## Step 1: Prerequisites and precheck
 

--- a/production-deployment-using-tiup.md
+++ b/production-deployment-using-tiup.md
@@ -12,7 +12,7 @@ TiUP supports deploying TiDB, TiFlash, TiDB Binlog, TiCDC, and the monitoring sy
 
 > **Note:**
 >
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
 
 ## Step 1: Prerequisites and precheck
 

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -8,10 +8,6 @@ aliases: ['/docs/dev/production-offline-deployment-using-tiup/']
 
 This document describes how to deploy a TiDB cluster offline using TiUP.
 
-> **Note:**
->
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
-
 ## Step 1: Prepare the TiUP offline component package
 
 To prepare the TiUP offline component package, manually pack an offline component package using `tiup mirror clone`.

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a TiDB Cluster Offline Using TiUP
 summary: Introduce how to deploy a TiDB cluster offline using TiUP.
-aliases: ['/docs/dev/production-offline-deployment-using-tiup/','/docs/dev/offline-deployment-using-ansible/','/docs/dev/how-to/deploy/orchestrated/offline-ansible/','/tidb/dev/offline-deployment-using-ansible/']
+aliases: ['/docs/dev/production-offline-deployment-using-tiup/']
 ---
 
 # Deploy a TiDB Cluster Offline Using TiUP
@@ -10,7 +10,7 @@ This document describes how to deploy a TiDB cluster offline using TiUP.
 
 > **Note:**
 >
-> Since TiDB v4.0, PingCAP no longer provides support for TiDB Ansible. Since TiDB v5.0, PingCAP no longer provides TiDB Ansible documents. If you want to read the document that introduces how to deploy a TiDB cluster using TiDB Ansible offline, see [Deploy TiDB Offline Using TiDB Ansible (v4.0)](https://docs.pingcap.com/tidb/v4.0/offline-deployment-using-ansible).
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
 
 ## Step 1: Prepare the TiUP offline component package
 

--- a/production-offline-deployment-using-tiup.md
+++ b/production-offline-deployment-using-tiup.md
@@ -10,7 +10,7 @@ This document describes how to deploy a TiDB cluster offline using TiUP.
 
 > **Note:**
 >
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
 
 ## Step 1: Prepare the TiUP offline component package
 

--- a/scale-tidb-using-tiup.md
+++ b/scale-tidb-using-tiup.md
@@ -12,7 +12,7 @@ This document describes how to scale the TiDB, TiKV, PD, TiCDC, or TiFlash clust
 
 > **Note:**
 >
-> TiUP is the recommended method to scale a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
+> TiUP is the recommended method to scale a TiDB cluster. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
 
 To view the current cluster name list, run `tiup cluster list`.
 

--- a/scale-tidb-using-tiup.md
+++ b/scale-tidb-using-tiup.md
@@ -10,10 +10,6 @@ The capacity of a TiDB cluster can be increased or decreased without interruptin
 
 This document describes how to scale the TiDB, TiKV, PD, TiCDC, or TiFlash cluster using TiUP. If you have not installed TiUP, refer to the steps in [Install TiUP on the control machine](/upgrade-tidb-using-tiup.md#install-tiup-on-the-control-machine) and import the cluster into TiUP before you use TiUP to scale the TiDB cluster.
 
-> **Note:**
->
-> TiUP is the recommended method to scale a TiDB cluster. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
-
 To view the current cluster name list, run `tiup cluster list`.
 
 For example, if the original topology of the cluster is as follows:

--- a/scale-tidb-using-tiup.md
+++ b/scale-tidb-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Scale the TiDB Cluster Using TiUP
 summary: Learn how to scale the TiDB cluster using TiUP.
-aliases: ['/docs/dev/scale-tidb-using-tiup/','/docs/dev/how-to/scale/with-tiup/','/docs/dev/scale-tidb-using-ansible/','/docs/dev/how-to/scale/with-ansible/','/tidb/dev/scale-tidb-using-ansible/']
+aliases: ['/docs/dev/scale-tidb-using-tiup/','/docs/dev/how-to/scale/with-tiup/']
 ---
 
 # Scale the TiDB Cluster Using TiUP
@@ -12,7 +12,7 @@ This document describes how to scale the TiDB, TiKV, PD, TiCDC, or TiFlash clust
 
 > **Note:**
 >
-> Since TiDB v4.0, PingCAP no longer provides support for TiDB Ansible. Since TiDB v5.0, PingCAP no longer provides TiDB Ansible documents. If you want to read the document that introduces how to scale a TiDB cluster using TiDB Ansible, see [Scale the TiDB Cluster Using TiDB Ansible (v4.0)](https://docs.pingcap.com/tidb/v4.0/scale-tidb-using-ansible).
+> TiUP is the recommended method to scale a TiDB cluster. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
 
 To view the current cluster name list, run `tiup cluster list`.
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -10,10 +10,6 @@ This document is targeted for users who want to upgrade from TiDB 3.0 or 3.1 ver
 
 If you have deployed the TiDB cluster using TiDB Ansible, you can use TiUP to import the TiDB Ansible configuration and perform the upgrade.
 
-> **Note:**
->
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
-
 ## Upgrade caveat
 
 - After the upgrade, rolling back to 3.0 or earlier versions is not supported.

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -12,7 +12,7 @@ If you have deployed the TiDB cluster using TiDB Ansible, you can use TiUP to im
 
 > **Note:**
 >
-> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for TiDB Ansible was deprecated in TiDB v4.0 and the TiDB Ansible documentation has been removed since TiDB v5.0.
 
 ## Upgrade caveat
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade TiDB Using TiUP
 summary: Learn how to upgrade TiDB using TiUP.
-aliases: ['/docs/dev/upgrade-tidb-using-tiup/','/docs/dev/how-to/upgrade/using-tiup/','/docs/dev/upgrade-tidb-using-ansible/','/docs/dev/how-to/upgrade/from-previous-version/','/docs/dev/how-to/upgrade/rolling-updates-with-ansible/','/tidb/dev/upgrade-tidb-using-ansible/']
+aliases: ['/docs/dev/upgrade-tidb-using-tiup/','/docs/dev/how-to/upgrade/using-tiup/']
 ---
 
 # Upgrade TiDB Using TiUP
@@ -12,7 +12,7 @@ If you have deployed the TiDB cluster using TiDB Ansible, you can use TiUP to im
 
 > **Note:**
 >
-> Since TiDB v4.0, PingCAP no longer provides support for TiDB Ansible. Since TiDB v5.0, PingCAP no longer provides TiDB Ansible documents. If you want to read the document that introduces how to upgrade a TiDB cluster using TiDB Ansible, see [Upgrade TiDB Using TiDB Ansible (v4.0)](https://docs.pingcap.com/tidb/v4.0/upgrade-tidb-using-ansible).
+> TiUP is the recommended upgrade path for users of TiDB Ansible. Support for Ansible was deprecated in TiDB v4.0 and removed starting with TiDB v5.0.
 
 ## Upgrade caveat
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

This PR addresses https://github.com/pingcap/docs/issues/4529.
+ Remove the links to deprecated v4.0 Ansible docs in TiUP docs 
+ Remove the Ansible-related aliases from TiUP docs and add them to v4.0 Ansible docs (added in https://github.com/pingcap/docs/pull/4947)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
