### PR TITLE
TiUP playground: fix wrong command-line flags

### DIFF
--- a/tiup/tiup-playground.md
+++ b/tiup/tiup-playground.md
@@ -31,8 +31,8 @@ The command-line flags of the playground component are described as follows:
 ```bash
 Flags:
       --db int                   Specify the number of TiDB instances (default: 1)
-      ----db.host host           Specify the listening address of TiDB
-      ----db.port int            Specify the port of TiDB
+      --db.host host           Specify the listening address of TiDB
+      --db.port int            Specify the port of TiDB
       --db.binpath string        Specify the TiDB instance binary path (optional, for debugging)
       --db.config string         Specify the TiDB instance configuration file (optional, for debugging)
       --db.timeout int           Specify TiDB maximum wait time in seconds for starting. 0 means no limit


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Fixed wrong command-line flags `----db.host host` and `----db.port int` according to the Chinese docs.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
