### PR TITLE
Move part of SELECT incompatibility to detailed page

### DIFF
--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -114,7 +114,9 @@ These differences are documented further in [`ANALYZE TABLE`](/sql-statements/sq
 
 - The syntax `SELECT ... INTO @variable` is not supported.
 - The syntax `SELECT ... GROUP BY ... WITH ROLLUP` is not supported.
-- The syntax `SELECT .. GROUP BY expr` does not imply `GROUP BY expr ORDER BY expr` as it does in MySQL 5.7. TiDB instead matches the behavior of MySQL 8.0 and does not imply a default order.
+- The syntax `SELECT .. GROUP BY expr` does not imply `GROUP BY expr ORDER BY expr` as it does in MySQL 5.7.
+
+For details, see [`SELECT`](/sql-statements/sql-statement-select.md) statement reference.
 
 ### Views
 

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -116,7 +116,7 @@ These differences are documented further in [`ANALYZE TABLE`](/sql-statements/sq
 - The syntax `SELECT ... GROUP BY ... WITH ROLLUP` is not supported.
 - The syntax `SELECT .. GROUP BY expr` does not imply `GROUP BY expr ORDER BY expr` as it does in MySQL 5.7.
 
-For details, see [`SELECT`](/sql-statements/sql-statement-select.md) statement reference.
+For details, see the [`SELECT`](/sql-statements/sql-statement-select.md) statement reference.
 
 ### Views
 

--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -133,7 +133,9 @@ mysql> SELECT * FROM t1;
 
 ## MySQL compatibility
 
-This statement is understood to be fully compatible with MySQL. Any compatibility differences should be [reported via an issue](https://github.com/pingcap/tidb/issues/new/choose) on GitHub.
+- The syntax `SELECT ... INTO @variable` is not supported.
+- The syntax `SELECT ... GROUP BY ... WITH ROLLUP` is not supported.
+- The syntax `SELECT .. GROUP BY expr` does not imply `GROUP BY expr ORDER BY expr` as it does in MySQL 5.7. TiDB instead matches the behavior of MySQL 8.0 and does not imply a default order.
 
 ## See also
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix https://github.com/pingcap/docs/issues/7048

We should describe the `SELECT` incompatibilities on both mysql compatibility and SELECT statement reference. To reduce duplication, I have edited the description on mysql compatibility to be just the facts. There is slightly more detail on the SELECT page.

This should be the standard we use for documenting compatibility, since otherwise the MySQL compatibilty page gets too long as we improve it.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
