### PR TITLE
sysvar: change the default value of tidb_multi_statement_mode in v4.0.14

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -570,7 +570,7 @@ Constraint checking is always performed in place for pessimistic transactions (d
 ### tidb_multi_statement_mode <span class="version-mark">New in v4.0.11</span>
 
 - Scope: SESSION | GLOBAL
-- Default value: WARN
+- Default value: For v4.0.14 or a later v4.0 version, the default value is OFF. For v4.0 versions earlier than v4.0.14, the default value is WARN.
 - Permitted values: OFF, ON, WARN
 - This variable controls whether to allow multiple queries to be executed in the same `COM_QUERY` call.
 - To reduce the impact of SQL injection attacks, TiDB now prevents multiple queries from being executed in the same `COM_QUERY` call by default. This variable is intended to be used as part of an upgrade path from earlier versions of TiDB. The following behaviors apply:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)
 change the default value of tidb_multi_statement_mode in v4.0.14
<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
