### PR TITLE
Punctuation fix: Replace 。with .

### DIFF
--- a/enable-tls-between-clients-and-servers.md
+++ b/enable-tls-between-clients-and-servers.md
@@ -183,4 +183,4 @@ The newly loaded certificate, key, and CA take effect on the connection that is 
 
 ### See also
 
-- [Enable TLS Between TiDB Components](/enable-tls-between-components.md)。
+- [Enable TLS Between TiDB Components](/enable-tls-between-components.md).

--- a/predicate-push-down.md
+++ b/predicate-push-down.md
@@ -108,7 +108,7 @@ explain select * from t left join s on t.a = s.a where s.a is null;
 6 rows in set (0.00 sec)
 ```
 
-In this query，there is a predicate `s.a is null` on the inner table `s`。
+In this query，there is a predicate `s.a is null` on the inner table `s`.
 
 From the `explain` results，we can see that the predicate is not pushed below join operator. This is because the outer join fills the inner table with `NULL` values when the `on` condition isn't satisfied, and the predicate `s.a is null` is used to filter the results after the join. If it is pushed down to the inner table below join, the execution plan is not equivalent to the original one.
 

--- a/sql-statements/sql-statement-show-analyze-status.md
+++ b/sql-statements/sql-statement-show-analyze-status.md
@@ -1,6 +1,6 @@
 ---
 title: SHOW ANALYZE STATUS
-summary: An overview of the usage of SHOW ANALYZE STATUS for the TiDB database。
+summary: An overview of the usage of SHOW ANALYZE STATUS for the TiDB database.
 aliases: ['/docs/dev/sql-statements/sql-statement-show-analyze-status/']
 ---
 

--- a/sql-statements/sql-statement-show-histograms.md
+++ b/sql-statements/sql-statement-show-histograms.md
@@ -1,6 +1,6 @@
 ---
 title: SHOW STATS_HISTOGRAMS
-summary: An overview of the usage of SHOW HISTOGRAMS for TiDB database。
+summary: An overview of the usage of SHOW HISTOGRAMS for TiDB database.
 aliases: ['/docs/dev/sql-statements/sql-statement-show-histograms/']
 ---
 

--- a/tidb-binlog/tidb-binlog-faq.md
+++ b/tidb-binlog/tidb-binlog-faq.md
@@ -244,7 +244,7 @@ To solve the problem, follow these steps:
 3. Check `drainer.log`. Search for the failed DDL operation and find the `commit-ts` of this operation. For example:
 
     ```
-    [2020/05/21 09:51:58.019 +08:00] [INFO] [syncer.go:398] ["add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` to skip this ddl if needed"] [sql="ALTER TABLE `test` ADD INDEX (`index1`)"] ["commit ts"=416815754209656834]。
+    [2020/05/21 09:51:58.019 +08:00] [INFO] [syncer.go:398] ["add ddl item to syncer, you can add this commit ts to `ignore-txn-commit-ts` to skip this ddl if needed"] [sql="ALTER TABLE `test` ADD INDEX (`index1`)"] ["commit ts"=416815754209656834].
     ```
 
 4. Modify the `drainer.toml` configuration file. Add the `commit-ts` in the `ignore-txn-commit-ts` item and restart the Drainer node.

--- a/user-defined-variables.md
+++ b/user-defined-variables.md
@@ -86,7 +86,7 @@ SELECT @a1, @a2, @a3, @a4 := @a1+@a2+@a3;
 +------+------+------+--------------------+
 ```
 
-Before the variable `@a4` is modified or the connection is closed, its value is always `7`。
+Before the variable `@a4` is modified or the connection is closed, its value is always `7`.
 
 If a hexadecimal literal or binary literal is used when setting the user-defined variable, TiDB will treat it as a binary string. If you want to set it to a number, you can manually add the `CAST` conversion, or use the numeric operator in the expression:
 


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

```
sed -i 's/。/./g' $(git grep -l 。 | egrep '\.md')
```

```
In [1]: import unicodedata                                                                                                              

In [2]: unicodedata.name('。')                                                                                                          
Out[2]: 'IDEOGRAPHIC FULL STOP'

In [3]: unicodedata.name('.')                                                                                                           
Out[3]: 'FULL STOP'
```



<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)
