### PR TITLE
explain: add hint about disabling line wrapping with less

### DIFF
--- a/explain-overview.md
+++ b/explain-overview.md
@@ -8,7 +8,7 @@ aliases: ['/docs/dev/query-execution-plan/','/docs/dev/reference/performance/und
 
 > **Note:**
 >
-> If you use the `mysql` client to connect to TiDB you may want to use `pager less -S` to avoid line wrapping in your terminal and instead press the right arrow on your keyboard to horizontally scroll through the explain output.
+> When you use the MySQL client to connect to TiDB, to read the output result in a clearer way without line wrapping, you can use the `pager less -S` command. Then, after the `EXPLAIN` result is output, you can press the right arrow <kbd>→</kbd> button on your keyboard to horizontally scroll through the output.
 
 SQL is a declarative language. It describes what the results of a query should look like, **not the methodology** to actually retrieve those results. TiDB considers all the possible ways in which a query could be executed, including using what order to join tables and whether any potential indexes can be used. The process of _considering query execution plans_ is known as SQL optimization.
 

--- a/explain-overview.md
+++ b/explain-overview.md
@@ -6,6 +6,10 @@ aliases: ['/docs/dev/query-execution-plan/','/docs/dev/reference/performance/und
 
 # `EXPLAIN` Overview
 
+> **Note:**
+>
+> If you use the `mysql` client to connect to TiDB you may want to use `pager less -S` to avoid line wrapping in your terminal and instead press the right arrow on your keyboard to horizontally scroll through the explain output.
+
 SQL is a declarative language. It describes what the results of a query should look like, **not the methodology** to actually retrieve those results. TiDB considers all the possible ways in which a query could be executed, including using what order to join tables and whether any potential indexes can be used. The process of _considering query execution plans_ is known as SQL optimization.
 
 The `EXPLAIN` statement shows the selected execution plan for a given statement. That is, after considering hundreds or thousands of ways in which the query could be executed, TiDB believes that this _plan_ will consume the least resources and execute in the shortest amount of time:

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -28,6 +28,10 @@ TiDB supports the `EXPLAIN [options] FOR CONNECTION connection_id` statement. Ho
 
 ## `EXPLAIN` output format
 
+> **Note:**
+>
+> If you use the `mysql` client to connect to TiDB you may want to use `pager less -S` to avoid line wrapping in your terminal and instead press the right arrow on your keyboard to horizontally scroll through the explain output.
+
 Currently, `EXPLAIN` in TiDB outputs 5 columns: `id`, `estRows`, `task`, `access object`, `operator info`. Each operator in the execution plan is described by these attributes, with each row in the `EXPLAIN` output describing an operator. The description of each attribute is as follows:
 
 | Attribute name          | Description |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add a hint to the `EXPLAIN` documentation about how to use `less -S` to view large explain output without line wrapping.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
