### PR TITLE
Add doc for raftstore asynchronous write IO

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -705,7 +705,7 @@ Configuration items related to Raftstore
 
 + The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. If the value of this configuration item is `0`, it means that the Raft I/O is processed by the Raftstore thread, but not the StoreWriter thread. The size of the Raftstore thread pool is configured by `store-pool-size`. When modifying its size, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
 + Default value: `2`
-+ Minimum value: greater than `0`
++ Minimum value: `0`
 
 ### `future-poll-size`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -76,11 +76,11 @@ This document only describes the parameters that are not included in command-lin
 + The compression algorithm for gRPC messages
 + Optional values: `"none"`, `"deflate"`, `"gzip"`
 + Default value: `"none"`
-+ Note: When the value is `gzip`, TiDB Dashboard will have a display error because it might not complete the corresponding compression algorithm in some cases. If you adjust the value back to the default `none`, TiDB Dashboard will display normally. 
++ Note: When the value is `gzip`, TiDB Dashboard will have a display error because it might not complete the corresponding compression algorithm in some cases. If you adjust the value back to the default `none`, TiDB Dashboard will display normally.
 
 ### `grpc-concurrency`
 
-+ The number of gRPC worker threads
++ The number of gRPC worker threads. When modifying the size of the gRPC thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `5`
 + Minimum value: `1`
 
@@ -167,7 +167,7 @@ This document only describes the parameters that are not included in command-lin
 
 ### `raft-client-queue-size`
 
-+ Specifies the queue size of the Raft messages in TiKV. If too many messages not sent in time result in a full buffer, or messages discarded, you can specify a greater value to improve system stability. 
++ Specifies the queue size of the Raft messages in TiKV. If too many messages not sent in time result in a full buffer, or messages discarded, you can specify a greater value to improve system stability.
 + Default value: `8192`
 
 ## readpool.unified
@@ -181,7 +181,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 
 ### `max-thread-count`
 
-+ The maximum working thread count of the unified read pool
++ The maximum working thread count of the unified read pool, that is, the size of the UnifyReadPool thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `MAX(4, CPU * 0.8)`
 
 ### `stack-size`
@@ -319,7 +319,7 @@ Configuration items related to storage
 
 ### `scheduler-worker-pool-size`
 
-+ The number of `scheduler` threads, mainly used for checking transaction consistency before data writing. If the number of CPU cores is greater than or equal to `16`, the default value is `8`; otherwise, the default value is `4`.
++ The number of `scheduler` threads, mainly used for checking transaction consistency before data writing. If the number of CPU cores is greater than or equal to `16`, the default value is `8`; otherwise, the default value is `4`. When modifying the size of the Scheduler thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `4`
 + Minimum value: `1`
 
@@ -685,7 +685,7 @@ Configuration items related to Raftstore
 
 ### `apply-pool-size`
 
-+ The allowable number of threads in the pool that flushes data to storage
++ The allowable number of threads in the pool that flushes data to storage. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: greater than `0`
 
@@ -697,13 +697,13 @@ Configuration items related to Raftstore
 
 ### `store-pool-size`
 
-+ The allowable number of threads that process Raft. When the value of the configuration item [`store-io-pool-size`](#store-io-pool-size) is `0`, the Raftstore thread processes Raft I/O. In this case, if you need to modify the value of `store-pool-size`, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
++ The allowable number of threads that process Raft, that is, the size of the Raftstore thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: greater than `0`
 
-### `store-io-pool-size`<span class="version-mark">New in v5.3.0</span>
+### `store-io-pool-size` <span class="version-mark">New in v5.3.0</span>
 
-+ The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. If the value of this configuration item is `0`, it means that the Raft I/O is processed by the Raftstore thread, but not the StoreWriter thread. The size of the Raftstore thread pool is configured by `store-pool-size`. When modifying its size, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
++ The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: `0`
 
@@ -715,25 +715,25 @@ Configuration items related to Raftstore
 
 ### `cmd-batch`
 
-+ Controls whether to enable batch processing of the requests. When it is enabled, the write performance is significantly improved. 
++ Controls whether to enable batch processing of the requests. When it is enabled, the write performance is significantly improved.
 + Default value: `true`
 
 ### `inspect-interval`
 
-+ At a certain interval, TiKV inspects the latency of the Raftstore component. This parameter specifies the interval of the inspection. If the latency exceeds this value, this inspection is marked as timeout. 
-+ Judges whether the TiKV node is slow based on the ratio of timeout inspection. 
++ At a certain interval, TiKV inspects the latency of the Raftstore component. This parameter specifies the interval of the inspection. If the latency exceeds this value, this inspection is marked as timeout.
++ Judges whether the TiKV node is slow based on the ratio of timeout inspection.
 + Default value: `"500ms"`
 + Minimum value: `"1ms"`
 
-### `raft-write-size-limit`<span class="version-mark">New in v5.3.0</span>
-	
-+ The threshold value triggers data writing through Raft. When the data size is larger than the value of this configuration item, the data is written to the disk. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
+### `raft-write-size-limit` <span class="version-mark">New in v5.3.0</span>
+
++ Determines the threshold at which Raft data is written into the disk. If the data size is larger than the value of this configuration item, the data is written to the disk. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
 + Default value: `1MB`
 + Minimum value: `0`
-	
-### `raft-msg-flush-interval`<span class="version-mark">New in v5.3.0</span>
-	
-+ The interval between Raft messages are sent in batch. Raft messages are sent in batch every interval specified by this configuration item. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
+
+### `raft-msg-flush-interval` <span class="version-mark">New in v5.3.0</span>
+
++ Determines the interval at which Raft messages are sent in batches. The Raft messages in batches are sent every interval specified by this configuration item. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
 + Default value: `250us`
 + Minimum value: `0`
 
@@ -780,7 +780,7 @@ Configuration items related to RocksDB
 
 ### `max-background-jobs`
 
-+ The number of background threads in RocksDB
++ The number of background threads in RocksDB. When modifying the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `8`
 + Minimum value: `2`
 
@@ -1254,7 +1254,7 @@ Configuration items related to `raftdb`
 
 ### `max-background-jobs`
 
-+ The number of background threads in RocksDB
++ The number of background threads in RocksDB. When modifying the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `4`
 + Minimum value: `2`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -703,8 +703,7 @@ Configuration items related to Raftstore
 
 ### `store-io-pool-size`<span class="version-mark">New in v5.3.0</span>
 
-+ The allowable number of threads that process Raft
-+ + The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. If the value of this configuration item is `0`, it means that the Raft I/O is processed by the Raftstore thread, but not the StoreWriter thread. The size of the Raftstore thread pool is configured by `store-pool-size`. When modifying its size, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
++ The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. If the value of this configuration item is `0`, it means that the Raft I/O is processed by the Raftstore thread, but not the StoreWriter thread. The size of the Raftstore thread pool is configured by `store-pool-size`. When modifying its size, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
 + Default value: `2`
 + Minimum value: greater than `0`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -697,7 +697,14 @@ Configuration items related to Raftstore
 
 ### `store-pool-size`
 
++ The allowable number of threads that process Raft. When the value of the configuration item [`store-io-pool-size`](#store-io-pool-size) is `0`, the Raftstore thread processes Raft I/O. In this case, if you need to modify the value of `store-pool-size`, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
++ Default value: `2`
++ Minimum value: greater than `0`
+
+### `store-io-pool-size`<span class="version-mark">New in v5.3.0</span>
+
 + The allowable number of threads that process Raft
++ + The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. If the value of this configuration item is `0`, it means that the Raft I/O is processed by the Raftstore thread, but not the StoreWriter thread. The size of the Raftstore thread pool is configured by `store-pool-size`. When modifying its size, refer to [Tune TiKV Thread Pool Performance](/tune-tikv-thread-performance).
 + Default value: `2`
 + Minimum value: greater than `0`
 
@@ -718,6 +725,18 @@ Configuration items related to Raftstore
 + Judges whether the TiKV node is slow based on the ratio of timeout inspection. 
 + Default value: `"500ms"`
 + Minimum value: `"1ms"`
+
+### `raft-write-size-limit`<span class="version-mark">New in v5.3.0</span>
+	
++ The threshold value triggers data writing through Raft. When the data size is larger than the value of this configuration item, the data is written to the disk. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
++ Default value: `1MB`
++ Minimum value: `0`
+	
+### `raft-msg-flush-interval`<span class="version-mark">New in v5.3.0</span>
+	
++ The interval between Raft messages are sent in batch. Raft messages are sent in batch every interval specified by this configuration item. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
++ Default value: `250us`
++ Minimum value: `0`
 
 ## Coprocessor
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -80,7 +80,7 @@ This document only describes the parameters that are not included in command-lin
 
 ### `grpc-concurrency`
 
-+ The number of gRPC worker threads. When modifying the size of the gRPC thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The number of gRPC worker threads. When you modify the size of the gRPC thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `5`
 + Minimum value: `1`
 
@@ -181,7 +181,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 
 ### `max-thread-count`
 
-+ The maximum working thread count of the unified read pool, that is, the size of the UnifyReadPool thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The maximum working thread count of the unified read pool or the UnifyReadPool thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `MAX(4, CPU * 0.8)`
 
 ### `stack-size`
@@ -319,7 +319,7 @@ Configuration items related to storage
 
 ### `scheduler-worker-pool-size`
 
-+ The number of `scheduler` threads, mainly used for checking transaction consistency before data writing. If the number of CPU cores is greater than or equal to `16`, the default value is `8`; otherwise, the default value is `4`. When modifying the size of the Scheduler thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The number of `scheduler` threads, mainly used for checking transaction consistency before data writing. If the number of CPU cores is greater than or equal to `16`, the default value is `8`; otherwise, the default value is `4`. When you modify the size of the Scheduler thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `4`
 + Minimum value: `1`
 
@@ -685,7 +685,7 @@ Configuration items related to Raftstore
 
 ### `apply-pool-size`
 
-+ The allowable number of threads in the pool that flushes data to storage. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The allowable number of threads in the pool that flushes data to storage. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: greater than `0`
 
@@ -697,14 +697,14 @@ Configuration items related to Raftstore
 
 ### `store-pool-size`
 
-+ The allowable number of threads that process Raft, that is, the size of the Raftstore thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The allowable number of threads that process Raft, which is the size of the Raftstore thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: greater than `0`
 
 ### `store-io-pool-size` <span class="version-mark">New in v5.3.0</span>
 
-+ The allowable number of threads process Raft I/O, that is, the size of the StoreWriter thread pool. When modifying the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
-+ Default value: `2`
++ The allowable number of threads that process Raft I/O tasks, which is the size of the StoreWriter thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ Default value: `0`
 + Minimum value: `0`
 
 ### `future-poll-size`
@@ -733,7 +733,7 @@ Configuration items related to Raftstore
 
 ### `raft-msg-flush-interval` <span class="version-mark">New in v5.3.0</span>
 
-+ Determines the interval at which Raft messages are sent in batches. The Raft messages in batches are sent every interval specified by this configuration item. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
++ Determines the interval at which Raft messages are sent in batches. The Raft messages in batches are sent at every interval specified by this configuration item. When the value of `store-io-pool-size` is `0`, this configuration item does not take effect.
 + Default value: `250us`
 + Minimum value: `0`
 
@@ -780,7 +780,7 @@ Configuration items related to RocksDB
 
 ### `max-background-jobs`
 
-+ The number of background threads in RocksDB. When modifying the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The number of background threads in RocksDB. When you modify the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `8`
 + Minimum value: `2`
 
@@ -1254,7 +1254,7 @@ Configuration items related to `raftdb`
 
 ### `max-background-jobs`
 
-+ The number of background threads in RocksDB. When modifying the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The number of background threads in RocksDB. When you modify the size of the RocksDB thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `4`
 + Minimum value: `2`
 

--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -19,7 +19,7 @@ The TiKV thread pool is mainly composed of gRPC, Scheduler, UnifyReadPool, Rafts
 * The Raftstore thread pool:
 
     - It processes all Raft messages and the proposal to add a new log.
-    - It writes Raft logs to the disk. If the value of  [`store-io-pool-size`](/tikv-configuration-file.md#store-io-pool-size-new-in-530) is `0`, the Raftstore thread writes the logs to the disk; if the value is not `0`, the Raftstore thread sends the logs to the StoreWriter thread.
+    - It writes Raft logs to the disk. If the value of  [`store-io-pool-size`](/tikv-configuration-file.md#store-io-pool-size-new-in-v530) is `0`, the Raftstore thread writes the logs to the disk; if the value is not `0`, the Raftstore thread sends the logs to the StoreWriter thread.
     - When Raft logs in the majority of replicas are consistent, the Raftstore thread sends the logs to the Apply thread.
 
 * The StoreWriter thread pool: it writes all Raft logs to the disk and returns the result to the Raftstore thread.

--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -10,13 +10,19 @@ This document introduces TiKV internal thread pools and how to tune their perfor
 
 ## Thread pool introduction
 
-The TiKV thread pool is mainly composed of gRPC, Scheduler, UnifyReadPool, Raftstore, Apply, RocksDB, and some scheduled tasks and detection components that do not consume much CPU. This document mainly introduces a few CPU-intensive thread pools that affect the performance of read and write requests.
+The TiKV thread pool is mainly composed of gRPC, Scheduler, UnifyReadPool, Raftstore, StoreWriter, Apply, RocksDB, and some scheduled tasks and detection components that do not consume much CPU. This document mainly introduces a few CPU-intensive thread pools that affect the performance of read and write requests.
 
 * The gRPC thread pool: it handles all network requests and forwards requests of different task types to different thread pools.
 
 * The Scheduler thread pool: it detects write transaction conflicts, converts requests like the two-phase commit, pessimistic locking, and transaction rollbacks into key-value pair arrays, and then sends them to the Raftstore thread for Raft log replication.
 
-* The Raftstore thread pool: it processes all Raft messages and the proposal to add a new log, and writing the log to a disk. When the logs in the majority of replicas are consistent, this thread pool sends the log to the Apply thread.
+* The Raftstore thread pool: When the logs in the majority of replicas are consistent, this thread pool sends the log to the Apply thread.
+
+    - It processes all Raft messages and the proposal to add a new log
+    - It writes Raft logs to a disk. If the value of the configuration item [`store-io-pool-size`](/tikv-configuration-file.md#store-io-pool-size) is `0`, the Raftstore thread writes the logs to disk; if the value is not `0`, the Raftstore thread sends the log to the StoreWriter thread.
+    - When Raft logs in the majority of replicas are consistent, it sends the logs to the Apply thread.
+
+* The StoreWriter thread pool: it writes all Raft logs to the disk and returns the result to the Raftstore thread.
 
 * The Apply thread pool: it receives the submitted log sent from the Raftstore thread pool, parses it as a key-value request, then writes it to RocksDB, calls the callback function to notify the gRPC thread pool that the write request is complete, and returns the result to the client.
 
@@ -55,9 +61,22 @@ Starting from TiKV v5.0, all read requests use the unified thread pool for queri
 
 * The Raftstore thread pool.
 
-    The Raftstore thread pool is the most complex thread pool in TiKV. The default size (configured by `raftstore.store-pool-size`) is `2`. All write requests are written into RocksDB in the way of `fsync` from the Raftstore thread.
+    The Raftstore thread pool is the most complex thread pool in TiKV. The default size (configured by `raftstore.store-pool-size`) is `2`. For the StoreWriter thread pool, the default size (configured by `raftstore.store-io-pool-size`) is `0`.
 
-    Due to I/O, Raftstore threads cannot reach 100% CPU usage theoretically. To reduce disk writes as much as possible, you can put together multiple write requests and write them to RocksDB. It is recommended to keep the overall CPU usage below 60% (If the default number of threads is `2`, it is recommended to keep `TiKV-Details.Thread CPU.Raft store CPU` on Grafana within 120%). Do not increase the size of the Raftstore thread pool to improve write performance without thinking, because this might increase the disk burden and degrade performance.
+    - When the size of the StoreWriter thread pool is 0, All write requests are written into RocksDB in the way of `fsync` from the Raftstore thread. In this case, it is recommended to tune the performance as follows:
+
+        - It is recommended to keep the overall CPU usage of the Raftstore thread below 60%. When the number of Raftstore thread is 2, the **TiKV-Details**、**Thread CPU**、**Raft store CPU** on Grafana are needed to keep within 120%. Due to I/O, Raftstore threads cannot reach 100% CPU usage theoretically.
+        - Do not increase the size of the Raftstore thread pool to improve write performance without other reasons, because this might increase the disk burden and degrade performance.
+
+    - When the size of the StoreWriter thread pool is not 0, All write requests are written into RocksDB in the way of `fsync` from the StoreWriter thread. In this case, it is recommended to tune the performance as follows:
+
+        - It is recommended to only enable the StoreWriter thread pool when overall CPU resources are sufficient. When the StoreWriter thread pool is enabled, the CPU usage of the StoreWriter thread and the Raftstore thread should keep below 80%.
+
+          Compared with the case when the write requests are completed from the Raftstore thread, in theory, the write request processed from the StoreWriter thread can significantly reduce the write latency and the tail latency of data read. However, when the write speed grew faster, the number of Raft logs increased accordingly, which causes the CPU overhead to increase for Raftstore threads, Apply threads, and gRPC threads. In this case, insufficient CPU resources might offset the optimization effect. As a result, the write speed might become slower than before. Hence, if the CPU resources are not sufficient, it is not recommended to enable the StoreWriter thread. Since the Raftstore thread sends most of the I/O requests to the StoreWriter, the CPU usage of the Raftstore thread can keep below 80%.
+
+    - In most cases, the size of the StoreWriter thread pool can be set to 1 or 2. This is because the size of the StoreWriter thread pool affects the number of Raft logs, so the value of it should not be too large. If the CPU usage is higher than 80%, you can consider increasing its size.
+
+    - You need to pay attention to the impact of increasing Raft logs on the CPU overhead of other thread pools. If necessary, you need to increase the number of Raftstore threads, Apply threads, and gRPC threads accordingly.
 
 * The UnifyReadPool thread pool.
 

--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -68,7 +68,7 @@ Starting from TiKV v5.0, all read requests use the unified thread pool for queri
         - Keep the overall CPU usage of the Raftstore thread below 60%. When the number of Raftstore threads is 2, keep the **TiKV-Details**, **Thread CPU**, **Raft store CPU** on Grafana below 120%. Due to I/O requests, the CPU usage of Raftstore threads in theory is always lower than 100%.
         - Do not increase the size of the Raftstore thread pool to improve write performance without careful consideration, because this might increase the disk burden and degrade performance.
 
-    - When the size of the StoreWriter thread pool is not 0, all write requests are written into RocksDB in the way of `fsync` from the StoreWriter thread. In this case, it is recommended to tune the performance as follows:
+    - When the size of the StoreWriter thread pool is not 0, all write requests are written into RocksDB in the way of `fsync` by the StoreWriter thread. In this case, it is recommended to tune the performance as follows:
 
         - Enable the StoreWriter thread pool ONLY when the overall CPU resources are sufficient. When the StoreWriter thread pool is enabled, keep the CPU usage of the StoreWriter thread and the Raftstore thread below 80%.
 

--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -63,7 +63,7 @@ Starting from TiKV v5.0, all read requests use the unified thread pool for queri
 
     The Raftstore thread pool is the most complex thread pool in TiKV. The default size (configured by `raftstore.store-pool-size`) of this thread pool is `2`. For the StoreWriter thread pool, the default size (configured by `raftstore.store-io-pool-size`) is `0`.
 
-    - When the size of the StoreWriter thread pool is 0, all write requests are written into RocksDB in the way of `fsync` from the Raftstore thread. In this case, it is recommended to tune the performance as follows:
+    - When the size of the StoreWriter thread pool is 0, all write requests are written into RocksDB in the way of `fsync` by the Raftstore thread. In this case, it is recommended to tune the performance as follows:
 
         - Keep the overall CPU usage of the Raftstore thread below 60%. When the number of Raftstore threads is 2, keep the **TiKV-Details**, **Thread CPU**, **Raft store CPU** on Grafana below 120%. Due to I/O requests, the CPU usage of Raftstore threads in theory is always lower than 100%.
         - Do not increase the size of the Raftstore thread pool to improve write performance without careful consideration, because this might increase the disk burden and degrade performance.

--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -16,11 +16,11 @@ The TiKV thread pool is mainly composed of gRPC, Scheduler, UnifyReadPool, Rafts
 
 * The Scheduler thread pool: it detects write transaction conflicts, converts requests like the two-phase commit, pessimistic locking, and transaction rollbacks into key-value pair arrays, and then sends them to the Raftstore thread for Raft log replication.
 
-* The Raftstore thread pool: When the logs in the majority of replicas are consistent, this thread pool sends the log to the Apply thread.
+* The Raftstore thread pool:
 
     - It processes all Raft messages and the proposal to add a new log.
-    - It writes Raft logs to a disk. If the value of the configuration item [`store-io-pool-size`](/tikv-configuration-file.md#store-io-pool-size-new-in-530) is `0`, the Raftstore thread writes the logs to disk; if the value is not `0`, the Raftstore thread sends the logs to the StoreWriter thread.
-    - When Raft logs in the majority of replicas are consistent, it sends the logs to the Apply thread.
+    - It writes Raft logs to the disk. If the value of  [`store-io-pool-size`](/tikv-configuration-file.md#store-io-pool-size-new-in-530) is `0`, the Raftstore thread writes the logs to the disk; if the value is not `0`, the Raftstore thread sends the logs to the StoreWriter thread.
+    - When Raft logs in the majority of replicas are consistent, the Raftstore thread sends the logs to the Apply thread.
 
 * The StoreWriter thread pool: it writes all Raft logs to the disk and returns the result to the Raftstore thread.
 
@@ -61,22 +61,22 @@ Starting from TiKV v5.0, all read requests use the unified thread pool for queri
 
 * The Raftstore thread pool.
 
-    The Raftstore thread pool is the most complex thread pool in TiKV. The default size (configured by `raftstore.store-pool-size`) of this thread pool is `2`. For the StoreWriter thread pool, the default size (configured by `raftstore.store-io-pool-size`) of it is `0`.
+    The Raftstore thread pool is the most complex thread pool in TiKV. The default size (configured by `raftstore.store-pool-size`) of this thread pool is `2`. For the StoreWriter thread pool, the default size (configured by `raftstore.store-io-pool-size`) is `0`.
 
     - When the size of the StoreWriter thread pool is 0, all write requests are written into RocksDB in the way of `fsync` from the Raftstore thread. In this case, it is recommended to tune the performance as follows:
 
-        - Keep the overall CPU usage of the Raftstore thread below 60%. When the number of Raftstore thread is 2, the **TiKV-Details**、**Thread CPU**、**Raft store CPU** on Grafana are needed to keep within 120%. Due to I/O requests, Raftstore threads cannot reach 100% CPU usage theoretically.
-        - Do not increase the size of the Raftstore thread pool to improve write performance without consideration, because this might increase the disk burden and degrade performance.
+        - Keep the overall CPU usage of the Raftstore thread below 60%. When the number of Raftstore threads is 2, keep the **TiKV-Details**, **Thread CPU**, **Raft store CPU** on Grafana below 120%. Due to I/O requests, the CPU usage of Raftstore threads in theory is always lower than 100%.
+        - Do not increase the size of the Raftstore thread pool to improve write performance without careful consideration, because this might increase the disk burden and degrade performance.
 
     - When the size of the StoreWriter thread pool is not 0, all write requests are written into RocksDB in the way of `fsync` from the StoreWriter thread. In this case, it is recommended to tune the performance as follows:
 
-        - Only enable the StoreWriter thread pool when overall CPU resources are sufficient. When the StoreWriter thread pool is enabled, keep the CPU usage of the StoreWriter thread and the Raftstore thread below 80%.
+        - Enable the StoreWriter thread pool ONLY when the overall CPU resources are sufficient. When the StoreWriter thread pool is enabled, keep the CPU usage of the StoreWriter thread and the Raftstore thread below 80%.
 
-          Compared with the case that the write requests are completed from the Raftstore thread, in theory, the write requests processed from the StoreWriter thread can significantly reduce write latency and tail latency of data read. However, when the write speed grows faster, the number of Raft logs increases accordingly. This can cause the CPU overhead to increase for the Raftstore threads, the Apply threads, and the gRPC threads. In this case, insufficient CPU resources might offset the optimization effect, and as a result, the write speed might become slower than before. Hence, if the CPU resources are not sufficient, it is not recommended to enable the StoreWriter thread. Since the Raftstore thread sends most of the I/O requests to the StoreWriter thread, the CPU usage of the Raftstore thread need to keep below 80%.
+         Compared with the case that the write requests are processed by the Raftstore thread, in theory, when the write requests are processed by the StoreWriter thread, write latency and the tail latency of data read are significantly reduced. However, as the write speed grows faster, the number of Raft logs increases accordingly. This can cause the CPU overhead of the Raftstore threads, the Apply threads, and the gRPC threads to increase. In this case, insufficient CPU resources might offset the tuning effect, and as a result, the write speed might become slower than before. Therefore, if the CPU resources are not sufficient, it is not recommended to enable the StoreWriter thread. Because the Raftstore thread sends most of the I/O requests to the StoreWriter thread, you need to keep the CPU usage of the Raftstore thread below 80%.
 
-    - In most cases, the size of the StoreWriter thread pool can be set to 1 or 2. This is because the size of the StoreWriter thread pool affects the number of Raft logs, so the value of it should not be too large. If the CPU usage is higher than 80%, you can consider increasing its size.
+    - In most cases, set the size of the StoreWriter thread pool to 1 or 2. This is because the size of the StoreWriter thread pool affects the number of Raft logs, so the value of the thread pool size should not be too large. If the CPU usage is higher than 80%, consider increasing the thread pool size.
 
-    - You need to pay attention to the impact of increasing Raft logs on the CPU overhead of other thread pools. If necessary, you need to increase the number of the Raftstore threads, the Apply threads, and the gRPC threads accordingly.
+    - Pay attention to the impact of increasing Raft logs on the CPU overhead of other thread pools. If necessary, you need to increase the number of Raftstore threads, Apply threads, and gRPC threads accordingly.
 
 * The UnifyReadPool thread pool.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Added new configuration items `store-io-pool-size`, `raft-write-size-limit`, `raft-msg-flush-interval`.
- Updated the configuration item `store-pool-size`.
- Updated the contents related to the StoreWriter thread pool in "tune-tikv-thread-performance.md".

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/7628
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
