### PR TITLE
system-variables: add datadir and license

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -92,7 +92,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: NONE
 - Default value: /tmp/tidb
-- This variable indicates the location where data is stored. This can be a local path or point to a PD server in case the data is stored on TiKV.
+- This variable indicates the location where data is stored. This location can be a local path or point to a PD server if the data is stored on TiKV.
 - A value in the format of `ip_address:port` indicates the PD server that TiDB connects to on startup.
 
 ### ddl_slow_threshold

--- a/system-variables.md
+++ b/system-variables.md
@@ -86,7 +86,7 @@ mysql> SELECT * FROM t1;
 - Scope: NONE
 - Default value: /tmp/tidb
 - This variable indicates the location where data is stored. This can be a local path or point to a PD server in case the data is stored on TiKV.
-- Typically the value when be in the format of `ip_address:port`, indicating the PD server that TiDB connected to on startup.
+- A value in the format of `ip_address:port` indicates the PD server that TiDB connects to on startup.
 
 ### ddl_slow_threshold
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -81,6 +81,13 @@ mysql> SELECT * FROM t1;
 - Default value: ON
 - Controls whether statements should automatically commit when not in an explicit transaction. See [Transaction Overview](/transaction-overview.md#autocommit) for more information.
 
+### datadir
+
+- Scope: NONE
+- Default value: /tmp/tidb
+- This variable indicates the location where data is stored.
+- Typically the value when be in the format of `ip_address:port`, indicating the PD server that TiDB connected to on startup.
+
 ### ddl_slow_threshold
 
 - Scope: INSTANCE
@@ -122,6 +129,12 @@ mysql> SELECT * FROM t1;
 - Scope: SESSION
 - Default value: 0
 - This variable is used to show whether the execution plan used in the previous `execute` statement is taken directly from the plan cache.
+
+### license
+
+- Scope: NONE
+- Default value: Apache License 2.0
+- This variable indicates the license of your TiDB server installation.
 
 ### max_execution_time
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -85,7 +85,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: NONE
 - Default value: /tmp/tidb
-- This variable indicates the location where data is stored.
+- This variable indicates the location where data is stored. This can be a local path or point to a PD server in case the data is stored on TiKV.
 - Typically the value when be in the format of `ip_address:port`, indicating the PD server that TiDB connected to on startup.
 
 ### ddl_slow_threshold


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This adds 2 missing system variables that function correctly in TiDB: datadir and license.

The language is intentionally a little vague and says "typically" because in mocktikv/unistore cases it will show a path, but that is for developers to know. I don't believe we ever change the license string for enterprise edition but the language doesn't preclude that.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
