### PR TITLE
update the local storage description from 'mocktikv' to 'unistore'

### DIFF
--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -97,11 +97,11 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 ## `--path`
 
-- The path to the data directory for local storage engine like "mocktikv"
-- For `--store = tikv`, you must specify the path; for `--store = mocktikv`, the default value is used if you do not specify the path.
+- The path to the data directory for local storage engine like "unistore"
+- For `--store = tikv`, you must specify the path; for `--store = unistore`, the default value is used if you do not specify the path.
 - For the distributed storage engine like TiKV, `--path` specifies the actual PD address. Assuming that you deploy the PD server on 192.168.100.113:2379, 192.168.100.114:2379 and 192.168.100.115:2379, the value of `--path` is "192.168.100.113:2379, 192.168.100.114:2379, 192.168.100.115:2379".
 - Default: "/tmp/tidb"
-- You can use `tidb-server --store=mocktikv --path=""` to enable a pure in-memory TiDB.
+- You can use `tidb-server --store=unistore --path=""` to enable a pure in-memory TiDB.
 
 ## `--tmp-storage-path`
 
@@ -162,8 +162,8 @@ When you start the TiDB cluster, you can use command-line options or environment
 ## `--store`
 
 - Specifies the storage engine used by TiDB in the bottom layer
-- Default: "mocktikv"
-- You can choose "mocktikv" or "tikv". ("mocktikv" is the local storage engine; "tikv" is a distributed storage engine)
+- Default: "unistore"
+- You can choose "unistore" or "tikv". ("unistore" is the local storage engine; "tikv" is a distributed storage engine)
 
 ## `--token-limit`
 

--- a/sql-statements/sql-statement-restore.md
+++ b/sql-statements/sql-statement-restore.md
@@ -20,7 +20,7 @@ The `RESTORE` statement is blocking, and will finish only after the entire resto
 
 Only one `BACKUP` and `RESTORE` task can be executed at a time. If a `BACKUP` or `RESTORE` task is already running on the same TiDB server, the new `RESTORE` execution will wait until all previous tasks are done.
 
-`RESTORE` can only be used with "tikv" storage engine. Using `RESTORE` with the "mocktikv" engine will fail.
+`RESTORE` can only be used with "tikv" storage engine. Using `RESTORE` with the "unistore" engine will fail.
 
 ## Synopsis
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
In 'dev' and 'v5.0' version, the default value of `--store` TiDB command-line argument has been changed to 'unistore'.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5874
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
