### PR TITLE
v5.2.2: change the default value of `l0-files-threshold`

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -372,7 +372,7 @@ Configuration items related to the flow control mechanism in TiKV. This mechanis
 ### `l0-files-threshold`
 
 + When the number of kvDB L0 files reaches this threshold, the flow control mechanism starts to work.
-+ Default value: `9`
++ Default value: `20`
 
 ### `soft-pending-compaction-bytes-limit`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Changed the default value of `l0-files-threshold` in "tikv-configuration-file.md".
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/7306
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
