### PR TITLE
sql-statements: use EBNF to render syntax diagrams - third batch

### DIFF
--- a/sql-statements/sql-statement-execute.md
+++ b/sql-statements/sql-statement-execute.md
@@ -10,9 +10,10 @@ The `EXECUTE` statement provides an SQL interface to server-side prepared statem
 
 ## Synopsis
 
-**ExecuteStmt:**
-
-![ExecuteStmt](/media/sqlgram/ExecuteStmt.png)
+```ebnf+diagram
+ExecuteStmt ::=
+    'EXECUTE' Identifier ( 'USING' UserVariable ( ',' UserVariable )* )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-explain-analyze.md
+++ b/sql-statements/sql-statement-explain-analyze.md
@@ -14,17 +14,23 @@ The `EXPLAIN ANALYZE` statement works similar to `EXPLAIN`, with the major diffe
 
 ## Synopsis
 
-**ExplainSym:**
+```ebnf+diagram
+ExplainSym ::=
+    'EXPLAIN'
+|   'DESCRIBE'
+|    'DESC'
 
-![ExplainSym](/media/sqlgram/ExplainSym.png)
+ExplainStmt ::=
+    ExplainSym ( TableName ColumnName? | 'ANALYZE'? ExplainableStmt | 'FOR' 'CONNECTION' NUM | 'FORMAT' '=' ( stringLit | ExplainFormatType ) ( 'FOR' 'CONNECTION' NUM | ExplainableStmt ) )
 
-**ExplainStmt:**
-
-![ExplainStmt](/media/sqlgram/ExplainStmt.png)
-
-**ExplainableStmt:**
-
-![ExplainableStmt](/media/sqlgram/ExplainableStmt.png)
+ExplainableStmt ::=
+    SelectStmt
+|   DeleteFromStmt
+|   UpdateStmt
+|   InsertIntoStmt
+|   ReplaceIntoStmt
+|   UnionStmt
+```
 
 ## EXPLAIN ANALYZE output format
 

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -14,17 +14,23 @@ TiDB supports the `EXPLAIN [options] FOR CONNECTION connection_id` statement. Ho
 
 ## Synopsis
 
-**ExplainSym:**
+```ebnf+diagram
+ExplainSym ::=
+    'EXPLAIN'
+|   'DESCRIBE'
+|   'DESC'
 
-![ExplainSym](/media/sqlgram/ExplainSym.png)
+ExplainStmt ::=
+    ExplainSym ( TableName ColumnName? | 'ANALYZE'? ExplainableStmt | 'FOR' 'CONNECTION' NUM | 'FORMAT' '=' ( stringLit | ExplainFormatType ) ( 'FOR' 'CONNECTION' NUM | ExplainableStmt ) )
 
-**ExplainStmt:**
-
-![ExplainStmt](/media/sqlgram/ExplainStmt.png)
-
-**ExplainableStmt:**
-
-![ExplainableStmt](/media/sqlgram/ExplainableStmt.png)
+ExplainableStmt ::=
+    SelectStmt
+|   DeleteFromStmt
+|   UpdateStmt
+|   InsertIntoStmt
+|   ReplaceIntoStmt
+|   UnionStmt
+```
 
 ## `EXPLAIN` output format
 

--- a/sql-statements/sql-statement-flashback-table.md
+++ b/sql-statements/sql-statement-flashback-table.md
@@ -28,17 +28,16 @@ FLASHBACK TABLE table_name [TO other_table_name]
 
 ## Synopsis
 
-**FlashbackTableStmt:**
+```ebnf+diagram
+FlashbackTableStmt ::=
+    'FLASHBACK' 'TABLE' TableName FlashbackToNewName
 
-![FlashbackTableStmt](/media/sqlgram/FlashbackTableStmt.png)
+TableName ::=
+    Identifier ( '.' Identifier )?
 
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
-
-**FlashbackToNewName:**
-
-![FlashbackToNewName](/media/sqlgram/FlashbackToNewName.png)
+FlashbackToNewName ::=
+    ( 'TO' Identifier )?
+```
 
 ## Notes
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -10,17 +10,21 @@ This statement triggers TiDB to reload the in-memory copy of privileges from the
 
 ## Synopsis
 
-**FlushStmt:**
+```ebnf+diagram
+FlushStmt ::=
+    'FLUSH' NoWriteToBinLogAliasOpt FlushOption
 
-![FlushStmt](/media/sqlgram/FlushStmt.png)
+NoWriteToBinLogAliasOpt ::=
+    ( 'NO_WRITE_TO_BINLOG' | 'LOCAL' )?
 
-**NoWriteToBinLogAliasOpt:**
-
-![NoWriteToBinLogAliasOpt](/media/sqlgram/NoWriteToBinLogAliasOpt.png)
-
-**FlushOption:**
-
-![FlushOption](/media/sqlgram/FlushOption.png)
+FlushOption ::=
+    'PRIVILEGES'
+|   'STATUS'
+|    'TIDB' 'PLUGINS' PluginNameList
+|    'HOSTS'
+|   LogTypeOpt 'LOGS'
+|   TableOrTables TableNameListOpt WithReadLockOpt
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-flush-status.md
+++ b/sql-statements/sql-statement-flush-status.md
@@ -10,17 +10,21 @@ This statement is included for compatibility with MySQL. It has no effect on TiD
 
 ## Synopsis
 
-**FlushStmt:**
+```ebnf+diagram
+FlushStmt ::=
+    'FLUSH' NoWriteToBinLogAliasOpt FlushOption
 
-![FlushStmt](/media/sqlgram/FlushStmt.png)
+NoWriteToBinLogAliasOpt ::=
+    ( 'NO_WRITE_TO_BINLOG' | 'LOCAL' )?
 
-**NoWriteToBinLogAliasOpt:**
-
-![NoWriteToBinLogAliasOpt](/media/sqlgram/NoWriteToBinLogAliasOpt.png)
-
-**FlushOption:**
-
-![FlushOption](/media/sqlgram/FlushOption.png)
+FlushOption ::=
+    'PRIVILEGES'
+|   'STATUS'
+|    'TIDB' 'PLUGINS' PluginNameList
+|    'HOSTS'
+|   LogTypeOpt 'LOGS'
+|   TableOrTables TableNameListOpt WithReadLockOpt
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-flush-tables.md
+++ b/sql-statements/sql-statement-flush-tables.md
@@ -10,33 +10,34 @@ This statement is included for compatibility with MySQL. It has no effective usa
 
 ## Synopsis
 
-**FlushStmt:**
+```ebnf+diagram
+FlushStmt ::=
+    'FLUSH' NoWriteToBinLogAliasOpt FlushOption
 
-![FlushStmt](/media/sqlgram/FlushStmt.png)
+NoWriteToBinLogAliasOpt ::=
+    ( 'NO_WRITE_TO_BINLOG' | 'LOCAL' )?
 
-**NoWriteToBinLogAliasOpt:**
+FlushOption ::=
+    'PRIVILEGES'
+|   'STATUS'
+|    'TIDB' 'PLUGINS' PluginNameList
+|    'HOSTS'
+|    LogTypeOpt 'LOGS'
+|    TableOrTables TableNameListOpt WithReadLockOpt
 
-![NoWriteToBinLogAliasOpt](/media/sqlgram/NoWriteToBinLogAliasOpt.png)
+LogTypeOpt ::=
+    ( 'BINARY' | 'ENGINE' | 'ERROR' | 'GENERAL' | 'SLOW' )?
 
-**FlushOption:**
+TableOrTables ::=
+    'TABLE'
+|   'TABLES'
 
-![FlushOption](/media/sqlgram/FlushOption.png)
+TableNameListOpt ::=
+    TableNameList?
 
-**LogTypeOpt:**
-
-![LogTypeOpt](/media/sqlgram/LogTypeOpt.png)
-
-**TableOrTables:**
-
-![TableOrTables](/media/sqlgram/TableOrTables.png)
-
-**TableNameListOpt:**
-
-![TableNameListOpt](/media/sqlgram/TableNameListOpt.png)
-
-**WithReadLockOpt:**
-
-![WithReadLockOpt](/media/sqlgram/WithReadLockOpt.png)
+WithReadLockOpt ::=
+    ( 'WITH' 'READ' 'LOCK' )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -10,33 +10,52 @@ This statement allocates privileges to a pre-existing user in TiDB. The privileg
 
 ## Synopsis
 
-**GrantStmt:**
+```ebnf+diagram
+GrantStmt ::=
+    'GRANT' PrivElemList 'ON' ObjectType PrivLevel 'TO' UserSpecList RequireClauseOpt WithGrantOptionOpt
 
-![GrantStmt](/media/sqlgram/GrantStmt.png)
+PrivElemList ::=
+    PrivElem ( ',' PrivElem )*
 
-**PrivElemList:**
+PrivElem ::=
+    PrivType ( '(' ColumnNameList ')' )?
 
-![PrivElemList](/media/sqlgram/PrivElemList.png)
+PrivType ::=
+    'ALL' 'PRIVILEGES'?
+|    'ALTER' 'ROUTINE'?
+|   'CREATE' ( 'USER' | 'TEMPORARY' 'TABLES' | 'VIEW' | 'ROLE' | 'ROUTINE' )?
+|   'TRIGGER'
+|   'DELETE'
+|   'DROP' 'ROLE'?
+|    'PROCESS'
+|   'EXECUTE'
+|   'INDEX'
+|   'INSERT'
+|   'SELECT'
+|   'SUPER'
+|   'SHOW' ( 'DATABASES' | 'VIEW' )
+|   'UPDATE'
+|    'GRANT' 'OPTION'
+|    'REFERENCES'
+|    'REPLICATION' ( 'SLAVE' | 'CLIENT' )
+|    'USAGE'
+|   'RELOAD'
+|   'FILE'
+|   'CONFIG'
+|   'LOCK' 'TABLES'
+|   'EVENT'
+|   'SHUTDOWN'
 
-**PrivElem:**
+ObjectType ::=
+    'TABLE'?
 
-![PrivElem](/media/sqlgram/PrivElem.png)
+PrivLevel ::=
+    '*' ( '.' '*' )?
+|    Identifier ( '.' ( '*' | Identifier ) )?
 
-**PrivType:**
-
-![PrivType](/media/sqlgram/PrivType.png)
-
-**ObjectType:**
-
-![ObjectType](/media/sqlgram/ObjectType.png)
-
-**PrivLevel:**
-
-![PrivLevel](/media/sqlgram/PrivLevel.png)
-
-**UserSpecList:**
-
-![UserSpecList](/media/sqlgram/UserSpecList.png)
+UserSpecList ::=
+    UserSpec ( ',' UserSpec )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-grant-role.md
+++ b/sql-statements/sql-statement-grant-role.md
@@ -9,17 +9,16 @@ Assigns a previously created role to an existing user. The user can use then use
 
 ## Synopsis
 
-**GrantRoleStmt:**
+```ebnf+diagram
+GrantRoleStmt ::=
+    'GRANT' RolenameList 'TO' UsernameList
 
-![GrantRoleStmt](/media/sqlgram/GrantRoleStmt.png)
+RolenameList ::=
+    Rolename ( ',' Rolename )*
 
-**RolenameList:**
-
-![RolenameList](/media/sqlgram/RolenameList.png)
-
-**UsernameList:**
-
-![UsernameList](/media/sqlgram/UsernameList.png)
+UsernameList ::=
+    Username ( ',' Username )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-insert.md
+++ b/sql-statements/sql-statement-insert.md
@@ -10,41 +10,37 @@ This statement inserts new rows into a table.
 
 ## Synopsis
 
-**InsertIntoStmt:**
+```ebnf+diagram
+InsertIntoStmt ::=
+    'INSERT' TableOptimizerHints PriorityOpt IgnoreOptional IntoOpt TableName PartitionNameListOpt InsertValues OnDuplicateKeyUpdate
 
-![InsertIntoStmt](/media/sqlgram/InsertIntoStmt.png)
+TableOptimizerHints ::=
+    hintComment?
 
-**TableOptimizerHints**
+PriorityOpt ::=
+    ( 'LOW_PRIORITY' | 'HIGH_PRIORITY' | 'DELAYED' )?
 
-![TableOptimizerHints](/media/sqlgram/TableOptimizerHints.png)
+IgnoreOptional ::=
+    'IGNORE'?
 
-**PriorityOpt:**
+IntoOpt  ::= 'INTO'?
 
-![PriorityOpt](/media/sqlgram/PriorityOpt.png)
+TableName ::=
+    Identifier ( '.' Identifier )?
 
-**IgnoreOptional:**
+PartitionNameListOpt ::=
+    ( 'PARTITION' '(' Identifier ( ',' Identifier )* ')' )?
 
-![IgnoreOptional](/media/sqlgram/IgnoreOptional.png)
+InsertValues ::=
+    '(' ( ColumnNameListOpt ')' ( ValueSym ValuesList | SelectStmt | '(' SelectStmt ')' | UnionStmt ) | SelectStmt ')' )
+|   ValueSym ValuesList
+|   SelectStmt
+|   UnionStmt
+|   'SET' ColumnSetValue? ( ',' ColumnSetValue )*
 
-**IntoOpt:**
-
-![IntoOpt](/media/sqlgram/IntoOpt.png)
-
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
-
-**PartitionNameListOpt:**
-
-![PartitionNameListOpt](/media/sqlgram/PartitionNameListOpt.png)
-
-**InsertValues:**
-
-![InsertValues](/media/sqlgram/InsertValues.png)
-
-**OnDuplicateKeyUpdate:**
-
-![OnDuplicateKeyUpdate](/media/sqlgram/OnDuplicateKeyUpdate.png)
+OnDuplicateKeyUpdate ::=
+    ( 'ON' 'DUPLICATE' 'KEY' 'UPDATE' AssignmentList )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-kill.md
+++ b/sql-statements/sql-statement-kill.md
@@ -10,13 +10,11 @@ The statement `KILL TIDB` is used to terminate connections in TiDB.
 
 ## Synopsis
 
-**KillStmt:**
+```ebnf+diagram
+KillStmt ::= KillOrKillTiDB ( 'CONNECTION' | 'QUERY' )? NUM
 
-![KillStmt](/media/sqlgram/KillStmt.png)
-
-**KillOrKillTiDB:**
-
-![KillOrKillTiDB](/media/sqlgram/KillOrKillTiDB.png)
+KillOrKillTiDB ::= 'KILL' 'TIDB'?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-load-data.md
+++ b/sql-statements/sql-statement-load-data.md
@@ -10,9 +10,10 @@ The `LOAD DATA` statement batch loads data into a TiDB table.
 
 ## Synopsis
 
-**LoadDataStmt:**
-
-![LoadDataStmt](/media/sqlgram/LoadDataStmt.png)
+```ebnf+diagram
+LoadDataStmt ::=
+    'LOAD' 'DATA' LocalOpt 'INFILE' stringLit DuplicateOpt 'INTO' 'TABLE' TableName CharsetOpt Fields Lines IgnoreLines ColumnNameOrUserVarListOptWithBrackets LoadDataSetSpecOpt
+```
 
 ## Parameters
 

--- a/sql-statements/sql-statement-load-stats.md
+++ b/sql-statements/sql-statement-load-stats.md
@@ -10,9 +10,10 @@ The `LOAD STATS` statement is used to load the statistics into TiDB.
 
 ## Synopsis
 
-**LoadStatsStmt:**
-
-![LoadStatsStmt](/media/sqlgram/LoadStatsStmt.png)
+```ebnf+diagram
+LoadStatsStmt ::=
+    'LOAD' 'STATS' stringLit
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-modify-column.md
+++ b/sql-statements/sql-statement-modify-column.md
@@ -10,25 +10,41 @@ The `ALTER TABLE.. MODIFY COLUMN` statement modifies a column on an existing tab
 
 ## Synopsis
 
-**AlterTableStmt:**
+```ebnf+diagram
+AlterTableStmt ::=
+    'ALTER' IgnoreOptional 'TABLE' TableName ( AlterTableSpecListOpt AlterTablePartitionOpt | 'ANALYZE' 'PARTITION' PartitionNameList ( 'INDEX' IndexNameList )? AnalyzeOptionListOpt )
 
-![AlterTableStmt](/media/sqlgram/AlterTableStmt.png)
+AlterTableSpec ::=
+    TableOptionList
+|   'SET' 'TIFLASH' 'REPLICA' LengthNum LocationLabelList
+|   'CONVERT' 'TO' CharsetKw ( CharsetName | 'DEFAULT' ) OptCollate
+|   'ADD' ( ColumnKeywordOpt IfNotExists ( ColumnDef ColumnPosition | '(' TableElementList ')' ) | Constraint | 'PARTITION' IfNotExists NoWriteToBinLogAliasOpt ( PartitionDefinitionListOpt | 'PARTITIONS' NUM ) )
+|   ( ( 'CHECK' | 'TRUNCATE' ) 'PARTITION' | ( 'OPTIMIZE' | 'REPAIR' | 'REBUILD' ) 'PARTITION' NoWriteToBinLogAliasOpt ) AllOrPartitionNameList
+|   'COALESCE' 'PARTITION' NoWriteToBinLogAliasOpt NUM
+|   'DROP' ( ColumnKeywordOpt IfExists ColumnName RestrictOrCascadeOpt | 'PRIMARY' 'KEY' | 'PARTITION' IfExists PartitionNameList | ( KeyOrIndex IfExists | 'CHECK' ) Identifier | 'FOREIGN' 'KEY' IfExists Symbol )
+|   'EXCHANGE' 'PARTITION' Identifier 'WITH' 'TABLE' TableName WithValidationOpt
+|   ( 'IMPORT' | 'DISCARD' ) ( 'PARTITION' AllOrPartitionNameList )? 'TABLESPACE'
+|   'REORGANIZE' 'PARTITION' NoWriteToBinLogAliasOpt ReorganizePartitionRuleOpt
+|   'ORDER' 'BY' AlterOrderItem ( ',' AlterOrderItem )*
+|   ( 'DISABLE' | 'ENABLE' ) 'KEYS'
+|   ( 'MODIFY' ColumnKeywordOpt IfExists | 'CHANGE' ColumnKeywordOpt IfExists ColumnName ) ColumnDef ColumnPosition
+|   'ALTER' ( ColumnKeywordOpt ColumnName ( 'SET' 'DEFAULT' ( SignedLiteral | '(' Expression ')' ) | 'DROP' 'DEFAULT' ) | 'CHECK' Identifier EnforcedOrNot | 'INDEX' Identifier IndexInvisible )
+|   'RENAME' ( ( 'COLUMN' | KeyOrIndex ) Identifier 'TO' Identifier | ( 'TO' | '='? | 'AS' ) TableName )
+|   LockClause
+|   AlgorithmClause
+|   'FORCE'
+|   ( 'WITH' | 'WITHOUT' ) 'VALIDATION'
+|   'SECONDARY_LOAD'
+|   'SECONDARY_UNLOAD'
 
-**AlterTableSpec:**
+ColumnKeywordOpt ::= 'COLUMN'?
 
-![AlterTableSpec](/media/sqlgram/AlterTableSpec.png)
+ColumnDef ::=
+    ColumnName ( Type | 'SERIAL' ) ColumnOptionListOpt
 
-**ColumnKeywordOpt:**
-
-![ColumnKeywordOpt](/media/sqlgram/ColumnKeywordOpt.png)
-
-**ColumnDef:**
-
-![ColumnDef](/media/sqlgram/ColumnDef.png)
-
-**ColumnPosition:**
-
-![ColumnPosition](/media/sqlgram/ColumnPosition.png)
+ColumnPosition ::=
+    ( 'FIRST' | 'AFTER' ColumnName )?
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-prepare.md
+++ b/sql-statements/sql-statement-prepare.md
@@ -10,13 +10,14 @@ The `PREPARE` statement provides an SQL interface to server-side prepared statem
 
 ## Synopsis
 
-**PreparedStmt:**
+```ebnf+diagram
+PreparedStmt ::=
+    'PREPARE' Identifier 'FROM' PrepareSQL
 
-![PreparedStmt](/media/sqlgram/PreparedStmt.png)
-
-**PrepareSQL:**
-
-![PrepareSQL](/media/sqlgram/PrepareSQL.png)
+PrepareSQL ::=
+    stringLit
+|   UserVariable
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-recover-table.md
+++ b/sql-statements/sql-statement-recover-table.md
@@ -24,21 +24,17 @@ RECOVER TABLE BY JOB ddl_job_id
 
 ## Synopsis
 
-**RecoverTableStmt:**
+```ebnf+diagram
+RecoverTableStmt ::=
+    'RECOVER' 'TABLE' ( 'BY' 'JOB' Int64Num | TableName Int64Num? )
 
-![RecoverTableStmt](/media/sqlgram/RecoverTableStmt.png)
+TableName ::=
+    Identifier ( '.' Identifier )?
 
-**TableName:**
+Int64Num ::= NUM
 
-![TableName](/media/sqlgram/TableName.png)
-
-**Int64Num:**
-
-![Int64Num](/media/sqlgram/Int64Num.png)
-
-**NUM:**
-
-![NUM](/media/sqlgram/NUM.png)
+NUM ::= intLit
+```
 
 > **Note:**
 >

--- a/sql-statements/sql-statement-rename-index.md
+++ b/sql-statements/sql-statement-rename-index.md
@@ -10,13 +10,14 @@ The statement `ALTER TABLE .. RENAME INDEX` renames an existing index to a new n
 
 ## Synopsis
 
-**AlterTableStmt:**
+```ebnf+diagram
+AlterTableStmt ::=
+    'ALTER' IgnoreOptional 'TABLE' TableName ( AlterTableSpecListOpt AlterTablePartitionOpt | 'ANALYZE' 'PARTITION' PartitionNameList ( 'INDEX' IndexNameList )? AnalyzeOptionListOpt )
 
-![AlterTableStmt](/media/sqlgram/AlterTableStmt.png)
-
-**KeyOrIndex:**
-
-![KeyOrIndex](/media/sqlgram/KeyOrIndex.png)
+KeyOrIndex ::=
+    'KEY'
+|   'INDEX'
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-rename-table.md
+++ b/sql-statements/sql-statement-rename-table.md
@@ -10,13 +10,13 @@ This statement renames an existing table to a new name.
 
 ## Synopsis
 
-**RenameTableStmt:**
+```ebnf+diagram
+RenameTableStmt ::=
+    'RENAME' 'TABLE' TableToTable ( ',' TableToTable )*
 
-![RenameTableStmt](/media/sqlgram/RenameTableStmt.png)
-
-**TableToTable:**
-
-![TableToTable](/media/sqlgram/TableToTable.png)
+TableToTable ::=
+    TableName 'TO' TableName
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-replace.md
+++ b/sql-statements/sql-statement-replace.md
@@ -10,29 +10,28 @@ The `REPLACE` statement is semantically a combined `DELETE`+`INSERT` statement. 
 
 ## Synopsis
 
-**ReplaceIntoStmt:**
+```ebnf+diagram
+ReplaceIntoStmt ::=
+    'REPLACE' PriorityOpt IntoOpt TableName PartitionNameListOpt InsertValues
 
-![ReplaceIntoStmt](/media/sqlgram/ReplaceIntoStmt.png)
+PriorityOpt ::=
+    ( 'LOW_PRIORITY' | 'HIGH_PRIORITY' | 'DELAYED' )?
 
-**PriorityOpt:**
+IntoOpt ::= 'INTO'?
 
-![PriorityOpt](/media/sqlgram/PriorityOpt.png)
+TableName ::=
+    Identifier ( '.' Identifier )?
 
-**IntoOpt:**
+PartitionNameListOpt ::=
+    ( 'PARTITION' '(' Identifier ( ',' Identifier )* ')' )?
 
-![IntoOpt](/media/sqlgram/IntoOpt.png)
-
-**TableName:**
-
-![TableName](/media/sqlgram/TableName.png)
-
-**PartitionNameListOpt:**
-
-![PartitionNameListOpt](/media/sqlgram/PartitionNameListOpt.png)
-
-**InsertValues:**
-
-![InsertValues](/media/sqlgram/InsertValues.png)
+InsertValues ::=
+    '(' ( ColumnNameListOpt ')' ( ValueSym ValuesList | SelectStmt | '(' SelectStmt ')' | UnionStmt ) | SelectStmt ')' )
+|   ValueSym ValuesList
+|   SelectStmt
+|   UnionStmt
+|   'SET' ColumnSetValue? ( ',' ColumnSetValue )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -10,33 +10,52 @@ This statement removes privileges from an existing user. Executing this statemen
 
 ## Synopsis
 
-**GrantStmt:**
+```ebnf+diagram
+GrantStmt ::=
+    'GRANT' PrivElemList 'ON' ObjectType PrivLevel 'TO' UserSpecList RequireClauseOpt WithGrantOptionOpt
 
-![GrantStmt](/media/sqlgram/GrantStmt.png)
+PrivElemList ::=
+    PrivElem ( ',' PrivElem )*
 
-**PrivElemList:**
+PrivElem ::=
+    PrivType ( '(' ColumnNameList ')' )?
 
-![PrivElemList](/media/sqlgram/PrivElemList.png)
+PrivType ::=
+    'ALL' 'PRIVILEGES'?
+|   'ALTER' 'ROUTINE'?
+|   'CREATE' ( 'USER' | 'TEMPORARY' 'TABLES' | 'VIEW' | 'ROLE' | 'ROUTINE' )?
+|    'TRIGGER'
+|   'DELETE'
+|    'DROP' 'ROLE'?
+|    'PROCESS'
+|    'EXECUTE'
+|   'INDEX'
+|   'INSERT'
+|   'SELECT'
+|   'SUPER'
+|    'SHOW' ( 'DATABASES' | 'VIEW' )
+|   'UPDATE'
+|   'GRANT' 'OPTION'
+|   'REFERENCES'
+|   'REPLICATION' ( 'SLAVE' | 'CLIENT' )
+|   'USAGE'
+|    'RELOAD'
+|   'FILE'
+|   'CONFIG'
+|   'LOCK' 'TABLES'
+|    'EVENT'
+|   'SHUTDOWN'
 
-**PrivElem:**
+ObjectType ::=
+    'TABLE'?
 
-![PrivElem](/media/sqlgram/PrivElem.png)
+PrivLevel ::=
+    '*' ( '.' '*' )?
+|    Identifier ( '.' ( '*' | Identifier ) )?
 
-**PrivType:**
-
-![PrivType](/media/sqlgram/PrivType.png)
-
-**ObjectType:**
-
-![ObjectType](/media/sqlgram/ObjectType.png)
-
-**PrivLevel:**
-
-![PrivLevel](/media/sqlgram/PrivLevel.png)
-
-**UserSpecList:**
-
-![UserSpecList](/media/sqlgram/UserSpecList.png)
+UserSpecList ::=
+    UserSpec ( ',' UserSpec )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-revoke-role.md
+++ b/sql-statements/sql-statement-revoke-role.md
@@ -9,17 +9,16 @@ This statement removes a previously assigned role from a specified user (or list
 
 ## Synopsis
 
-**RevokeRoleStmt:**
+```ebnf+diagram
+RevokeRoleStmt ::=
+    'REVOKE' RolenameList 'FROM' UsernameList
 
-![RevokeRoleStmt](/media/sqlgram/RevokeRoleStmt.png)
+RolenameList ::=
+    Rolename ( ',' Rolename )*
 
-**RolenameList:**
-
-![RolenameList](/media/sqlgram/RolenameList.png)
-
-**UsernameList:**
-
-![UsernameList](/media/sqlgram/UsernameList.png)
+UsernameList ::=
+    Username ( ',' Username )*
+```
 
 ## Examples
 

--- a/sql-statements/sql-statement-rollback.md
+++ b/sql-statements/sql-statement-rollback.md
@@ -10,13 +10,14 @@ This statement reverts all changes in the current transaction inside of TIDB.  I
 
 ## Synopsis
 
-**RollbackStmt:**
+```ebnf+diagram
+RollbackStmt ::=
+    'ROLLBACK' CompletionTypeWithinTransaction?
 
-![RollbackStmt](/media/sqlgram/RollbackStmt.png)
-
-**CompletionTypeWithinTransaction:**
-
-![CompletionTypeWithinTransaction](/media/sqlgram/CompletionTypeWithinTransaction.png)
+CompletionTypeWithinTransaction ::=
+    'AND' ( 'CHAIN' ( 'NO' 'RELEASE' )? | 'NO' 'CHAIN' ( 'NO'? 'RELEASE' )? )
+|   'NO'? 'RELEASE'
+```
 
 ## Examples
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR changes the synopsis sections of BEGIN, CHANGE, COMMIT, CREATE, DEALLOCATE, DELETE, DO, and DROP statements to use the ```ebnf+diagrm block, replacing the original image-based sqlgrams. It is a follow-up PR to https://github.com/pingcap/docs/issues/4389.

To avoid making one single PR too large, I will open 4-5 follow-up PRs to process sql-statements files in batches. And I will delete all image files in the last PR in case of any display issues.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/5540
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
