### PR TITLE
tiup: add notice about importing cluster

### DIFF
--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -17,6 +17,7 @@ Before TiDB v4.0, TiDB clusters were mainly deployed using TiDB Ansible. For TiD
 > + Clusters with TiDB Lightning/TiKV Importer enabled
 > + Clusters still using the old `push` mode to collect monitoring metrics (if you keep the default mode `pull` unchanged, using the `import` command is supported)
 > + Clusters in which the non-default ports (the ports configured in the `group_vars` directory are compatible) are separately configured in the `inventory.ini` configuration file using `node_exporter_port` / `blackbox_exporter_port`
+> + If some nodes in the cluster deployed with TiDB Ansible are not deployed with monitoring components, you should first use TiDB Ansible to add the corresponding node information in `monitored_servers`section of `inventory.ini` file, and then use `deploy.yaml` playbook to fully deployed monitoring components. Otherwise, after data is imported into TiUP, when you perform other maintenance operations, errors might occur due to the lack of monitoring components.
 
 ## Syntax
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
Some clusters deployed by TiDB-Ansible may not having monitoring agents deployed on all nodes, and if the user imported the cluster with TiUP Cluster, future operations may fail.

This PR adds a notice to the import doc to guide the user to deploy monitoring agents to all nodes before importing to TiUP Cluster.

This PR changes the manual page of tiup cluster import subcommand, I'll file another PR to change the import guidance doc in the release-4.0 branch.
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/6659
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
