### PR TITLE
Add docs for version_compile_* variables

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -1552,13 +1552,13 @@ This variable is an alias for _transaction_isolation_.
 
 - Scope: NONE
 - Default value: (string)
-- This variable returns the OS that TiDB is running on.
+- This variable returns the name of the OS on which TiDB is running.
 
 ### version_compile_machine
 
 - Scope: NONE
 - Default value: (string)
-- This variable returns the CPU architecture that TiDB is running on.
+- This variable returns the name of the CPU architecture on which TiDB is running.
 
 ### wait_timeout
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1548,6 +1548,18 @@ This variable is an alias for _transaction_isolation_.
 - Default value: (string)
 - This variable returns additional details about the TiDB version. For example, 'TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible'.
 
+### version_compile_os
+
+- Scope: NONE
+- Default value: (string)
+- This variable returns the OS that TiDB is running on.
+
+### version_compile_machine
+
+- Scope: NONE
+- Default value: (string)
+- This variable returns the CPU architecture that TiDB is running on.
+
 ### wait_timeout
 
 - Scope: SESSION | GLOBAL


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

```
 MySQL  127.0.0.1:4000 ssl  test  SQL > SHOW VARIABLES LIKE 'version\_compile\_%';
+-------------------------+-------+
| Variable_name           | Value |
+-------------------------+-------+
| version_compile_machine | amd64 |
| version_compile_os      | linux |
+-------------------------+-------+
2 rows in set, 1 warning (0.0028 sec)
```

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

Related PR: https://github.com/pingcap/tidb/pull/28958

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
