### PR TITLE
ticdc: fix kafka message size limit

### DIFF
--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -246,7 +246,7 @@ For more information, refer to [Replication task configuration file](/ticdc/mana
 
 ## When TiCDC replicates data to Kafka, can I control the maximum size of a single message in TiDB?
 
-You can set `max-message-bytes` to control the maximum size of data sent to the Kafka broker each time (optional, the default value is 64MB); set the `max-batch-size` parameter to specify the maximum number of change records in each Kafka message, Currently only take effect when Kafka's protocol is `default` (optional, the default value is `4096`);
+Yes. You can set `max-message-bytes` to control the maximum size of data sent to the Kafka broker each time (optional, `64MB` by default). You can also set the `max-batch-size` parameter to specify the maximum number of change records in each Kafka message. Currently it only takes effect when Kafka's protocol is `default` (optional, `4096` by default).
 
 ## When TiCDC replicates data to Kafka, does a message contain multiple types of data changes?
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -246,7 +246,7 @@ For more information, refer to [Replication task configuration file](/ticdc/mana
 
 ## When TiCDC replicates data to Kafka, can I control the maximum size of a single message in TiDB?
 
-Yes. You can set `max-message-bytes` to control the maximum size of data sent to the Kafka broker each time (optional, `64MB` by default). You can also set the `max-batch-size` parameter to specify the maximum number of change records in each Kafka message. Currently it only takes effect when Kafka's protocol is `default` (optional, `4096` by default).
+Yes. You can set the `max-message-bytes` parameter to control the maximum size of data sent to the Kafka broker each time (optional, `64MB` by default). You can also set `max-batch-size` to specify the maximum number of change records in each Kafka message. Currently, the setting only takes effect when Kafka's protocol is `default` (optional, `4096` by default).
 
 ## When TiCDC replicates data to Kafka, does a message contain multiple types of data changes?
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -246,7 +246,7 @@ For more information, refer to [Replication task configuration file](/ticdc/mana
 
 ## When TiCDC replicates data to Kafka, can I control the maximum size of a single message in TiDB?
 
-No. Currently TiCDC sets the maximum size of batch messages to 512 MB, and that of a single message to 4 MB.
+You can set `max-message-bytes` to control the maximum size of data sent to the Kafka broker each time (optional, the default value is 64MB); set the `max-batch-size` parameter to specify the maximum number of change records in each Kafka message, Currently only take effect when Kafka's protocol is `default` (optional, the default value is `4096`);
 
 ## When TiCDC replicates data to Kafka, does a message contain multiple types of data changes?
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
TiCDC provides two parameters to control the message size and batch size of Kafka messages.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->
 
- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5650
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
