### PR TITLE
check-before-deployment: Add info about chronyd/chronyc on CentOS 8

### DIFF
--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -249,7 +249,7 @@ To check whether the NTP service is installed and whether it synchronizes with t
     chronyc tracking
     ```
 
-    - If it returns `Leap status     : Normal`, then the synchronization process is normal.
+    - If the command returns `Leap status     : Normal`, the synchronization process is normal.
 
         ```
         Reference ID    : 5EC69F0A (ntp1.time.nl)

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -267,13 +267,13 @@ To check whether the NTP service is installed and whether it synchronizes with t
         Leap status     : Normal
         ```
 
-    - The following situation indicates the synchronization is not synchronizing normally:
+    - If the command returns the following result, an error occurs in the synchronization:
 
         ```
         Leap status    : Not synchronised
         ```
 
-    - The following situation indicates the `chronyd` service is not running normally:
+    - If the command returns the following result, the `chronyd` service is not running normally:
 
         ```
         506 Cannot talk to daemon

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -241,7 +241,7 @@ To check whether the NTP service is installed and whether it synchronizes with t
 
     > **Note:**
     >
-    > This only applies to system that use Chrony instead of NTPd.
+    > This only applies to systems that use Chrony instead of NTPd.
 
     {{< copyable "shell-regular" >}}
 

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -203,7 +203,7 @@ To check whether the NTP service is installed and whether it synchronizes with t
     Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
     ```
 
-    This would mean that your system is configured to use `chronyd` instead of `ntpd` to do synchronization with NTP. If this is the case proceed to step 3.
+    If your system is configured to use `chronyd`, proceed to step 3.
 
 2. Run the `ntpstat` command to check whether the NTP service synchronizes with the NTP server.
 

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -189,7 +189,7 @@ To check whether the NTP service is installed and whether it synchronizes with t
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
-    - If it returns `Unit ntpd.service could not be found.` then try the following:
+    - If it returns `Unit ntpd.service could not be found.`, then try the following command to see whether your system is configured to use `chronyd` instead of `ntpd` to perform clock synchronization with NTP:
 
     {{< copyable "shell-regular" >}}
 

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -191,19 +191,19 @@ To check whether the NTP service is installed and whether it synchronizes with t
 
     - If it returns `Unit ntpd.service could not be found.`, then try the following command to see whether your system is configured to use `chronyd` instead of `ntpd` to perform clock synchronization with NTP:
 
-    {{< copyable "shell-regular" >}}
-
-    ```bash
-    sudo systemctl status cronyd.service
-    ```
-
-    ```
-    chronyd.service - NTP client/server
-    Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
-    Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
-    ```
-
-    If your system is configured to use `chronyd`, proceed to step 3.
+        {{< copyable "shell-regular" >}}
+    
+        ```bash
+        sudo systemctl status cronyd.service
+        ```
+    
+        ```
+        chronyd.service - NTP client/server
+        Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
+        Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
+        ```
+    
+        If your system is configured to use `chronyd`, proceed to step 3.
 
 2. Run the `ntpstat` command to check whether the NTP service synchronizes with the NTP server.
 

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -189,6 +189,22 @@ To check whether the NTP service is installed and whether it synchronizes with t
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
+    - If it returns `Unit ntpd.service could not be found.` then try the following:
+
+    {{< copyable "shell-regular" >}}
+
+    ```bash
+    sudo systemctl status cronyd.service
+    ```
+
+    ```
+    chronyd.service - NTP client/server
+    Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
+    Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
+    ```
+
+    This would mean that your system is configured to use `chronyd` instead of `ntpd` to do synchronization with NTP. If this is the case proceed to step 3.
+
 2. Run the `ntpstat` command to check whether the NTP service synchronizes with the NTP server.
 
     > **Note:**
@@ -219,6 +235,48 @@ To check whether the NTP service is installed and whether it synchronizes with t
 
         ```
         Unable to talk to NTP daemon. Is it running?
+        ```
+
+3. Run the `chronyc tracking` command to check wheter the Chrony service synchronizes with the NTP server.
+
+    > **Note:**
+    >
+    > This only applies to system that use Chrony instead of NTPd.
+
+    {{< copyable "shell-regular" >}}
+
+    ```bash
+    chronyc tracking
+    ```
+
+    - If it returns `Leap status     : Normal`, then the synchronization process is normal.
+
+        ```
+        Reference ID    : 5EC69F0A (ntp1.time.nl)
+        Stratum         : 2
+        Ref time (UTC)  : Thu May 20 15:19:08 2021
+        System time     : 0.000022151 seconds slow of NTP time
+        Last offset     : -0.000041040 seconds
+        RMS offset      : 0.000053422 seconds
+        Frequency       : 2.286 ppm slow
+        Residual freq   : -0.000 ppm
+        Skew            : 0.012 ppm
+        Root delay      : 0.012706812 seconds
+        Root dispersion : 0.000430042 seconds
+        Update interval : 1029.8 seconds
+        Leap status     : Normal
+        ```
+
+    - The following situation indicates the synchronization is not synchronizing normally:
+
+        ```
+        Leap status    : Not synchronised
+        ```
+
+    - The following situation indicates the `chronyd` service is not running normally:
+
+        ```
+        506 Cannot talk to daemon
         ```
 
 To make the NTP service start synchronizing as soon as possible, run the following command. Replace `pool.ntp.org` with your NTP server.


### PR DESCRIPTION
On CentOS 8 Chrony is used by default for NTP services.
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp#sect-checking_if_chrony_is_synchronized

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
