### PR TITLE
TiKV config: update the description of `reserve-space`

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -324,7 +324,9 @@ Configuration items related to storage
 
 ### `reserve-space`
 
-+ The size of the temporary file that preoccupies the extra space when TiKV is started. The name of temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV runs out of disk space and cannot be started normally, you can delete this file as an emergency intervention and set `reserve-space` to `"0MB"`.
++ When TiKV starts, a space is reserved to protect its disk space. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts in form: 80% of the reserved space is used as extra disk space required for operations when the disk space is insufficient, and the remaining 20% is used to save a temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file plays the role of the last defense for restoring services.
++ The name of temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, you can restart TiKV to make it automatically delete the temporary file and attempt to reclaim space.
++ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the defense is related to the size of the reserved space. The size of the reserved space is calculated as the maximum value between 5% of the disk capacity and this configuration item. When the value of this configuration item is `"0MB"`, TiKV disables this feature that protects the disk space.
 + Default value: `"5GB"`
 + Unite: MB|GB
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -324,9 +324,9 @@ Configuration items related to storage
 
 ### `reserve-space`
 
-+ When TiKV starts, a space is reserved to protect its disk space. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts in form: 80% of the reserved space is used as extra disk space required for operations when the disk space is insufficient, and the remaining 20% is used to save a temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file plays the role of the last defense for restoring services.
-+ The name of the temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, you can restart TiKV to make it automatically delete the temporary file and attempt to reclaim space.
-+ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the defense is related to the size of the reserved space. The size of the reserved space is calculated as the maximum value between 5% of the disk capacity and this configuration item. When the value of this configuration item is `"0MB"`, TiKV disables this feature that protects the disk space.
++ When TiKV is started, some space is reserved on the disk as disk protection. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts: 80% of the reserved space is used as the extra disk space required for operations when the disk space is insufficient, and the other 20% is used to store the temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file serves as the last protection for restoring services.
++ The name of the temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, if you restart TiKV, the temporary file is automatically deleted and TiKV tries to reclaim the space.
++ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the protection is related to the size of the reserved space. The size of the reserved space is the larger value between 5% of the disk capacity and this configuration value. When the value of this configuration item is `"0MB"`, TiKV disables this disk protection feature.
 + Default value: `"5GB"`
 + Unite: MB|GB
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -325,7 +325,7 @@ Configuration items related to storage
 ### `reserve-space`
 
 + When TiKV starts, a space is reserved to protect its disk space. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts in form: 80% of the reserved space is used as extra disk space required for operations when the disk space is insufficient, and the remaining 20% is used to save a temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file plays the role of the last defense for restoring services.
-+ The name of temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, you can restart TiKV to make it automatically delete the temporary file and attempt to reclaim space.
++ The name of the temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, you can restart TiKV to make it automatically delete the temporary file and attempt to reclaim space.
 + When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the defense is related to the size of the reserved space. The size of the reserved space is calculated as the maximum value between 5% of the disk capacity and this configuration item. When the value of this configuration item is `"0MB"`, TiKV disables this feature that protects the disk space.
 + Default value: `"5GB"`
 + Unite: MB|GB


### PR DESCRIPTION
### Which TiDB version(s) do your changes apply to? (Required)

Updated the description of `reserve-space` in "tikv-configuration-file.md".

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/7407
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
