### PR TITLE
ticdc: Include local:// and s3:// sink support

### DIFF
--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -230,6 +230,7 @@ The following command creates a changefeed that will write cdclog files locally 
 
 ```shell
 cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="local:///data/cdclog" --config changefeed.toml
+```
 
 The following command creates a changefeed that will write cdclog files to an external S3 storage in the `logbucket` bucket with a subdirectory of `test`. The endpoint is set in the URI, which is needed if you are using an S3-compatible storage other than Amazon S3.
 
@@ -237,6 +238,7 @@ The following command creates a changefeed that will write cdclog files to an ex
 
 ```shell
 cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="s3://logbucket/test?endpoint=http://$S3_ENDPOINT/" --config changefeed.toml
+```
 
 #### Use the task configuration file
 

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -90,7 +90,7 @@ Info: {"sink-uri":"mysql://root:123456@127.0.0.1:3306/","opts":{},"create-time":
 ```
 
 - `--changefeed-id`: The ID of the replication task. The format must match the `^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$` regular expression. If this ID is not specified, TiCDC automatically generates a UUID (the version 4 format) as the ID.
-- `--sink-uri`: The downstream address of the replication task. Configure `--sink-uri` according to the following format. Currently, the scheme supports `mysql`/`tidb`/`kafka`/`pulsar`.
+- `--sink-uri`: The downstream address of the replication task. Configure `--sink-uri` according to the following format. Currently, the scheme supports `mysql`/`tidb`/`kafka`/`pulsar`/`s3`/`local`.
 
     {{< copyable "" >}}
 
@@ -219,6 +219,26 @@ The following are descriptions of parameters that can be configured for the sink
 | `properties.*` | The customized properties added to the Pulsar producer in TiCDC (optional). For example, `properties.location=Hangzhou`. |
 
 For more parameters of Pulsar, see [pulsar-client-go ClientOptions](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ClientOptions) and [pulsar-client-go ProducerOptions](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ProducerOptions).
+
+#### Configure sink URI with cdclog
+
+The `cdclog` files (files written by TiCDC on the local filesystem or on the Amazon S3 compatible storage) can be used together with Backup & Restore (BR) to provide point-in-time (PITR) recovery. See [Point in Time recovery (experimental feature)](/br/use-br-command-line-tool.md#point-in-time-recovery-experimental-feature) for details.
+
+{{< copyable "shell-regular" >}}
+
+```shell
+cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="local:///data/cdclog" --config changefeed.toml
+```
+
+This command creates a changefeed that would write cdclog files localy to `/data/cdc/log`.
+
+{{< copyable "shell-regular" >}}
+
+```shell
+cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="s3://logbucket/test?endpoint=http://$S3_ENDPOINT/" --config changefeed.toml
+```
+
+This command creates a changefeed that would write cdclog files to external S3 storage in the `logbucket` bucket with a subdirectory of test. The endpoint is set in the URI, this is needed if you are using S3 compatible storage instead of Amazon S3.
 
 #### Use the task configuration file
 

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -222,7 +222,7 @@ For more parameters of Pulsar, see [pulsar-client-go ClientOptions](https://godo
 
 #### Configure sink URI with cdclog
 
-The `cdclog` files (files written by TiCDC on the local filesystem or on the Amazon S3 compatible storage) can be used together with Backup & Restore (BR) to provide point-in-time (PITR) recovery. See [Point in Time recovery (experimental feature)](/br/use-br-command-line-tool.md#point-in-time-recovery-experimental-feature) for details.
+The `cdclog` files (files written by TiCDC on the local filesystem or on the Amazon S3-compatible storage) can be used together with Backup & Restore (BR) to provide point-in-time (PITR) recovery. See [Point in Time recovery (experimental feature)](/br/use-br-command-line-tool.md#point-in-time-recovery-experimental-feature) for details.
 
 {{< copyable "shell-regular" >}}
 

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -224,13 +224,12 @@ For more parameters of Pulsar, see [pulsar-client-go ClientOptions](https://godo
 
 The `cdclog` files (files written by TiCDC on the local filesystem or on the Amazon S3-compatible storage) can be used together with Backup & Restore (BR) to provide point-in-time (PITR) recovery. See [Point in Time recovery (experimental feature)](/br/use-br-command-line-tool.md#point-in-time-recovery-experimental-feature) for details.
 
+The following command creates a changefeed that will write cdclog files locally to the `/data/cdc/log` directory.
+
 {{< copyable "shell-regular" >}}
 
 ```shell
 cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="local:///data/cdclog" --config changefeed.toml
-```
-
-This command creates a changefeed that would write cdclog files localy to `/data/cdc/log`.
 
 {{< copyable "shell-regular" >}}
 

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -231,13 +231,12 @@ The following command creates a changefeed that will write cdclog files locally 
 ```shell
 cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="local:///data/cdclog" --config changefeed.toml
 
+The following command creates a changefeed that will write cdclog files to an external S3 storage in the `logbucket` bucket with a subdirectory of `test`. The endpoint is set in the URI, which is needed if you are using an S3-compatible storage other than Amazon S3.
+
 {{< copyable "shell-regular" >}}
 
 ```shell
 cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="s3://logbucket/test?endpoint=http://$S3_ENDPOINT/" --config changefeed.toml
-```
-
-This command creates a changefeed that would write cdclog files to external S3 storage in the `logbucket` bucket with a subdirectory of test. The endpoint is set in the URI, this is needed if you are using S3 compatible storage instead of Amazon S3.
 
 #### Use the task configuration file
 

--- a/ticdc/ticdc-overview.md
+++ b/ticdc/ticdc-overview.md
@@ -43,6 +43,8 @@ Currently, the TiCDC sink component supports replicating data to the following d
 
 - Databases compatible with MySQL protocol. The sink component provides the final consistency support.
 - Kafka based on the TiCDC Open Protocol. The sink component ensures the row-level order, final consistency or strict transactional consistency.
+- `cdclog` (experimental): Files written on the local filesystem or on the Amazon S3-compatible storage.
+- Apache Pulsar (experimental)
 
 ### Ensure replication order and consistency
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Add documentation about the `local://` and `s3://` sinks in TiCDC
- Add documentation about `br restore cdclog`

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
