### PR TITLE
Add infoschema.referential_constraints

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -450,6 +450,7 @@
         + [`METRICS_TABLES`](/information-schema/information-schema-metrics-tables.md)
         + [`PARTITIONS`](/information-schema/information-schema-partitions.md)
         + [`PROCESSLIST`](/information-schema/information-schema-processlist.md)
+        + [`REFERENTIAL_CONSTRAINTS`](/information-schema/information-schema-referential-constraints.md)
         + [`SCHEMATA`](/information-schema/information-schema-schemata.md)
         + [`SEQUENCES`](/information-schema/information-schema-sequences.md)
         + [`SESSION_VARIABLES`](/information-schema/information-schema-session-variables.md)

--- a/information-schema/information-schema-referential-constraints.md
+++ b/information-schema/information-schema-referential-constraints.md
@@ -1,0 +1,69 @@
+---
+title: REFERENTIAL_CONSTRAINTS
+summary: Learn the `REFERENTIAL_CONSTRAINTS` information_schema table.
+---
+
+# REFERENTIAL_CONSTRAINTS
+
+The `REFERENTIAL_CONSTRAINTS` table provides information about `FOREIGN KEY` relationships between tables. Note that TiDB currently does not enforce `FOREIGN KEY` constraints, or perform actions such as `ON DELETE CASCADE`.
+
+{{< copyable "sql" >}}
+
+```sql
+USE information_schema;
+DESC referential_constraints;
+```
+
+```sql
++---------------------------+--------------+------+------+---------+-------+
+| Field                     | Type         | Null | Key  | Default | Extra |
++---------------------------+--------------+------+------+---------+-------+
+| CONSTRAINT_CATALOG        | varchar(512) | NO   |      | NULL    |       |
+| CONSTRAINT_SCHEMA         | varchar(64)  | NO   |      | NULL    |       |
+| CONSTRAINT_NAME           | varchar(64)  | NO   |      | NULL    |       |
+| UNIQUE_CONSTRAINT_CATALOG | varchar(512) | NO   |      | NULL    |       |
+| UNIQUE_CONSTRAINT_SCHEMA  | varchar(64)  | NO   |      | NULL    |       |
+| UNIQUE_CONSTRAINT_NAME    | varchar(64)  | YES  |      | NULL    |       |
+| MATCH_OPTION              | varchar(64)  | NO   |      | NULL    |       |
+| UPDATE_RULE               | varchar(64)  | NO   |      | NULL    |       |
+| DELETE_RULE               | varchar(64)  | NO   |      | NULL    |       |
+| TABLE_NAME                | varchar(64)  | NO   |      | NULL    |       |
+| REFERENCED_TABLE_NAME     | varchar(64)  | NO   |      | NULL    |       |
++---------------------------+--------------+------+------+---------+-------+
+11 rows in set (0.00 sec)
+```
+
+{{< copyable "sql" >}}
+
+```sql
+CREATE TABLE test.parent (
+ id INT NOT NULL AUTO_INCREMENT,
+ PRIMARY KEY (id)
+);
+
+CREATE TABLE test.child (
+ id INT NOT NULL AUTO_INCREMENT,
+ name varchar(255) NOT NULL,
+ parent_id INT DEFAULT NULL,
+ PRIMARY KEY (id),
+ CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+SELECT * FROM referential_constraints\G
+```
+
+```
+*************************** 1. row ***************************
+       CONSTRAINT_CATALOG: def
+        CONSTRAINT_SCHEMA: test
+          CONSTRAINT_NAME: fk_parent
+UNIQUE_CONSTRAINT_CATALOG: def
+ UNIQUE_CONSTRAINT_SCHEMA: test
+   UNIQUE_CONSTRAINT_NAME: PRIMARY
+             MATCH_OPTION: NONE
+              UPDATE_RULE: CASCADE
+              DELETE_RULE: RESTRICT
+               TABLE_NAME: child
+    REFERENCED_TABLE_NAME: parent
+1 row in set (0.00 sec)
+```

--- a/information-schema/information-schema.md
+++ b/information-schema/information-schema.md
@@ -32,7 +32,7 @@ Many `INFORMATION_SCHEMA` tables have a corresponding `SHOW` command. The benefi
 | `PLUGINS`                                                                               | Not implemented by TiDB. Returns zero rows. |
 | [`PROCESSLIST`](/information-schema/information-schema-processlist.md)                  | Provides similar information to the command `SHOW PROCESSLIST`. |
 | `PROFILING`                                                                             | Not implemented by TiDB. Returns zero rows. |
-| `REFERENTIAL_CONSTRAINTS`                                                               | Not implemented by TiDB. Returns zero rows. |
+| `REFERENTIAL_CONSTRAINTS`                                                               | Provides information on `FOREIGN KEY` constraints. |
 | `ROUTINES`                                                                              | Not implemented by TiDB. Returns zero rows. |
 | [`SCHEMATA`](/information-schema/information-schema-schemata.md)                        | Provides similar information to `SHOW DATABASES`. |
 | `SCHEMA_PRIVILEGES`                                                                     | Not implemented by TiDB. Returns zero rows. |


### PR DESCRIPTION


### What is changed, added or deleted? (Required)

This provides documentation for https://github.com/pingcap/tidb/pull/26450

The motivation for adding this to TiDB was for ruby-on-rails compatibility. The value is limited however, because foreign keys are not enforced. I am documenting it however for correctness.. but the documentation is brief.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
