### PR TITLE
partitioned-table: Correct the variable name for list partitioning

### DIFF
--- a/partitioned-table.md
+++ b/partitioned-table.md
@@ -170,13 +170,15 @@ Range partitioning is particularly useful when one or more of the following cond
 >
 > List partitioning is an experimental feature. It is not recommended that you use it in the production environment.
 
-Before creating a List partitioned table, you need to set the value of the session variable `tidb_enable_table_partition` to `ON`.
+Before creating a List partitioned table, you need to set the value of the session variable `tidb_enable_list_partition` to `ON`.
 
 {{< copyable "sql" >}}
 
 ```sql
-set @@session.tidb_enable_table_partition = ON
+set @@session.tidb_enable_list_partition = ON
 ```
+
+Also `tidb_enable_table_partition` needs to be set to `ON`, but this is the default.
 
 List partitioning is similar to Range partitioning. Unlike Range partitioning, in List partitioning, the partitioning expression values for all rows in each partition are in a given value set. This value set defined for each partition can have any number of values but cannot have duplicate values. You can use the `PARTITION ... VALUES IN (...)` clause to define a value set.
 

--- a/partitioned-table.md
+++ b/partitioned-table.md
@@ -178,7 +178,7 @@ Before creating a List partitioned table, you need to set the value of the sessi
 set @@session.tidb_enable_list_partition = ON
 ```
 
-Also `tidb_enable_table_partition` needs to be set to `ON`, but this is the default.
+Also, make sure that `tidb_enable_table_partition` is set to `ON`, which is the default setting.
 
 List partitioning is similar to Range partitioning. Unlike Range partitioning, in List partitioning, the partitioning expression values for all rows in each partition are in a given value set. This value set defined for each partition can have any number of values but cannot have duplicate values. You can use the `PARTITION ... VALUES IN (...)` clause to define a value set.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

List partitioning requires the `tidb_enable_list_partition` variable to be set to ON, not just `tidb_enable_table_partition`. Updating the text for this.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
