### PR TITLE
release-5.2.0: Add info about caching_sha2

### DIFF
--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -60,6 +60,7 @@ In v5.2, the key new features and improvements are as follows:
 - Before the upgrade, check the value of the TiDB configuration [`feedback-probability`](/tidb-configuration-file.md#feedback-probability). If the value is not `0`, the "panic in the recoverable goroutine" error will occur after the upgrade, but this error does not affect the upgrade.
 - TiDB is now compatible with MySQL 5.7's noop variable `innodb_default_row_format`. Setting this variable has no effect. [#23541](https://github.com/pingcap/tidb/issues/23541)
 - Starting from TiDB 5.2, to improve system security, it is recommended (but not mandatory) to encrypt the transport layer for connections from clients. TiDB provides the Auto TLS feature to automatically configure and enable encryption in TiDB. To use the Auto TLS feature, before the TiDB upgrade, set [`security.auto-tls`](/tidb-configuration-file.md#auto-tls) in the TiDB configuration file to `true`.
+- Support for the `caching_sha2_password` was added to make migration from MySQL 8.0 easier and to improve security.
 
 ## New features
 

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -60,7 +60,7 @@ In v5.2, the key new features and improvements are as follows:
 - Before the upgrade, check the value of the TiDB configuration [`feedback-probability`](/tidb-configuration-file.md#feedback-probability). If the value is not `0`, the "panic in the recoverable goroutine" error will occur after the upgrade, but this error does not affect the upgrade.
 - TiDB is now compatible with MySQL 5.7's noop variable `innodb_default_row_format`. Setting this variable has no effect. [#23541](https://github.com/pingcap/tidb/issues/23541)
 - Starting from TiDB 5.2, to improve system security, it is recommended (but not mandatory) to encrypt the transport layer for connections from clients. TiDB provides the Auto TLS feature to automatically configure and enable encryption in TiDB. To use the Auto TLS feature, before the TiDB upgrade, set [`security.auto-tls`](/tidb-configuration-file.md#auto-tls) in the TiDB configuration file to `true`.
-- Support for the `caching_sha2_password` authentication method was added to make migration from MySQL 8.0 easier and to improve security.
+- Support the `caching_sha2_password` authentication method to make migration from MySQL 8.0 easier and to improve security.
 
 ## New features
 

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -60,7 +60,7 @@ In v5.2, the key new features and improvements are as follows:
 - Before the upgrade, check the value of the TiDB configuration [`feedback-probability`](/tidb-configuration-file.md#feedback-probability). If the value is not `0`, the "panic in the recoverable goroutine" error will occur after the upgrade, but this error does not affect the upgrade.
 - TiDB is now compatible with MySQL 5.7's noop variable `innodb_default_row_format`. Setting this variable has no effect. [#23541](https://github.com/pingcap/tidb/issues/23541)
 - Starting from TiDB 5.2, to improve system security, it is recommended (but not mandatory) to encrypt the transport layer for connections from clients. TiDB provides the Auto TLS feature to automatically configure and enable encryption in TiDB. To use the Auto TLS feature, before the TiDB upgrade, set [`security.auto-tls`](/tidb-configuration-file.md#auto-tls) in the TiDB configuration file to `true`.
-- Support for the `caching_sha2_password` was added to make migration from MySQL 8.0 easier and to improve security.
+- Support for the `caching_sha2_password` authentication method was added to make migration from MySQL 8.0 easier and to improve security.
 
 ## New features
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Mention `caching_sha2_password` in the release notes

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- Other reference link(s):

- https://github.com/pingcap/parser/pull/1232
