### PR TITLE
config: update the default value of `feedback-probability`

### DIFF
--- a/statistics.md
+++ b/statistics.md
@@ -148,11 +148,7 @@ Three system variables related to automatic update of statistics are as follows:
 
 When the ratio of the number of modified rows to the total number of rows of `tbl` in a table is greater than `tidb_auto_analyze_ratio`, and the current time is between `tidb_auto_analyze_start_time` and `tidb_auto_analyze_end_time`, TiDB executes the `ANALYZE TABLE tbl` statement in the background to automatically update the statistics of this table.
 
-When the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. You can modify the value of `feedback-probability` in the configuration file. The default value is `0.05`. You can set the value to `0.0` to disable this feature.
-
-> **Note:**
->
-> If you set the value of `feedback-probability` to `0` in the configuration file, a failure will occur and an error will be reported. To disable `feedback-probability`, you need to set the value to `0.0`.
+Before v5.0, when the query is executed, TiDB collects feedback with the probability of `feedback-probability` and uses it to update the histogram and Count-Min Sketch. **In v5.0, this feature is disabled by default, and it is not recommended to enable this feature.**
 
 ### Control `ANALYZE` concurrency
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -407,8 +407,8 @@ Configuration items related to performance.
 ### `feedback-probability`
 
 - The probability that TiDB collects the feedback statistics of each query.
-- Default value: `0.05`
-- TiDB collects the feedback of each query at the probability of `feedback-probability`, to update statistics.
+- Default value: `0`
+- This feature is disabled by default, and it is not recommended to enable this feature. If it is enabled, TiDB collects the feedback of each query at the probability of `feedback-probability`, to update statistics.
 
 ### `query-feedback-limit`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The feature`feedback-probability` has been disabled by default since v4.0.9 because its behavior is unstable (see https://github.com/pingcap/tidb/pull/21923). So I update the default value of it to `0` and modify some descriptions.

After this PR is cherry-picked to the release-4.0 branch, I will add the information that the feature`feedback-probability` is disabled from the patch version v4.0.9.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/6113
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
