### PR TITLE
system-variables: Add charset documentation

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -84,6 +84,36 @@ mysql> SELECT * FROM t1;
 - Default value: `ON`
 - Controls whether statements should automatically commit when not in an explicit transaction. See [Transaction Overview](/transaction-overview.md#autocommit) for more information.
 
+### character_set_client
+
+- Scope: SESSION | GLOBAL
+- Default value: `utf8mb4`
+- Character set for data send by the client. See [Character Set and Collation](/character-set-and-collation.md) for details on the use of character sets and collations in TiDB. It is recommended to use [`SET NAMES`](/sql-statements/sql-statement-set-names.md) to change the character set when needed.
+
+### character_set_connection
+
+- Scope: SESSION | GLOBAL
+- Default value: `utf8mb4`
+- Character set for string literals that don't have a character set specified.
+
+### character_set_database
+
+- Scope: SESSION | GLOBAL
+- Default value: `utf8mb4`
+- This indicates the character set of the default database that is in use. Setting this variable is not recommended. The server changes this varible when a new default database is selected.
+
+### character_set_results
+
+- Scope: SESSION | GLOBAL
+- Default value: `utf8mb4`
+- The character set that is used when data is sent to the client.
+
+### character_set_server
+
+- Scope: SESSION | GLOBAL
+- Default value: `utf8mb4`
+- The collation used for new schemas in case none is provided by the `CREATE SCHEMA` statement.
+
 ### `cte_max_recursion_depth`
 
 - Scope：SESSION | GLOBAL

--- a/system-variables.md
+++ b/system-variables.md
@@ -112,7 +112,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: SESSION | GLOBAL
 - Default value: `utf8mb4`
-- The character set used for new schemas in case none is provided by the `CREATE SCHEMA` statement.
+- The character set used for new schemas when no character set is specified in the `CREATE SCHEMA` statement.
 
 ### `cte_max_recursion_depth`
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -88,7 +88,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: SESSION | GLOBAL
 - Default value: `utf8mb4`
-- Character set for data send by the client. See [Character Set and Collation](/character-set-and-collation.md) for details on the use of character sets and collations in TiDB. It is recommended to use [`SET NAMES`](/sql-statements/sql-statement-set-names.md) to change the character set when needed.
+- The character set for data sent from the client. See [Character Set and Collation](/character-set-and-collation.md) for details on the use of character sets and collations in TiDB. It is recommended to use [`SET NAMES`](/sql-statements/sql-statement-set-names.md) to change the character set when needed.
 
 ### character_set_connection
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -100,7 +100,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: SESSION | GLOBAL
 - Default value: `utf8mb4`
-- This indicates the character set of the default database that is in use. Setting this variable is not recommended. The server changes this varible when a new default database is selected.
+- This variable indicates the character set of the default database in use. **It is NOT recommended to set this variable**. When a new default database is selected, the server changes the variable value.
 
 ### character_set_results
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -112,7 +112,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: SESSION | GLOBAL
 - Default value: `utf8mb4`
-- The collation used for new schemas in case none is provided by the `CREATE SCHEMA` statement.
+- The character set used for new schemas in case none is provided by the `CREATE SCHEMA` statement.
 
 ### `cte_max_recursion_depth`
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -94,7 +94,7 @@ mysql> SELECT * FROM t1;
 
 - Scope: SESSION | GLOBAL
 - Default value: `utf8mb4`
-- Character set for string literals that don't have a character set specified.
+- The character set for string literals that do not have a specified character set.
 
 ### character_set_database
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add documentation for these:
<pre><span style="background-color:#E4E4E4"><font color="#005F5F">5.7.25-TiDB-v5.2.0-alpha-164-g8434069c5</font></span><span style="background-color:#3A3A3A"><font color="#E4E4E4"></font></span><span style="background-color:#3A3A3A"><font color="#FDF6E3"> 127.0.0.1:4000 </font></span><span style="background-color:#6C6C6C"><font color="#3A3A3A"></font></span><span style="background-color:#6C6C6C"><font color="#FDF6E3"> test </font></span><span style="background-color:#D75F00"><font color="#6C6C6C"></font></span><span style="background-color:#D75F00"><font color="#FDF6E3"> SQL </font></span><span style="background-color:#073642"><font color="#D75F00"> </font></span>show global variables like &apos;char%&apos;;
+--------------------------+--------------------------------------------------------+
| Variable_name            | Value                                                  |
+--------------------------+--------------------------------------------------------+
| character_set_client     | utf8mb4                                                |
| character_set_connection | utf8mb4                                                |
| character_set_database   | utf8mb4                                                |
| character_set_filesystem | binary                                                 |
| character_set_results    | utf8mb4                                                |
| character_set_server     | utf8mb4                                                |
| character_set_system     | utf8                                                   |
| character_sets_dir       | /usr/local/mysql-5.6.25-osx10.8-x86_64/share/charsets/ |
+--------------------------+--------------------------------------------------------+
8 rows in set (0.0042 sec)
</pre>

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

Related to  #3155