### PR TITLE
TiKV configuration: defaultcf.titan config should not apply to other CFs

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1142,7 +1142,7 @@ Configuration items related to `rocksdb.defaultcf.titan`.
 + Determines whether to use the merge operator to write back blob indexes for Titan GC. When `gc-merge-rewrite` is enabled, it reduces the effect of Titan GC on the writes in the foreground.
 + Default value: `false`
 
-## `raftdb`
+## raftdb
 
 Configuration items related to `raftdb`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1064,9 +1064,9 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 + Default value: `"128MB"`
 + Unit: KB|MB|GB
 
-## rocksdb.defaultcf.titan | rocksdb.writecf.titan | rocksdb.lockcf.titan
+## rocksdb.defaultcf.titan
 
-Configuration items related to `rocksdb.defaultcf.titan`, `rocksdb.writecf.titan`, and `rocksdb.lockcf.titan`.
+Configuration items related to `rocksdb.defaultcf.titan`.
 
 ### `min-blob-size`
 


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
Titan only works on the defaultcf. The `rocksdb.defaultcf.titan` configs do not apply to `writecf` and `lockcf`. Fixing it. It looks like the Chinese version doesn't have such mistake.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs/pull/5746

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
