### PR TITLE
release-5.0.0: Fix 'tidb_enable_clustered_index' values

### DIFF
--- a/releases/release-5.0.0.md
+++ b/releases/release-5.0.0.md
@@ -45,8 +45,8 @@ In v5.0, the key new features or improvements are as follows:
 + Change the default value of [`enable-joint-consensus`](/pd-configuration-file.md#enable-joint-consensus-new-in-v50) from `false` to `true`, which enables the Joint Consensus feature by default.
 + Change the value of [`tidb_enable_amend_pessimistic_txn`](/system-variables.md#tidb_enable_amend_pessimistic_txn-new-in-v407) from `0` or `1` to `ON` or `OFF`.
 + Change the default value of [`tidb_enable_clustered_index`](/system-variables.md#tidb_enable_clustered_index-new-in-v50) from `OFF` to `INT_ONLY` with the following new meanings:
-    + `OFF`: clustered index is enabled. Adding or deleting non-clustered indexes is supported.
-    + `ON`: clustered index is disabled. Adding or deleting non-clustered indexes is supported.
+    + `ON`: clustered index is enabled. Adding or deleting non-clustered indexes is supported.
+    + `OFF`: clustered index is disabled. Adding or deleting non-clustered indexes is supported.
     + `INT_ONLY`: the default value. The behavior is consistent with that before v5.0. You can control whether to enable clustered index for the INT type together with `alter-primary-key = false`.
 
     > **Note:**


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fixed the description of the `tidb_enable_clustered_index` setting.

Reported on #sig-docs in community slack by jun.seok.heo@samsung.com

https://tidbcommunity.slack.com/archives/CTW5HG9FH/p1618297103003000



<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
