### PR TITLE
br, cdc: remove cdclog sink and PiTR

### DIFF
--- a/br/use-br-command-line-tool.md
+++ b/br/use-br-command-line-tool.md
@@ -246,6 +246,10 @@ In the above example, for the incremental backup data, BR records the data chang
 
 ### Point-in-time recovery (experimental feature)
 
+> **Warning:**
+>
+> This feature is experimental and not thoroughly tested. It is highly not recommended to use this feature in the production environment.
+
 Point-in-time recovery (PITR) allows you to restore data to a point in time of your choice.
 
 An example scenario would be to take a full backup every day and take incremental backups every 6 hours and then use TiCDC for PITR. Assume that on one day, the full backup was performed at 00:00 and the first incremental backup was performed at 06:00. If you want to restore the database to the state of 07:16, you can first restore the full backup (taken at 00:00) and the incremental backup (taken at 06:00), and then restore TiCDC logs that fill in the gap between 06:00 and 07:16.

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -274,6 +274,10 @@ For more parameters of Pulsar, see [pulsar-client-go ClientOptions](https://godo
 
 #### Configure sink URI with cdclog
 
+> **Warning:**
+>
+> This feature is experimental and not thoroughly tested. It is highly not recommended to use this feature in the production environment.
+
 The `cdclog` files (files written by TiCDC on the local filesystem or on the Amazon S3-compatible storage) can be used together with Backup & Restore (BR) to provide point-in-time (PITR) recovery. See [Point in Time recovery (experimental feature)](/br/use-br-command-line-tool.md#point-in-time-recovery-experimental-feature) for details.
 
 The following command creates a changefeed that will write cdclog files locally to the `/data/cdc/log` directory.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

According to @IANTHEREAL, the cdclog sink and the PiTR are just prototype features(even not experimental) and not ready to be documented. They should be removed for preventing misusing of them.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
