### PR TITLE
Configuration Options: remove two TiDB's command options

### DIFF
--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -14,12 +14,6 @@ When you start the TiDB cluster, you can use command-line options or environment
 - Default: ""
 - This address must be accessible by the rest of the TiDB cluster and the user.
 
-## `--binlog-socket`
-
-- The TiDB services use the unix socket file for internal connections, such as the Pump service
-- Default: ""
-- You can use "/tmp/pump.sock" to accept the communication of Pump unix socket file.
-
 ## `--config`
 
 - The configuration file
@@ -102,11 +96,6 @@ When you start the TiDB cluster, you can use command-line options or environment
 - For the distributed storage engine like TiKV, `--path` specifies the actual PD address. Assuming that you deploy the PD server on 192.168.100.113:2379, 192.168.100.114:2379 and 192.168.100.115:2379, the value of `--path` is "192.168.100.113:2379, 192.168.100.114:2379, 192.168.100.115:2379".
 - Default: "/tmp/tidb"
 - You can use `tidb-server --store=unistore --path=""` to enable a pure in-memory TiDB.
-
-## `--tmp-storage-path`
-
-+ TiDB's temporary storage path
-+ Default: `<TMPDIR>/tidb/tmp-storage`
 
 ## `--proxy-protocol-networks`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Removed two deprecated flags `--binlog-socket` and `--tmp-storage-path` in "command-line-flags-for-tidb-configuration.md".
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/6757
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
