### PR TITLE
sql-statements: update claims on optimizer/explain compatibility

### DIFF
--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -82,7 +82,11 @@ TiDB uses a combination of [Prometheus and Grafana](/tidb-monitoring-api.md) to 
 
 ### Query Execution Plan
 
-The output format, output content, and the privilege setting of Query Execution Plan (`EXPLAIN`/`EXPLAIN FOR`) in TiDB is greatly different from those in MySQL. See [Understand the Query Execution Plan](/explain-overview.md) for more details.
+The output format, output content, and the privilege setting of Query Execution Plan (`EXPLAIN`/`EXPLAIN FOR`) in TiDB is greatly different from those in MySQL.
+
+The `optimizer_switch` system variable is read-only in TiDB and has no effect on query plans. [Optimizer Hints](/optimizer-hints.md) are supported using similar syntax to MySQL, but the available hints and implementation might differ.
+
+See [Understand the Query Execution Plan](/explain-overview.md) for more details.
 
 ### Built-in functions
 

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -84,7 +84,7 @@ TiDB uses a combination of [Prometheus and Grafana](/tidb-monitoring-api.md) to 
 
 The output format, output content, and the privilege setting of Query Execution Plan (`EXPLAIN`/`EXPLAIN FOR`) in TiDB is greatly different from those in MySQL.
 
-The `optimizer_switch` system variable is read-only in TiDB and has no effect on query plans. [Optimizer Hints](/optimizer-hints.md) are supported using similar syntax to MySQL, but the available hints and implementation might differ.
+The MySQL system variable `optimizer_switch` is read-only in TiDB and has no effect on query plans. You can also use [optimizer hints](/optimizer-hints.md) in similar syntax to MySQL, but the available hints and implementation might differ.
 
 See [Understand the Query Execution Plan](/explain-overview.md) for more details.
 

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -244,10 +244,10 @@ If the `dot` program is not installed on your computer, copy the result to [this
 ## MySQL compatibility
 
 * Both the format of `EXPLAIN` and the potential execution plans in TiDB differ substaintially from MySQL.
-* TiDB does not support the `EXPLAIN FORMAT=JSON` as in MySQL.
+* TiDB does not support the `FORMAT=JSON`  or `FORMAT=TREE` options.
 * TiDB does not currently support `EXPLAIN` for insert statements.
 
-## `EXPLAIN FOR CONNECTION`
+### `EXPLAIN FOR CONNECTION`
 
 `EXPLAIN FOR CONNECTION` is used to get the execution plan of the currently executed SQL query or the last executed SQL query in a connection. The output format is the same as that of `EXPLAIN`. However, the implementation of `EXPLAIN FOR CONNECTION` in TiDB is different from that in MySQL. Their differences (apart from the output format) are listed as follows:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB does not support `EXPLAIN FORMAT=tree`. It comes from MySQL 8.0, so it had not previously been documented (our official claim  = 5.7), but users might not know this. So it helps to include it here.

**Note:** I've updated this to cover optimizer switch compatibility as well. In https://github.com/pingcap/tidb/issues/29040 we determined that optimizer_switch should be read_only for now.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
