### PR TITLE
configure-time-zone: mention `system_time_zone`

### DIFF
--- a/configure-time-zone.md
+++ b/configure-time-zone.md
@@ -28,12 +28,12 @@ Each client has its own time zone setting, given by the session `time_zone` vari
 SET time_zone = timezone;
 ```
 
-You can use the following statement to view the current values of the global and client-specific time zones:
+You can use the following statement to view the current values of the global, client-specific and system time zones:
 
 {{< copyable "sql" >}}
 
 ```sql
-SELECT @@global.time_zone, @@session.time_zone;
+SELECT @@global.time_zone, @@session.time_zone, @@global.system_time_zone;
 ```
 
 To set the format of the value of the `time_zone`:


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Without this you will see `SYSTEM` for both in most cases, which still doesn't tell you which timezone is used.

<!--Tell us what you did and why.-->
```
mysql> SELECT @@global.time_zone, @@session.time_zone, @@global.system_time_zone;
+--------------------+---------------------+---------------------------+
| @@global.time_zone | @@session.time_zone | @@global.system_time_zone |
+--------------------+---------------------+---------------------------+
| SYSTEM             | SYSTEM              | UTC                       |
+--------------------+---------------------+---------------------------+
1 row in set (0.17 sec)
```

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->




### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)



### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
