### PR TITLE
sql-statements: use EBNF to render syntax diagrams - second batch

### DIFF
--- a/sql-statements/sql-statement-begin.md
+++ b/sql-statements/sql-statement-begin.md
@@ -12,9 +12,11 @@ In the absence of a `BEGIN` statement, every statement will by default autocommi
 
 ## Synopsis
 
-**BeginTransactionStmt:**
-
-![BeginTransactionStmt](/media/sqlgram/BeginTransactionStmt.png)
+```ebnf+diagram
+BeginTransactionStmt ::=
+    'BEGIN' ( 'PESSIMISTIC' | 'OPTIMISTIC' )?
+|   'START' 'TRANSACTION' ( 'READ' ( 'WRITE' | 'ONLY' ( 'WITH' 'TIMESTAMP' 'BOUND' TimestampBound )? ) | 'WITH' 'CONSISTENT' 'SNAPSHOT' )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-change-column.md
+++ b/sql-statements/sql-statement-change-column.md
@@ -10,25 +10,42 @@ The `ALTER TABLE.. CHANGE COLUMN` statement changes a column on an existing tabl
 
 ## Synopsis
 
-**AlterTableStmt:**
+```ebnf+diagram
+AlterTableStmt ::=
+    'ALTER' IgnoreOptional 'TABLE' TableName ( AlterTableSpecListOpt AlterTablePartitionOpt | 'ANALYZE' 'PARTITION' PartitionNameList ( 'INDEX' IndexNameList )? AnalyzeOptionListOpt )
 
-![AlterTableStmt](/media/sqlgram/AlterTableStmt.png)
+AlterTableSpec ::=
+    TableOptionList
+|   'SET' 'TIFLASH' 'REPLICA' LengthNum LocationLabelList
+|   'CONVERT' 'TO' CharsetKw ( CharsetName | 'DEFAULT' ) OptCollate
+|   'ADD' ( ColumnKeywordOpt IfNotExists ( ColumnDef ColumnPosition | '(' TableElementList ')' ) | Constraint | 'PARTITION' IfNotExists NoWriteToBinLogAliasOpt ( PartitionDefinitionListOpt | 'PARTITIONS' NUM ) )
+|   ( ( 'CHECK' | 'TRUNCATE' ) 'PARTITION' | ( 'OPTIMIZE' | 'REPAIR' | 'REBUILD' ) 'PARTITION' NoWriteToBinLogAliasOpt ) AllOrPartitionNameList
+|   'COALESCE' 'PARTITION' NoWriteToBinLogAliasOpt NUM
+|   'DROP' ( ColumnKeywordOpt IfExists ColumnName RestrictOrCascadeOpt | 'PRIMARY' 'KEY' | 'PARTITION' IfExists PartitionNameList | ( KeyOrIndex IfExists | 'CHECK' ) Identifier | 'FOREIGN' 'KEY' IfExists Symbol )
+|   'EXCHANGE' 'PARTITION' Identifier 'WITH' 'TABLE' TableName WithValidationOpt
+|   ( 'IMPORT' | 'DISCARD' ) ( 'PARTITION' AllOrPartitionNameList )? 'TABLESPACE'
+|   'REORGANIZE' 'PARTITION' NoWriteToBinLogAliasOpt ReorganizePartitionRuleOpt
+|   'ORDER' 'BY' AlterOrderItem ( ',' AlterOrderItem )*
+|   ( 'DISABLE' | 'ENABLE' ) 'KEYS'
+|   ( 'MODIFY' ColumnKeywordOpt IfExists | 'CHANGE' ColumnKeywordOpt IfExists ColumnName ) ColumnDef ColumnPosition
+|   'ALTER' ( ColumnKeywordOpt ColumnName ( 'SET' 'DEFAULT' ( SignedLiteral | '(' Expression ')' ) | 'DROP' 'DEFAULT' ) | 'CHECK' Identifier EnforcedOrNot | 'INDEX' Identifier IndexInvisible )
+|   'RENAME' ( ( 'COLUMN' | KeyOrIndex ) Identifier 'TO' Identifier | ( 'TO' | '='? | 'AS' ) TableName )
+|   LockClause
+|   AlgorithmClause
+|   'FORCE'
+|   ( 'WITH' | 'WITHOUT' ) 'VALIDATION'
+|   'SECONDARY_LOAD'
+|   'SECONDARY_UNLOAD'
 
-**AlterTableSpec:**
+ColumnName ::=
+    Identifier ( '.' Identifier ( '.' Identifier )? )?
 
-![AlterTableSpec](/media/sqlgram/AlterTableSpec.png)
+ColumnDef ::=
+    ColumnName ( Type | 'SERIAL' ) ColumnOptionListOpt
 
-**ColumnName:**
-
-![ColumnName](/media/sqlgram/ColumnName.png)
-
-**ColumnDef:**
-
-![ColumnDef](/media/sqlgram/ColumnDef.png)
-
-**ColumnPosition:**
-
-![ColumnPosition](/media/sqlgram/ColumnPosition.png)
+ColumnPosition ::=
+    ( 'FIRST' | 'AFTER' ColumnName )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-commit.md
+++ b/sql-statements/sql-statement-commit.md
@@ -12,13 +12,14 @@ In the absence of a `BEGIN` or `START TRANSACTION` statement, the default behavi
 
 ## Synopsis
 
-**CommitStmt:**
+```ebnf+diagram
+CommitStmt ::=
+    'COMMIT' CompletionTypeWithinTransaction?
 
-![CommitStmt](/media/sqlgram/CommitStmt.png)
-
-**CompletionTypeWithinTransaction:**
-
-![CompletionTypeWithinTransaction](/media/sqlgram/CompletionTypeWithinTransaction.png)
+CompletionTypeWithinTransaction ::=
+    'AND' ( 'CHAIN' ( 'NO' 'RELEASE' )? | 'NO' 'CHAIN' ( 'NO'? 'RELEASE' )? )
+|   'NO'? 'RELEASE'
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-create-binding.md
+++ b/sql-statements/sql-statement-create-binding.md
@@ -14,17 +14,14 @@ The bound SQL statement is parameterized and stored in the system table. When a 
 
 ## Synopsis
 
-**CreateBindingStmt:**
-
-![CreateBindingStmt](/media/sqlgram/CreateBindingStmt.png)
-
-**GlobalScope:**
-
-![GlobalScope](/media/sqlgram/GlobalScope.png)
-
-**SelectStmt**
-
-![SelectStmt](/media/sqlgram/SelectStmt.png)
+```ebnf+diagram
+CreateBindingStmt ::=
+    'CREATE' GlobalScope 'BINDING' 'FOR' SelectStmt 'USING' SelectStmt
+GlobalScope ::=
+    ( 'GLOBAL' | 'SESSION' )?
+SelectStmt ::=
+    ( SelectStmtBasic | SelectStmtFromDualTable | SelectStmtFromTable ) OrderByOptional SelectStmtLimit SelectLockOpt SelectStmtIntoOption
+```
 
 ****
 

--- a/sql-statements/sql-statement-create-binding.md
+++ b/sql-statements/sql-statement-create-binding.md
@@ -17,8 +17,10 @@ The bound SQL statement is parameterized and stored in the system table. When a 
 ```ebnf+diagram
 CreateBindingStmt ::=
     'CREATE' GlobalScope 'BINDING' 'FOR' SelectStmt 'USING' SelectStmt
+
 GlobalScope ::=
     ( 'GLOBAL' | 'SESSION' )?
+
 SelectStmt ::=
     ( SelectStmtBasic | SelectStmtFromDualTable | SelectStmtFromTable ) OrderByOptional SelectStmtLimit SelectLockOpt SelectStmtIntoOption
 ```

--- a/sql-statements/sql-statement-create-database.md
+++ b/sql-statements/sql-statement-create-database.md
@@ -10,21 +10,19 @@ This statement creates a new database in TiDB. The MySQL terminology for 'databa
 
 ## Synopsis
 
-**CreateDatabaseStmt:**
+```ebnf+diagram
+CreateDatabaseStmt ::=
+    'CREATE' 'DATABASE' IfNotExists DBName DatabaseOptionListOpt
 
-![CreateDatabaseStmt](/media/sqlgram/CreateDatabaseStmt.png)
+IfNotExists ::=
+    ( 'IF' 'NOT' 'EXISTS' )?
 
-**IfNotExists:**
+DBName ::=
+    Identifier
 
-![IfNotExists](/media/sqlgram/IfNotExists.png)
-
-**DBName:**
-
-![DBName](/media/sqlgram/DBName.png)
-
-**DatabaseOptionListOpt:**
-
-![DatabaseOptionListOpt](/media/sqlgram/DatabaseOptionListOpt.png)
+DatabaseOptionListOpt ::=
+    DatabaseOptionList?
+```
 
 ## Syntax
 

--- a/sql-statements/sql-statement-create-index.md
+++ b/sql-statements/sql-statement-create-index.md
@@ -10,65 +10,58 @@ This statement adds a new index to an existing table. It is an alternative synta
 
 ## Synopsis
 
-**CreateIndexStmt:**
+```ebnf+diagram
+CreateIndexStmt ::=
+    'CREATE' IndexKeyTypeOpt 'INDEX' IfNotExists Identifier IndexTypeOpt 'ON' TableName '(' IndexPartSpecificationList ')' IndexOptionList IndexLockAndAlgorithmOpt
 
-![CreateIndexStmt](/media/sqlgram/CreateIndexStmt.png)
+IndexKeyTypeOpt ::=
+    ( 'UNIQUE' | 'SPATIAL' | 'FULLTEXT' )?
 
-**IndexKeyTypeOpt:**
+IfNotExists ::=
+    ( 'IF' 'NOT' 'EXISTS' )?
 
-![IndexKeyTypeOpt](/media/sqlgram/IndexKeyTypeOpt.png)
+IndexTypeOpt ::=
+    IndexType?
 
-**IfNotExists:**
+IndexPartSpecificationList ::=
+    IndexPartSpecification ( ',' IndexPartSpecification )*
 
-![IfNotExists](/media/sqlgram/IfNotExists.png)
+IndexOptionList ::=
+    IndexOption*
 
-**IndexTypeOpt:**
+IndexLockAndAlgorithmOpt ::=
+    ( LockClause AlgorithmClause? | AlgorithmClause LockClause? )?
 
-![IndexTypeOpt](/media/sqlgram/IndexTypeOpt.png)
+IndexType ::=
+    ( 'USING' | 'TYPE' ) IndexTypeName
 
-**IndexPartSpecificationList:**
+IndexPartSpecification ::=
+    ( ColumnName OptFieldLen | '(' Expression ')' ) Order
 
-![IndexPartSpecificationList](/media/sqlgram/IndexPartSpecificationList.png)
+IndexOption ::=
+    'KEY_BLOCK_SIZE' '='? LengthNum
+|   IndexType
+|   'WITH' 'PARSER' Identifier
+|   'COMMENT' stringLit
+|   IndexInvisible
 
-**IndexOptionList:**
+IndexTypeName ::=
+    'BTREE'
+|   'HASH'
+|   'RTREE'
 
-![IndexOptionList](/media/sqlgram/IndexOptionList.png)
+ColumnName ::=
+    Identifier ( '.' Identifier ( '.' Identifier )? )?
 
-**IndexLockAndAlgorithmOpt:**
+OptFieldLen ::=
+    FieldLen?
 
-![IndexLockAndAlgorithmOpt](/media/sqlgram/IndexLockAndAlgorithmOpt.png)
+IndexNameList ::=
+    ( Identifier | 'PRIMARY' )? ( ',' ( Identifier | 'PRIMARY' ) )*
 
-**IndexType:**
-
-![IndexType](/media/sqlgram/IndexType.png)
-
-**IndexPartSpecification:**
-
-![IndexPartSpecification](/media/sqlgram/IndexPartSpecification.png)
-
-**IndexOption:**
-
-![IndexOption](/media/sqlgram/IndexOption.png)
-
-**IndexTypeName:**
-
-![IndexTypeName](/media/sqlgram/IndexTypeName.png)
-
-**ColumnName:**
-
-![ColumnName](/media/sqlgram/ColumnName.png)
-
-**OptFieldLen:**
-
-![OptFieldLen](/media/sqlgram/OptFieldLen.png)
-
-**IndexNameList:**
-
-![IndexNameList](/media/sqlgram/IndexNameList.png)
-
-**KeyOrIndex:**
-
-![KeyOrIndex](/media/sqlgram/KeyOrIndex.png)
+KeyOrIndex ::=
+    'Key' | 'Index'
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-create-role.md
+++ b/sql-statements/sql-statement-create-role.md
@@ -9,17 +9,16 @@ This statement creates a new role, which can be assigned to users as part of rol
 
 ## Synopsis
 
-**CreateRoleStmt:**
+```ebnf+diagram
+CreateRoleStmt ::=
+    'CREATE' 'ROLE' IfNotExists RoleSpec (',' RoleSpec)*
 
-![CreateRoleStmt](/media/sqlgram/CreateRoleStmt.png)
+IfNotExists ::=
+    ('IF' 'NOT' 'EXISTS')?
 
-**IfNotExists:**
-
-![IfNotExists](/media/sqlgram/IfNotExists.png)
-
-**RoleSpec:**
-
-![RoleSpec](/media/sqlgram/RoleSpec.png)
+RoleSpec ::=
+    Rolename
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-create-sequence.md
+++ b/sql-statements/sql-statement-create-sequence.md
@@ -10,29 +10,31 @@ The `CREATE SEQUENCE` statement creates sequence objects in TiDB. The sequence i
 
 ## Synopsis
 
-**CreateSequenceStmt:**
+```ebnf+diagram
+CreateSequenceStmt ::=
+    'CREATE' 'SEQUENCE' IfNotExists TableName CreateSequenceOptionListOpt CreateTableOptionListOpt
 
-![CreateSequenceStmt](/media/sqlgram/CreateSequenceStmt.png)
+IfNotExists ::=
+    ('IF' 'NOT' 'EXISTS')?
 
-**IfNotExists:**
+TableName ::=
+    Identifier ('.' Identifier)?
 
-![IfNotExists](/media/sqlgram/IfNotExists.png)
+CreateSequenceOptionListOpt ::=
+    SequenceOption*
 
-**TableName:**
+SequenceOptionList ::=
+    SequenceOption
 
-![TableName](/media/sqlgram/TableName.png)
-
-**CreateSequenceOptionListOpt:**
-
-![CreateSequenceOptionListOpt](/media/sqlgram/CreateSequenceOptionListOpt.png)
-
-**SequenceOptionList:**
-
-![SequenceOptionList](/media/sqlgram/SequenceOptionList.png)
-
-**SequenceOption:**
-
-![SequenceOption](/media/sqlgram/SequenceOption.png)
+SequenceOption ::=
+    ( 'INCREMENT' ( '='? | 'BY' ) | 'START' ( '='? | 'WITH' ) | ( 'MINVALUE' | 'MAXVALUE' | 'CACHE' ) '='? ) SignedNum
+|   'NOMINVALUE'
+|   'NO' ( 'MINVALUE' | 'MAXVALUE' | 'CACHE' | 'CYCLE' )
+|   'NOMAXVALUE'
+|   'NOCACHE'
+|   'CYCLE'
+|   'NOCYCLE'
+```
 
 ## Syntax
 

--- a/sql-statements/sql-statement-create-table-like.md
+++ b/sql-statements/sql-statement-create-table-like.md
@@ -10,13 +10,14 @@ This statement copies the definition of an existing table, without copying any d
 
 ## Synopsis
 
-**CreateTableStmt:**
+```ebnf+diagram
+CreateTableLikeStmt ::=
+    'CREATE' OptTemporary 'TABLE' IfNotExists TableName LikeTableWithOrWithoutParen
 
-![CreateTableLikeStmt](/media/sqlgram/CreateTableLikeStmt.png)
-
-**LikeTableWithOrWithoutParen:**
-
-![LikeTableWithOrWithoutParen](/media/sqlgram/LikeTableWithOrWithoutParen.png)
+LikeTableWithOrWithoutParen ::=
+    'LIKE' TableName
+|   '(' 'LIKE' TableName ')'
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-create-table.md
+++ b/sql-statements/sql-statement-create-table.md
@@ -10,65 +10,77 @@ This statement creates a new table in the currently selected database. It behave
 
 ## Synopsis
 
-**CreateTableStmt:**
+```ebnf+diagram
+CreateTableStmt ::=
+    'CREATE' OptTemporary 'TABLE' IfNotExists TableName ( TableElementListOpt CreateTableOptionListOpt PartitionOpt DuplicateOpt AsOpt CreateTableSelectOpt | LikeTableWithOrWithoutParen )
 
-![CreateTableStmt](/media/sqlgram/CreateTableStmt.png)
+IfNotExists ::=
+    ('IF' 'NOT' 'EXISTS')?
 
-**IfNotExists:**
+TableName ::=
+    Identifier ('.' Identifier)?
 
-![IfNotExists](/media/sqlgram/IfNotExists.png)
+TableElementListOpt ::=
+    ( '(' TableElementList ')' )?
 
-**TableName:**
+TableElementList ::=
+    TableElement ( ',' TableElement )*
 
-![TableName](/media/sqlgram/TableName.png)
+TableElement ::=
+    ColumnDef
+|   Constraint
 
-**TableElementListOpt:**
+ColumnDef ::=
+    ColumnName ( Type | 'SERIAL' ) ColumnOptionListOpt
 
-![TableElementListOpt](/media/sqlgram/TableElementListOpt.png)
+ColumnOptionListOpt ::=
+    ColumnOption*
 
-**TableElementList:**
+ColumnOptionList ::=
+    ColumnOption*
 
-![TableElementList](/media/sqlgram/TableElementList.png)
+ColumnOption ::=
+    'NOT'? 'NULL'
+|   'AUTO_INCREMENT'
+|   PrimaryOpt 'KEY'
+|   'UNIQUE' 'KEY'?
+|   'DEFAULT' DefaultValueExpr
+|   'SERIAL' 'DEFAULT' 'VALUE'
+|   'ON' 'UPDATE' NowSymOptionFraction
+|   'COMMENT' stringLit
+|   ConstraintKeywordOpt 'CHECK' '(' Expression ')' EnforcedOrNotOrNotNullOpt
+|   GeneratedAlways 'AS' '(' Expression ')' VirtualOrStored
+|   ReferDef
+|   'COLLATE' CollationName
+|   'COLUMN_FORMAT' ColumnFormat
+|   'STORAGE' StorageMedia
+|   'AUTO_RANDOM' OptFieldLen
 
-**TableElement:**
+CreateTableOptionListOpt ::=
+    TableOptionList?
 
-![TableElement](/media/sqlgram/TableElement.png)
+PartitionOpt ::=
+    ( 'PARTITION' 'BY' PartitionMethod PartitionNumOpt SubPartitionOpt PartitionDefinitionListOpt )?
 
-**ColumnDef:**
+DuplicateOpt ::=
+    ( 'IGNORE' | 'REPLACE' )?
 
-![ColumnDef](/media/sqlgram/ColumnDef.png)
+TableOptionList ::=
+    TableOption ( ','? TableOption )*
 
-**ColumnOptionListOpt:**
-
-![ColumnOptionListOpt](/media/sqlgram/ColumnOptionListOpt.png)
-
-**ColumnOptionList:**
-
-![ColumnOptionList](/media/sqlgram/ColumnOptionList.png)
-
-**ColumnOption:**
-
-![ColumnOption](/media/sqlgram/ColumnOption.png)
-
-**CreateTableOptionListOpt:**
-
-![CreateTableOptionListOpt](/media/sqlgram/CreateTableOptionListOpt.png)
-
-**PartitionOpt:**
-
-![PartitionOpt](/media/sqlgram/PartitionOpt.png)
-
-**DuplicateOpt:**
-
-![DuplicateOpt](/media/sqlgram/DuplicateOpt.png)
-
-**TableOptionList:**
-
-![TableOptionList](/media/sqlgram/TableOptionList.png)
-
-**TableOption:**
-
-![TableOption](/media/sqlgram/TableOption.png)
+TableOption ::=
+    PartDefOption
+|   DefaultKwdOpt ( CharsetKw EqOpt CharsetName | 'COLLATE' EqOpt CollationName )
+|   ( 'AUTO_INCREMENT' | 'AUTO_ID_CACHE' | 'AUTO_RANDOM_BASE' | 'AVG_ROW_LENGTH' | 'CHECKSUM' | 'TABLE_CHECKSUM' | 'KEY_BLOCK_SIZE' | 'DELAY_KEY_WRITE' | 'SHARD_ROW_ID_BITS' | 'PRE_SPLIT_REGIONS' ) EqOpt LengthNum
+|   ( 'CONNECTION' | 'PASSWORD' | 'COMPRESSION' ) EqOpt stringLit
+|   RowFormat
+|   ( 'STATS_PERSISTENT' | 'PACK_KEYS' ) EqOpt StatsPersistentVal
+|   ( 'STATS_AUTO_RECALC' | 'STATS_SAMPLE_PAGES' ) EqOpt ( LengthNum | 'DEFAULT' )
+|   'STORAGE' ( 'MEMORY' | 'DISK' )
+|   'SECONDARY_ENGINE' EqOpt ( 'NULL' | StringName )
+|   'UNION' EqOpt '(' TableNameListOpt ')'
+|   'ENCRYPTION' EqOpt EncryptionOpt
+```
 
 The following *table_options* are supported. Other options such as `AVG_ROW_LENGTH`, `CHECKSUM`, `COMPRESSION`, `CONNECTION`, `DELAY_KEY_WRITE`, `ENGINE`, `KEY_BLOCK_SIZE`, `MAX_ROWS`, `MIN_ROWS`, `ROW_FORMAT` and `STATS_PERSISTENT` are parsed but ignored.
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -10,29 +10,26 @@ This statement creates a new user, specified with a password. In the MySQL privi
 
 ## Synopsis
 
-**CreateUserStmt:**
+```ebnf+diagram
+CreateUserStmt ::=
+    'CREATE' 'USER' IfNotExists UserSpecList RequireClauseOpt ConnectionOptions PasswordOrLockOptions
 
-![CreateUserStmt](/media/sqlgram/CreateUserStmt.png)
+IfNotExists ::=
+    ('IF' 'NOT' 'EXISTS')?
 
-**IfNotExists:**
+UserSpecList ::=
+    UserSpec ( ',' UserSpec )*
 
-![IfNotExists](/media/sqlgram/IfNotExists.png)
+UserSpec ::=
+    Username AuthOption
 
-**UserSpecList:**
+AuthOption ::=
+    ( 'IDENTIFIED' ( 'BY' ( AuthString | 'PASSWORD' HashString ) | 'WITH' StringName ( 'BY' AuthString | 'AS' HashString )? ) )?
 
-![UserSpecList](/media/sqlgram/UserSpecList.png)
-
-**UserSpec:**
-
-![UserSpec](/media/sqlgram/UserSpec.png)
-
-**AuthOption:**
-
-![AuthOption](/media/sqlgram/AuthOption.png)
-
-**StringName:**
-
-![StringName](/media/sqlgram/StringName.png)
+StringName ::=
+    stringLit
+|   Identifier
+```
 
 ## Examples
 
@@ -55,7 +52,7 @@ Create a user who is enforced to log in using TLS connection.
 ```sql
 CREATE USER 'newuser3'@'%' REQUIRE SSL IDENTIFIED BY 'newuserpassword';
 Query OK, 1 row affected (0.02 sec)
-``` 
+```
 
 Create a user who is required to use X.509 certificate at login.
 

--- a/sql-statements/sql-statement-create-view.md
+++ b/sql-statements/sql-statement-create-view.md
@@ -10,37 +10,30 @@ The `CREATE VIEW` statement saves a `SELECT` statement as a queryable object, si
 
 ## Synopsis
 
-**CreateViewStmt:**
+```ebnf+diagram
+CreateViewStmt ::=
+    'CREATE' OrReplace ViewAlgorithm ViewDefiner ViewSQLSecurity 'VIEW' ViewName ViewFieldList 'AS' CreateViewSelectOpt ViewCheckOption
 
-![CreateViewStmt](/media/sqlgram/CreateViewStmt.png)
+OrReplace ::=
+    ( 'OR' 'REPLACE' )?
 
-**OrReplace:**
+ViewAlgorithm ::=
+    ( 'ALGORITHM' '=' ( 'UNDEFINED' | 'MERGE' | 'TEMPTABLE' ) )?
 
-![OrReplace](/media/sqlgram/OrReplace.png)
+ViewDefiner ::=
+    ( 'DEFINER' '=' Username )?
 
-**ViewAlgorithm:**
+ViewSQLSecurity ::=
+    ( 'SQL' 'SECURITY' ( 'DEFINER' | 'INVOKER' ) )?
 
-![ViewAlgorithm](/media/sqlgram/ViewAlgorithm.png)
+ViewName ::= TableName
 
-**ViewDefiner:**
+ViewFieldList ::=
+    ( '(' Identifier ( ',' Identifier )* ')' )?
 
-![ViewDefiner](/media/sqlgram/ViewDefiner.png)
-
-**ViewSQLSecurity:**
-
-![ViewSQLSecurity](/media/sqlgram/ViewSQLSecurity.png)
-
-**ViewName:**
-
-![ViewName](/media/sqlgram/ViewName.png)
-
-**ViewFieldList:**
-
-![ViewFieldList](/media/sqlgram/ViewFieldList.png)
-
-**ViewCheckOption:**
-
-![ViewCheckOption](/media/sqlgram/ViewCheckOption.png)
+ViewCheckOption ::=
+    ( 'WITH' ( 'CASCADED' | 'LOCAL' ) 'CHECK' 'OPTION' )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-deallocate.md
+++ b/sql-statements/sql-statement-deallocate.md
@@ -10,17 +10,20 @@ The `DEALLOCATE` statement provides an SQL interface to server-side prepared sta
 
 ## Synopsis
 
-**DeallocateStmt:**
+```ebnf+diagram
+DeallocateStmt ::=
+    DeallocateSym 'PREPARE' Identifier
 
-![DeallocateStmt](/media/sqlgram/DeallocateStmt.png)
+DeallocateSym ::=
+    'DEALLOCATE'
+|   'DROP'
 
-**DeallocateSym:**
-
-![DeallocateSym](/media/sqlgram/DeallocateSym.png)
-
-**Identifier:**
-
-![Identifier](/media/sqlgram/Identifier.png)
+Identifier ::=
+    identifier
+|   UnReservedKeyword
+|   NotKeywordToken
+|   TiDBKeyword
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-delete.md
+++ b/sql-statements/sql-statement-delete.md
@@ -10,9 +10,10 @@ The `DELETE` statement removes rows from a specified table.
 
 ## Synopsis
 
-**DeleteFromStmt:**
-
-![DeleteFromStmt](/media/sqlgram/DeleteFromStmt.png)
+```ebnf+diagram
+DeleteFromStmt ::=
+    'DELETE' TableOptimizerHints PriorityOpt QuickOptional IgnoreOptional ( 'FROM' ( TableName TableAsNameOpt IndexHintListOpt WhereClauseOptional OrderByOptional LimitClause | TableAliasRefList 'USING' TableRefs WhereClauseOptional ) | TableAliasRefList 'FROM' TableRefs WhereClauseOptional )
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-do.md
+++ b/sql-statements/sql-statement-do.md
@@ -10,23 +10,23 @@ aliases: ['/docs/dev/sql-statements/sql-statement-do/','/docs/dev/reference/sql/
 
 > **Note:**
 >
-> `DO` only executes expressions. It cannot be used in all cases where `SELECT` can be used. For example, `DO id FROM t1` is invalid because it references a table. 
+> `DO` only executes expressions. It cannot be used in all cases where `SELECT` can be used. For example, `DO id FROM t1` is invalid because it references a table.
 
 In MySQL, a common use case is to execute stored procedure or trigger. Since TiDB does not provide stored procedure or trigger, this function has a limited use.
 
 ## Synopsis
 
-**DoStmt:**
+```ebnf+diagram
+DoStmt   ::= 'DO' ExpressionList
 
-![DoStmt](/media/sqlgram/DoStmt.png)
+ExpressionList ::=
+    Expression ( ',' Expression )*
 
-**ExpressionList:**
-
-![ExpressionList](/media/sqlgram/ExpressionList.png)
-
-**Expression:**
-
-![Expression](/media/sqlgram/Expression.png)
+Expression ::=
+    ( singleAtIdentifier assignmentEq | 'NOT' | Expression ( logOr | 'XOR' | logAnd ) ) Expression
+|   'MATCH' '(' ColumnNameList ')' 'AGAINST' '(' BitExpr FulltextSearchModifierOpt ')'
+|   PredicateExpr ( IsOrNotOp 'NULL' | CompareOp ( ( singleAtIdentifier assignmentEq )? PredicateExpr | AnyOrAll SubSelect ) )* ( IsOrNotOp ( trueKwd | falseKwd | 'UNKNOWN' ) )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-binding.md
+++ b/sql-statements/sql-statement-drop-binding.md
@@ -12,17 +12,16 @@ A `BINDING` can be on either a `GLOBAL` or `SESSION` basis. The default is `SESS
 
 ## Synopsis
 
-**DropBindingStmt:**
+```ebnf+diagram
+DropBindingStmt ::=
+    'DROP' GlobalScope 'BINDING' 'FOR' SelectStmt ( 'USING' SelectStmt )?
 
-![DropBindingStmt](/media/sqlgram/DropBindingStmt.png)
+GlobalScope ::=
+    ( 'GLOBAL' | 'SESSION' )?
 
-**GlobalScope:**
-
-![GlobalScope](/media/sqlgram/GlobalScope.png)
-
-**SelectStmt**
-
-![SelectStmt](/media/sqlgram/SelectStmt.png)
+SelectStmt ::=
+    ( SelectStmtBasic | SelectStmtFromDualTable | SelectStmtFromTable ) OrderByOptional SelectStmtLimit SelectLockOpt SelectStmtIntoOption
+```
 
 ## Syntax description
 

--- a/sql-statements/sql-statement-drop-column.md
+++ b/sql-statements/sql-statement-drop-column.md
@@ -10,17 +10,36 @@ This statement drops a column from a specified table. `DROP COLUMN` is online in
 
 ## Synopsis
 
-**AlterTableStmt:**
+```ebnf+diagram
+AlterTableStmt ::=
+    'ALTER' IgnoreOptional 'TABLE' TableName ( AlterTableSpecListOpt AlterTablePartitionOpt | 'ANALYZE' 'PARTITION' PartitionNameList ( 'INDEX' IndexNameList )? AnalyzeOptionListOpt )
 
-![AlterTableStmt](/media/sqlgram/AlterTableStmt.png)
+AlterTableSpec ::=
+    TableOptionList
+|   'SET' 'TIFLASH' 'REPLICA' LengthNum LocationLabelList
+|   'CONVERT' 'TO' CharsetKw ( CharsetName | 'DEFAULT' ) OptCollate
+|   'ADD' ( ColumnKeywordOpt IfNotExists ( ColumnDef ColumnPosition | '(' TableElementList ')' ) | Constraint | 'PARTITION' IfNotExists NoWriteToBinLogAliasOpt ( PartitionDefinitionListOpt | 'PARTITIONS' NUM ) )
+|   ( ( 'CHECK' | 'TRUNCATE' ) 'PARTITION' | ( 'OPTIMIZE' | 'REPAIR' | 'REBUILD' ) 'PARTITION' NoWriteToBinLogAliasOpt ) AllOrPartitionNameList
+|   'COALESCE' 'PARTITION' NoWriteToBinLogAliasOpt NUM
+|   'DROP' ( ColumnKeywordOpt IfExists ColumnName RestrictOrCascadeOpt | 'PRIMARY' 'KEY' |  'PARTITION' IfExists PartitionNameList | ( KeyOrIndex IfExists | 'CHECK' ) Identifier | 'FOREIGN' 'KEY' IfExists Symbol )
+|   'EXCHANGE' 'PARTITION' Identifier 'WITH' 'TABLE' TableName WithValidationOpt
+|   ( 'IMPORT' | 'DISCARD' ) ( 'PARTITION' AllOrPartitionNameList )? 'TABLESPACE'
+|   'REORGANIZE' 'PARTITION' NoWriteToBinLogAliasOpt ReorganizePartitionRuleOpt
+|   'ORDER' 'BY' AlterOrderItem ( ',' AlterOrderItem )*
+|   ( 'DISABLE' | 'ENABLE' ) 'KEYS'
+|   ( 'MODIFY' ColumnKeywordOpt IfExists | 'CHANGE' ColumnKeywordOpt IfExists ColumnName ) ColumnDef ColumnPosition
+|   'ALTER' ( ColumnKeywordOpt ColumnName ( 'SET' 'DEFAULT' ( SignedLiteral | '(' Expression ')' ) | 'DROP' 'DEFAULT' ) | 'CHECK' Identifier EnforcedOrNot | 'INDEX' Identifier IndexInvisible )
+|   'RENAME' ( ( 'COLUMN' | KeyOrIndex ) Identifier 'TO' Identifier | ( 'TO' | '='? | 'AS' ) TableName )
+|   LockClause
+|   AlgorithmClause
+|   'FORCE'
+|   ( 'WITH' | 'WITHOUT' ) 'VALIDATION'
+|   'SECONDARY_LOAD'
+|   'SECONDARY_UNLOAD'
 
-**AlterTableSpec:**
-
-![AlterTableSpec](/media/sqlgram/AlterTableSpec.png)
-
-**ColumnName:**
-
-![ColumnName](/media/sqlgram/ColumnName.png)
+ColumnName ::=
+    Identifier ( '.' Identifier ( '.' Identifier )? )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-database.md
+++ b/sql-statements/sql-statement-drop-database.md
@@ -10,13 +10,12 @@ The `DROP DATABASE` statement permanently removes a specified database schema, a
 
 ## Synopsis
 
-**DropDatabaseStmt:**
+```ebnf+diagram
+DropDatabaseStmt ::=
+    'DROP' 'DATABASE' IfExists DBName
 
-![DropDatabaseStmt](/media/sqlgram/DropDatabaseStmt.png)
-
-**IfExists:**
-
-![IfExists](/media/sqlgram/IfExists.png)
+IfExists ::= ( 'IF' 'EXISTS' )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-index.md
+++ b/sql-statements/sql-statement-drop-index.md
@@ -10,29 +10,25 @@ This statement removes an index from a specified table, marking space as free in
 
 ## Synopsis
 
-**AlterTableDropIndexStmt:**
+```ebnf+diagram
+AlterTableDropIndexStmt ::=
+    'ALTER' IgnoreOptional 'TABLE' AlterTableDropIndexSpec
 
-![AlterTableDropIndexStmt](/media/sqlgram/AlterTableDropIndexStmt.png)
+IgnoreOptional ::=
+    'IGNORE'?
 
-**IgnoreOptional:**
+TableName ::=
+    Identifier ('.' Identifier)?
 
-![IgnoreOptional](/media/sqlgram/IgnoreOptional.png)
+AlterTableDropIndexSpec ::=
+    'DROP' ( KeyOrIndex | 'FOREIGN' 'KEY' ) IfExists Identifier
 
-**TableName:**
+KeyOrIndex ::=
+    'KEY'
+|   'INDEX'
 
-![TableName](/media/sqlgram/TableName.png)
-
-**AlterTableDropIndexSpec:**
-
-![AlterTableDropIndexSpec](/media/sqlgram/AlterTableDropIndexSpec.png)
-
-**KeyOrIndex:**
-
-![KeyOrIndex](/media/sqlgram/KeyOrIndex.png)
-
-**IfExists:**
-
-![IfExists](/media/sqlgram/IfExists.png)
+IfExists ::= ( 'IF' 'EXISTS' )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-role.md
+++ b/sql-statements/sql-statement-drop-role.md
@@ -9,13 +9,13 @@ This statement removes a role, that was previously created with `CREATE ROLE`.
 
 ## Synopsis
 
-**DropRoleStmt:**
+```ebnf+diagram
+DropRoleStmt ::=
+    'DROP' 'ROLE' ( 'IF' 'EXISTS' )? RolenameList
 
-![DropRoleStmt](/media/sqlgram/DropRoleStmt.png)
-
-**RolenameList:**
-
-![RolenameList](/media/sqlgram/RolenameList.png)
+RolenameList ::=
+    Rolename ( ',' Rolename )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-sequence.md
+++ b/sql-statements/sql-statement-drop-sequence.md
@@ -10,21 +10,18 @@ The `DROP SEQUENCE` statement drops the sequence object in TiDB.
 
 ## Synopsis
 
-**DropSequenceStmt:**
+```ebnf+diagram
+DropSequenceStmt ::=
+    'DROP' 'SEQUENCE' IfExists TableNameList
 
-![DropSequenceStmt](/media/sqlgram/DropSequenceStmt.png)
+IfExists ::= ( 'IF' 'EXISTS' )?
 
-**IfExists:**
+TableNameList ::=
+    TableName ( ',' TableName )*
 
-![IfExists](/media/sqlgram/IfExists.png)
-
-**TableNameList:**
-
-![TableNameList](/media/sqlgram/TableNameList.png)
-
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
+TableName ::=
+    Identifier ('.' Identifier)?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-stats.md
+++ b/sql-statements/sql-statement-drop-stats.md
@@ -10,13 +10,13 @@ The `DROP STATS` statement is used to delete the statistics of the selected tabl
 
 ## Synopsis
 
-**DropStatsStmt:**
+```ebnf+diagram
+DropStatsStmt ::=
+    'DROP' 'STATS' TableName
 
-![DropTableStmt](/media/sqlgram/DropStatsStmt.png)
-
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
+TableName ::=
+    Identifier ('.' Identifier)?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -10,17 +10,17 @@ This statement drops a table from the currently selected database. An error is r
 
 ## Synopsis
 
-**DropTableStmt:**
+```ebnf+diagram
+DropTableStmt ::=
+    'DROP' OptTemporary TableOrTables IfExists TableNameList RestrictOrCascadeOpt
 
-![DropTableStmt](/media/sqlgram/DropTableStmt.png)
+TableOrTables ::=
+    'TABLE'
+|   'TABLES'
 
-**TableOrTables:**
-
-![TableOrTables](/media/sqlgram/TableOrTables.png)
-
-**TableNameList:**
-
-![TableNameList](/media/sqlgram/TableNameList.png)
+TableNameList ::=
+    TableName ( ',' TableName )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-user.md
+++ b/sql-statements/sql-statement-drop-user.md
@@ -10,13 +10,13 @@ This statement removes a user from the TiDB system database. The optional keywor
 
 ## Synopsis
 
-**DropUserStmt:**
+```ebnf+diagram
+DropUserStmt ::=
+    'DROP' 'USER' ( 'IF' 'EXISTS' )? UsernameList
 
-![DropUserStmt](/media/sqlgram/DropUserStmt.png)
-
-**Username:**
-
-![Username](/media/sqlgram/Username.png)
+Username ::=
+    StringName ('@' StringName | singleAtIdentifier)? | 'CURRENT_USER' OptionalBraces
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-drop-view.md
+++ b/sql-statements/sql-statement-drop-view.md
@@ -10,17 +10,16 @@ This statement drops an view object from the currently selected database. It doe
 
 ## Synopsis
 
-**DropViewStmt:**
+```ebnf+diagram
+DropViewStmt ::=
+    'DROP' 'VIEW' ( 'IF' 'EXISTS' )? TableNameList RestrictOrCascadeOpt
 
-![DropViewStmt](/media/sqlgram/DropViewStmt.png)
+TableNameList ::=
+    TableName ( ',' TableName )*
 
-**TableNameList:**
-
-![TableNameList](/media/sqlgram/TableNameList.png)
-
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
+TableName ::=
+    Identifier ('.' Identifier)?
+```
 
 ## Examples
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR changes the synopsis sections of BEGIN, CHANGE, COMMIT, CREATE, DEALLOCATE, DELETE, DO, and DROP statements to use the ` ```ebnf+diagrm ` block, replacing the original image-based sqlgrams. It is a follow-up PR to https://github.com/pingcap/docs/issues/4389. 

To avoid making one single PR too large, I will open 4-5 follow-up PRs to process sql-statements files in batches. And I will delete all image files in the last PR in case of any display issues.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5376
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [x] Might cause conflicts after applied to another branch
