### PR TITLE
5.1.0 release notes: Fix link to telemetry docs

### DIFF
--- a/releases/release-5.1.0.md
+++ b/releases/release-5.1.0.md
@@ -174,7 +174,7 @@ In v5.1, the key new features or improvements are as follows:
 
 TiDB adds the running status of TiDB cluster requests in telemetry, including execution status, failure status, etc.
 
-To learn more about the information and how to disable this behavior, refer to [Telemetry](https://docs.pingcap.com/zh/tidb/stable/telemetry).
+To learn more about the information and how to disable this behavior, refer to [Telemetry](/telemetry.md).
 
 ## Improvements
 


### PR DESCRIPTION


### What is changed, added or deleted? (Required)

Fix a link in the English TiDB v5.1.0 release notes that pointed to the Chinese version of the telemetry docs.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)


