### PR TITLE
Add v5.1.0 / release-5.1 where it is missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Currently, we maintain six versions of TiDB documentation, each with a separate 
 | Docs branch name | Version description |
 | :--- | :--- |
 | `master` branch | the latest development version |
+| `release-5.1` branch | the 5.1 stable version |
 | `release-5.0` branch | the 5.0 stable version |
 | `release-4.0` branch | the 4.0 stable version |
 | `release-3.1` branch | the 3.1 stable version |
@@ -51,6 +52,7 @@ Currently, we maintain six versions of TiDB documentation, each with a separate 
 - If your changes apply to only one docs version, just submit a PR to the corresponding version branch.
 
 - If your changes apply to multiple docs versions, you don't have to submit a PR to each branch. Instead, after you submit your PR, trigger the sre-bot to submit a PR to other version branches by adding one or several of the following labels as needed. Once the current PR is merged, sre-bot will start to work.
+    - `needs-cherry-pick-5.1` label: sre-bot will submit a PR to the `release-5.1` branch.
     - `needs-cherry-pick-5.0` label: sre-bot will submit a PR to the `release-5.0` branch.
     - `needs-cherry-pick-4.0` label: sre-bot will submit a PR to the `release-4.0` branch.
     - `needs-cherry-pick-3.1` label: sre-bot will submit a PR to the `release-3.1` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Currently, we maintain six versions of TiDB documentation, each with a separate 
 | Docs branch name | Version description |
 | :--- | :--- |
 | `master` branch | the latest development version |
-| `release-5.1` branch | the 5.1 stable version |
+| `release-5.1` branch | the 5.1 version |
 | `release-5.0` branch | the 5.0 stable version |
 | `release-4.0` branch | the 4.0 stable version |
 | `release-3.1` branch | the 3.1 stable version |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently, we maintain the following versions of TiDB documentation in different
 | Branch name | TiDB docs version |
 | :---------|:----------|
 | [`master`](https://github.com/pingcap/docs/tree/master) | The latest development version |
-| [`release-5.1`](https://github.com/pingcap/docs/tree/release-5.1) | 5.1 stable version |
+| [`release-5.1`](https://github.com/pingcap/docs/tree/release-5.1) | 5.1 version |
 | [`release-5.0`](https://github.com/pingcap/docs/tree/release-5.0) | 5.0 stable version |
 | [`release-4.0`](https://github.com/pingcap/docs/tree/release-4.0) | 4.0 stable version |
 | [`release-3.1`](https://github.com/pingcap/docs/tree/release-3.1) | 3.1 stable version |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently, we maintain the following versions of TiDB documentation in different
 | Branch name | TiDB docs version |
 | :---------|:----------|
 | [`master`](https://github.com/pingcap/docs/tree/master) | The latest development version |
+| [`release-5.1`](https://github.com/pingcap/docs/tree/release-5.1) | 5.1 stable version |
 | [`release-5.0`](https://github.com/pingcap/docs/tree/release-5.0) | 5.0 stable version |
 | [`release-4.0`](https://github.com/pingcap/docs/tree/release-4.0) | 4.0 stable version |
 | [`release-3.1`](https://github.com/pingcap/docs/tree/release-3.1) | 3.1 stable version |


### PR DESCRIPTION



### What is changed, added or deleted? (Required)

Add `release-5.1` where it was missing.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

Related to fff8d90edfa8a4bf23aa9d4fa3e1ab247b046b13


