### PR TITLE
Add auth_socket support

### DIFF
--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -26,11 +26,12 @@ The support for TLS authentication is configured differently. For detailed infor
 | `mysql_native_password`  | Yes              |
 | `sha256_password`        | No               |
 | `caching_sha2_password`  | Yes, since 5.2.0 |
-| `auth_socket`            | No               |
+| `auth_socket`            | Yes, since 5.3.0 |
 | [TLS Certificates]       | Yes              |
 | LDAP                     | No               |
 | PAM                      | No               |
 | ed25519 (MariaDB)        | No               |
 | GSSAPI (MariaDB)         | No               |
+| FIDO                     | No               |
 
 [TLS Certificates]: /enable-tls-between-clients-and-servers.md


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

Add Socket Authentication info.

Note that this doesn't update `default_authentication_plugin` as setting that to `auth_socket` doesn't make sense and isn't supported.

Also adding info about [FIDO](https://dev.mysql.com/doc/refman/8.0/en/fido-pluggable-authentication.html) authentication that was [released in MySQL 8.0.27](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-27.html) this week.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

Related PR: https://github.com/pingcap/tidb/pull/27561

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
