### PR TITLE
correct a tikv config name

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -272,7 +272,7 @@ Configuration items related to storage
 + Note: The TTL feature is only available for the RawKV interface for now. You can only configure this feature when creating a new cluster because TTL uses different data formats in the storage layer. If you modify this item on an existing cluster, TiKV reports errors when it starts.
 + Default value: `false`
 
-### `ttl-poll-check-interval` <span class="version-mark">New in v5.0 GA</span>
+### `ttl-check-poll-interval` <span class="version-mark">New in v5.0 GA</span>
 
 + The interval of checking data to reclaim physical spaces. If data reaches its TTL, TiKV forcibly reclaims its physical space during the check.
 + Default value: `"12h"`


### PR DESCRIPTION
ttl-poll-check-interval -> ttl-check-poll-interval

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

ttl-**poll-check**-interval -> ttl-**check-poll**-interval
```mysql
mysql> show config;
| tikv | 10.186.1.1:20160 | storage.ttl-check-poll-interval | 12h
```
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- Other reference link(s):  https://github.com/pingcap/docs-cn/pull/6073
