### PR TITLE
no server.request-batch-enable-cross-command in v5.0.0

### DIFF
--- a/benchmark/v5.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v5.0-performance-benchmarking-with-tpcc.md
@@ -90,7 +90,6 @@ readpool.unified.max-thread-count: 20
 readpool.unified.min-thread-count: 5
 rocksdb.max-background-jobs: 8
 server.grpc-concurrency: 6
-server.request-batch-enable-cross-command: false
 storage.scheduler-worker-pool-size: 20
 ```
 


### PR DESCRIPTION
same as pr 5414, the parameter is obsolete in v5.0.0

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
