### PR TITLE
Log redact on TiFlash and PD (4.0)

### DIFF
--- a/log-redaction.md
+++ b/log-redaction.md
@@ -40,3 +40,11 @@ From the error log above, you can see that all sensitive information is shielded
 ## Log redaction in TiKV side
 
 To enable log redaction in the TiKV side, set the value of [`security.redact-info-log`](/tikv-configuration-file.md#redact-info-log-new-in-v408) to `true`. This configuration value defaults to `false`, which means that log redaction is disabled.
+
+## Log redaction in PD side
+
+To enable log redaction in the PD side, set the value of [`security.redact-info-log`](/pd-configuration-file.md#redact-info-log-) to `true`. This configuration value defaults to `false`, which means that log redaction is disabled.
+
+## Log redaction in TiFlash side
+
+To enable log redaction in the TiFlash side, set both the [`security.redact_info_log`](/tiflash/tiflash-configuration.md#configure-the-tiflash.toml-file) value in tiflash-server and the [`security.redact-info-log`](/tiflash/tiflash-configuration.md#configure-the-tiflash-learner.toml-file) value in tiflash-learner to `true`. Both configuration values default to `false`, which means that log redaction is disabled.

--- a/log-redaction.md
+++ b/log-redaction.md
@@ -43,8 +43,8 @@ To enable log redaction in the TiKV side, set the value of [`security.redact-inf
 
 ## Log redaction in PD side
 
-To enable log redaction in the PD side, set the value of [`security.redact-info-log`](/pd-configuration-file.md#redact-info-log-) to `true`. This configuration value defaults to `false`, which means that log redaction is disabled.
+To enable log redaction in the PD side, set the value of [`security.redact-info-log`](/pd-configuration-file.md#redact-info-log-new-in-v4010) to `true`. This configuration value defaults to `false`, which means that log redaction is disabled.
 
 ## Log redaction in TiFlash side
 
-To enable log redaction in the TiFlash side, set both the [`security.redact_info_log`](/tiflash/tiflash-configuration.md#configure-the-tiflash.toml-file) value in tiflash-server and the [`security.redact-info-log`](/tiflash/tiflash-configuration.md#configure-the-tiflash-learner.toml-file) value in tiflash-learner to `true`. Both configuration values default to `false`, which means that log redaction is disabled.
+To enable log redaction in the TiFlash side, set both the [`security.redact_info_log`](/tiflash/tiflash-configuration.md#configure-the-tiflashtoml-file) value in tiflash-server and the [`security.redact-info-log`](/tiflash/tiflash-configuration.md#configure-the-tiflash-learnertoml-file) value in tiflash-learner to `true`. Both configuration values default to `false`, which means that log redaction is disabled.

--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -90,8 +90,8 @@ Configuration items related to security
 
 ### `redact-info-log` <span class="version-mark">New in v4.0.10</span>
 
-+ Enables or disables log redaction in PD.
-+ If the configuration value is set to `true`, all user data in the PD log will be redacted.
++ Controls whether to enable log redaction in the PD log.
++ When you set the configuration value to `true`, user data is redacted in the PD log.
 + Default value: `false`
 
 ## `log`

--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -88,6 +88,12 @@ Configuration items related to security
 + The path of the PEM file that contains the X509 key
 + Default value: ""
 
+### `redact-info-log` <span class="version-mark">New in v4.0.10</span>
+
++ Enables or disables log redaction in PD.
++ If the configuration value is set to `true`, all user data in the PD log will be redacted.
++ Default value: `false`
+
 ## `log`
 
 Configuration items related to log

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -155,6 +155,12 @@ minmax_index_cache_size = 5368709120
     # cert_path = "/path/to/tiflash-server.pem"
     ## Path of the file that contains X509 key in PEM format.
     # key_path = "/path/to/tiflash-server-key.pem"
+
+    ## New in v4.0.10. This configuration item enables or disables log redaction. If the configuration value
+    ## is set to `true`, all user data in the log will be replaced by `?`.
+    ## Note that you also need to set `security.redact-info-log` for tiflash-learner's logging
+    ## in tiflash-learner.toml
+    # redact_info_log = false
 ```
 
 ### Configure the `tiflash-learner.toml` file

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -158,8 +158,7 @@ minmax_index_cache_size = 5368709120
 
     ## New in v4.0.10. This configuration item enables or disables log redaction. If the configuration value
     ## is set to `true`, all user data in the log will be replaced by `?`.
-    ## Note that you also need to set `security.redact-info-log` for tiflash-learner's logging
-    ## in tiflash-learner.toml
+    ## Note that you also need to set `security.redact-info-log` for tiflash-learner's logging in tiflash-learner.toml.
     # redact_info_log = false
 ```
 

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -178,6 +178,11 @@ minmax_index_cache_size = 5368709120
     ## The default value is "4ms".
     ## If you set it to 0ms, the optimization is disabled.
     store-batch-retry-recv-timeout = "4ms"
+[security]
+    ## New in v4.0.10. This configuration item enables or disables log redaction.
+    ## If the configuration value is set to true,
+    ## all user data in the log will be replaced by ?. The default value is false.
+    redact-info-log = false
 ```
 
 In addition to the items above, other parameters are the same with those of TiKV. Note that the configuration items in `tiflash.toml [flash.proxy]` will override the overlapping parameters in `tiflash-learner.toml`; The `label` whose key is `engine` is reserved and cannot be configured manually.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

TiFlash and PD have picked the feature "redact-log" to the release-4.0 branch(released in 4.0.10), but forgot to add documents to the release-4.0 branch.
Add redact log configurations for TiFlash and PD.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
