### PR TITLE
add a better clarification on how sysvar changes "propagate"

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -24,7 +24,7 @@ SET  GLOBAL tidb_distsql_scan_concurrency = 10;
 
 > **Note:**
 >
-> TiDB differs from MySQL in that `GLOBAL` scoped variables **persist** through TiDB server restarts. Changes to `GLOBAL` variables may take up to 2 seconds to be effective, including the TiDB server where the `SET` statement was issued. See [TiDB #14531](https://github.com/pingcap/tidb/issues/14531).
+> TiDB differs from MySQL in that `GLOBAL` scoped variables **persist** through TiDB server restarts. Changes to `GLOBAL` variables might take up to 2 seconds to be effective, including on the TiDB server where the changes are made. See [TiDB #14531](https://github.com/pingcap/tidb/issues/14531) for details.
 > Additionally, TiDB presents several MySQL variables from MySQL 5.7 as both readable and settable. This is required for compatibility, since it is common for both applications and connectors to read MySQL variables. For example: JDBC connectors both read and set query cache settings, despite not relying on the behavior.
 
 ## Variable Reference

--- a/system-variables.md
+++ b/system-variables.md
@@ -24,7 +24,7 @@ SET  GLOBAL tidb_distsql_scan_concurrency = 10;
 
 > **Note:**
 >
-> TiDB differs from MySQL in that `GLOBAL` scoped variables **persist** through TiDB server restarts. Changes are also propagated to other TiDB servers every 2 seconds [TiDB #14531](https://github.com/pingcap/tidb/issues/14531).
+> TiDB differs from MySQL in that `GLOBAL` scoped variables **persist** through TiDB server restarts. Changes to `GLOBAL` variables may take up to 2 seconds to be effective, including the TiDB server where the `SET` statement was issued. See [TiDB #14531](https://github.com/pingcap/tidb/issues/14531).
 > Additionally, TiDB presents several MySQL variables from MySQL 5.7 as both readable and settable. This is required for compatibility, since it is common for both applications and connectors to read MySQL variables. For example: JDBC connectors both read and set query cache settings, despite not relying on the behavior.
 
 ## Variable Reference


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The sysvar docs imply that the 2 second delay is propagation to other servers. This is not the case, there is no propagation at all, because the table is stored in TiKV. The delay is the global values cache, and thus it affects the issuing server as well.

This affects all versions, but master will hopefully have a [fix soon](https://github.com/pingcap/tidb/pull/24359) so I'll create a separate PR to document the different semantics.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

For GA releases it is https://github.com/pingcap/tidb/issues/22808

(I will leave the issue open until master is fixed)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
