### PR TITLE
chore: remove useless aliases for DM Dev docs

### DIFF
--- a/dm/deploy-a-dm-cluster-using-tiup.md
+++ b/dm/deploy-a-dm-cluster-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a DM Cluster Using TiUP
 summary: Learn how to deploy TiDB Data Migration using TiUP DM.
-aliases: ['/docs/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible/','/docs/tools/dm/deployment/','/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible']
+aliases: ['/docs/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible/','/docs/tools/dm/deployment/']
 ---
 
 # Deploy a DM Cluster Using TiUP

--- a/dm/dm-alert-rules.md
+++ b/dm/dm-alert-rules.md
@@ -1,7 +1,6 @@
 ---
 title: DM Alert Information
 summary: Introduce the alert information of DM.
-aliases: ['/tidb-data-migration/dev/alert-rules/']
 ---
 
 # DM Alert Information

--- a/dm/dm-benchmark-v5.3.0.md
+++ b/dm/dm-benchmark-v5.3.0.md
@@ -1,7 +1,6 @@
 ---
 title: DM 5.3.0 Benchmark Report
 summary: Learn about the performance of 5.3.0.
-aliases: ['/tidb-data-migration/dev/benchmark-v5.3.0/']
 ---
 
 # DM 5.3.0 Benchmark Report

--- a/dm/dm-command-line-flags.md
+++ b/dm/dm-command-line-flags.md
@@ -1,7 +1,6 @@
 ---
 title: Command-line Flags
 summary: Learn about the command-line flags in DM.
-aliases: ['/tidb-data-migration/dev/command-line-flags/']
 ---
 
 # Command-line Flags

--- a/dm/dm-config-overview.md
+++ b/dm/dm-config-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Data Migration Configuration File Overview
 summary: This document gives an overview of Data Migration configuration files.
-aliases: ['/docs/tidb-data-migration/dev/config-overview/','/tidb-data-migration/dev/config-overview/']
+aliases: ['/docs/tidb-data-migration/dev/config-overview/']
 ---
 
 # Data Migration Configuration File Overview

--- a/dm/dm-create-task.md
+++ b/dm/dm-create-task.md
@@ -1,7 +1,6 @@
 ---
 title: Create a Data Migration Task
 summary: Learn how to create a data migration task in TiDB Data Migration.
-aliases: ['/tidb-data-migration/dev/create-task/']
 ---
 
 # Create a Data Migration Task

--- a/dm/dm-daily-check.md
+++ b/dm/dm-daily-check.md
@@ -1,7 +1,7 @@
 ---
 title: Daily Check
 summary: Learn about the daily check of TiDB Data Migration (DM).
-aliases: ['/docs/tidb-data-migration/dev/daily-check/','/tidb-data-migration/dev/daily-check/']
+aliases: ['/docs/tidb-data-migration/dev/daily-check/']
 ---
 
 # Daily Check

--- a/dm/dm-enable-tls.md
+++ b/dm/dm-enable-tls.md
@@ -1,7 +1,6 @@
 ---
 title: Enable TLS for DM Connections
 summary: Learn how to enable TLS for DM connections.
-aliases: ['/tidb-data-migration/dev/enable-tls/']
 ---
 
 # Enable TLS for DM Connections

--- a/dm/dm-error-handling.md
+++ b/dm/dm-error-handling.md
@@ -1,7 +1,7 @@
 ---
 title: Handle Errors
 summary: Learn about the error system and how to handle common errors when you use DM.
-aliases: ['/docs/tidb-data-migration/dev/error-handling/','/docs/tidb-data-migration/dev/troubleshoot-dm/','/docs/tidb-data-migration/dev/error-system/','/tidb-data-migration/dev/error-system/','/tidb-data-migration/dev/error-handling/']
+aliases: ['/docs/tidb-data-migration/dev/error-handling/','/docs/tidb-data-migration/dev/troubleshoot-dm/','/docs/tidb-data-migration/dev/error-system/']
 ---
 
 # Handle Errors

--- a/dm/dm-export-import-config.md
+++ b/dm/dm-export-import-config.md
@@ -1,7 +1,6 @@
 ---
 title: Export and Import Data Sources and Task Configuration of Clusters
 summary: Learn how to export and import data sources and task configuration of clusters when you use DM.
-aliases: ['/tidb-data-migration/dev/export-import-config/']
 ---
 
 # Export and Import Data Sources and Task Configuration of Clusters

--- a/dm/dm-faq.md
+++ b/dm/dm-faq.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration FAQ
 summary: Learn about frequently asked questions (FAQs) about TiDB Data Migration (DM).
-aliases: ['/docs/tidb-data-migration/dev/faq/','/tidb-data-migration/dev/faq/']
+aliases: ['/docs/tidb-data-migration/dev/faq/']
 ---
 
 # TiDB Data Migration FAQ

--- a/dm/dm-generate-self-signed-certificates.md
+++ b/dm/dm-generate-self-signed-certificates.md
@@ -1,7 +1,6 @@
 ---
 title: Generate Self-signed Certificates
 summary: Use `openssl` to generate self-signed certificates.
-aliases: ['/tidb-data-migration/dev/generate-self-signed-certificates/']
 ---
 
 # Generate Self-signed Certificates

--- a/dm/dm-glossary.md
+++ b/dm/dm-glossary.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration Glossary
 summary: Learn the terms used in TiDB Data Migration.
-aliases: ['/docs/tidb-data-migration/dev/glossary/','/tidb-data-migration/dev/glossary/']
+aliases: ['/docs/tidb-data-migration/dev/glossary/']
 ---
 
 # TiDB Data Migration Glossary

--- a/dm/dm-handle-alerts.md
+++ b/dm/dm-handle-alerts.md
@@ -1,7 +1,6 @@
 ---
 title: Handle Alerts
 summary: Understand how to deal with the alert information in DM.
-aliases: ['/tidb-data-migration/dev/handle-alerts/']
 ---
 
 # Handle Alerts

--- a/dm/dm-handle-performance-issues.md
+++ b/dm/dm-handle-performance-issues.md
@@ -1,7 +1,6 @@
 ---
 title: Handle Performance Issues
 summary: Learn about common performance issues that might exist in DM and how to deal with them.
-aliases: ['/tidb-data-migration/dev/handle-performance-issues/']
 ---
 
 # Handle Performance Issues

--- a/dm/dm-hardware-and-software-requirements.md
+++ b/dm/dm-hardware-and-software-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Software and Hardware Requirements
 summary: Learn the software and hardware requirements for DM cluster.
-aliases: ['/docs/tidb-data-migration/dev/hardware-and-software-requirements/','/tidb-data-migration/dev/hardware-and-software-requirements/']
+aliases: ['/docs/tidb-data-migration/dev/hardware-and-software-requirements/']
 ---
 
 # Software and Hardware Requirements

--- a/dm/dm-key-features.md
+++ b/dm/dm-key-features.md
@@ -1,7 +1,7 @@
 ---
 title: Key Features
 summary: Learn about the key features of DM and appropriate parameter configurations.
-aliases: ['/docs/tidb-data-migration/dev/feature-overview/','/tidb-data-migration/dev/feature-overview','/tidb-data-migration/dev/key-features/']
+aliases: ['/docs/tidb-data-migration/dev/feature-overview/']
 ---
 
 # Key Features

--- a/dm/dm-manage-schema.md
+++ b/dm/dm-manage-schema.md
@@ -1,7 +1,6 @@
 ---
 title: Manage Table Schemas of Tables to be Migrated
 summary: Learn how to manage the schema of the table to be migrated in DM.
-aliases: ['/tidb-data-migration/dev/manage-schema/']
 ---
 
 # Manage Table Schemas of Tables to be Migrated

--- a/dm/dm-manage-source.md
+++ b/dm/dm-manage-source.md
@@ -1,7 +1,6 @@
 ---
 title: Manage Data Source Configurations
 summary: Learn how to manage upstream MySQL instances in TiDB Data Migration.
-aliases: ['/tidb-data-migration/dev/manage-source/']
 ---
 
 # Manage Data Source Configurations

--- a/dm/dm-open-api.md
+++ b/dm/dm-open-api.md
@@ -1,7 +1,6 @@
 ---
 title: Maintain DM Clusters Using OpenAPI
 summary: Learn about how to use OpenAPI interface to manage the cluster status and data replication.
-aliases: ['/tidb-data-migration/dev/open-api/']
 ---
 
 # Maintain DM Clusters Using OpenAPI

--- a/dm/dm-overview.md
+++ b/dm/dm-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Data Migration Overview
 summary: Learn about the Data Migration tool, the architecture, the key components, and features.
-aliases: ['/docs/tidb-data-migration/dev/overview/','/tidb-data-migration/dev/overview/']
+aliases: ['/docs/tidb-data-migration/dev/overview/']
 ---
 
 <!-- markdownlint-disable MD007 -->

--- a/dm/dm-pause-task.md
+++ b/dm/dm-pause-task.md
@@ -1,7 +1,6 @@
 ---
 title: Pause a Data Migration Task
 summary: Learn how to pause a data migration task in TiDB Data Migration.
-aliases: ['/tidb-data-migration/dev/pause-task/']
 ---
 
 # Pause a Data Migration Task

--- a/dm/dm-performance-test.md
+++ b/dm/dm-performance-test.md
@@ -1,7 +1,6 @@
 ---
 title: DM Cluster Performance Test
 summary: Learn how to test the performance of DM clusters.
-aliases: ['/tidb-data-migration/dev/performance-test/']
 ---
 
 # DM Cluster Performance Test

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -1,7 +1,7 @@
 ---
 title: Precheck the Upstream MySQL Instance Configurations
 summary: Learn how to use the precheck feature provided by DM to detect errors in the upstream MySQL instance configurations.
-aliases: ['/docs/tidb-data-migration/dev/precheck/','/tidb-data-migration/dev/precheck/']
+aliases: ['/docs/tidb-data-migration/dev/precheck/']
 ---
 
 # Precheck the Upstream MySQL Instance Configurations

--- a/dm/dm-query-status.md
+++ b/dm/dm-query-status.md
@@ -1,7 +1,7 @@
 ---
 title: Query Status
 summary: Learn how to query the status of a data replication task.
-aliases: ['/docs/tidb-data-migration/dev/query-status/','/tidb-data-migration/dev/query-error/','/tidb-data-migration/dev/query-status/']
+aliases: ['/docs/tidb-data-migration/dev/query-status/']
 ---
 
 # Query Status

--- a/dm/dm-resume-task.md
+++ b/dm/dm-resume-task.md
@@ -1,7 +1,6 @@
 ---
 title: Resume a Data Migration Task
 summary: Learn how to resume a data migration task.
-aliases: ['/tidb-data-migration/dev/resume-task/']
 ---
 
 # Resume a Data Migration Task

--- a/dm/dm-source-configuration-file.md
+++ b/dm/dm-source-configuration-file.md
@@ -1,7 +1,7 @@
 ---
 title: Upstream Database Configuration File
 summary: Learn the configuration file of the upstream database
-aliases: ['/docs/tidb-data-migration/dev/source-configuration-file/','/tidb-data-migration/dev/source-configuration-file/']
+aliases: ['/docs/tidb-data-migration/dev/source-configuration-file/']
 ---
 
 # Upstream Database Configuration File

--- a/dm/dm-stop-task.md
+++ b/dm/dm-stop-task.md
@@ -1,7 +1,6 @@
 ---
 title: Stop a Data Migration Task
 summary: Learn how to stop a data migration task.
-aliases: ['/tidb-data-migration/dev/stop-task/']
 ---
 
 # Stop a Data Migration Task

--- a/dm/dm-task-configuration-guide.md
+++ b/dm/dm-task-configuration-guide.md
@@ -1,7 +1,6 @@
 ---
 title: Data Migration Task Configuration Guide
 summary: Learn how to configure a data migration task in Data Migration (DM).
-aliases: ['/tidb-data-migration/dev/task-configuration-guide/']
 ---
 
 # Data Migration Task Configuration Guide

--- a/dm/dm-tune-configuration.md
+++ b/dm/dm-tune-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Optimize Configuration of DM
 summary: Learn how to optimize the configuration of the data migration task to improve the performance of data migration.
-aliases: ['/tidb-data-migration/dev/tune-configuration/']
 ---
 
 # Optimize Configuration of DM

--- a/dm/dmctl-introduction.md
+++ b/dm/dmctl-introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Maintain DM Clusters Using dmctl
 summary: Learn how to maintain a DM cluster using dmctl.
-aliases: ['/docs/tidb-data-migration/dev/manage-replication-tasks/','/tidb-data-migration/dev/manage-replication-tasks/']
+aliases: ['/docs/tidb-data-migration/dev/manage-replication-tasks/']
 ---
 
 # Maintain DM Clusters Using dmctl

--- a/dm/feature-online-ddl.md
+++ b/dm/feature-online-ddl.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate from Databases that Use GH-ost/PT-osc
 summary: This document introduces the `online-ddl/online-ddl-scheme` feature of DM.
-aliases: ['/docs/tidb-data-migration/dev/online-ddl-scheme/','/tidb-data-migration/dev/online-ddl-scheme/','tidb-data-migration/dev/feature-online-ddl-scheme']
+aliases: ['/docs/tidb-data-migration/dev/online-ddl-scheme/','tidb-data-migration/dev/feature-online-ddl-scheme']
 ---
 
 # Migrate from Databases that Use GH-ost/PT-osc

--- a/dm/handle-failed-ddl-statements.md
+++ b/dm/handle-failed-ddl-statements.md
@@ -1,7 +1,7 @@
 ---
 title: Handle Failed DDL Statements
 summary: Learn how to handle failed DDL statements when you're using the TiDB Data Migration tool to migrate data.
-aliases: ['/docs/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements','/tidb-data-migration/dev/handle-failed-sql-statements']
+aliases: ['/docs/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/']
 ---
 
 # Handle Failed DDL Statements

--- a/dm/maintain-dm-using-tiup.md
+++ b/dm/maintain-dm-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: Maintain a DM Cluster Using TiUP
 summary: Learn how to maintain a DM cluster using TiUP.
-aliases: ['/docs/tidb-data-migration/dev/cluster-operations/','/tidb-data-migration/dev/cluster-operations']
+aliases: ['/docs/tidb-data-migration/dev/cluster-operations/']
 ---
 
 # Maintain a DM Cluster Using TiUP

--- a/dm/manually-handling-sharding-ddl-locks.md
+++ b/dm/manually-handling-sharding-ddl-locks.md
@@ -1,7 +1,7 @@
 ---
 title: Handle Sharding DDL Locks Manually in DM
 summary: Learn how to handle sharding DDL locks manually in DM.
-aliases: ['/docs/tidb-data-migration/dev/feature-manually-handling-sharding-ddl-locks/','/tidb-data-migration/dev/feature-manually-handling-sharding-ddl-locks/']
+aliases: ['/docs/tidb-data-migration/dev/feature-manually-handling-sharding-ddl-locks/']
 ---
 
 # Handle Sharding DDL Locks Manually in DM

--- a/dm/migrate-data-using-dm.md
+++ b/dm/migrate-data-using-dm.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate Data Using Data Migration
 summary: Use the Data Migration tool to migrate the full data and the incremental data.
-aliases: ['/docs/tidb-data-migration/dev/replicate-data-using-dm/','/tidb-data-migration/dev/replicate-data-using-dm']
+aliases: ['/docs/tidb-data-migration/dev/replicate-data-using-dm/']
 ---
 
 # Migrate Data Using Data Migration

--- a/dm/quick-start-create-task.md
+++ b/dm/quick-start-create-task.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Data Migration Task
 summary: Learn how to create a migration task after the DM cluster is deployed.
-aliases: ['/docs/tidb-data-migration/dev/create-task-and-verify/','/tidb-data-migration/dev/create-task-and-verify']
+aliases: ['/docs/tidb-data-migration/dev/create-task-and-verify/']
 ---
 
 # Create a Data Migration Task

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration Quick Start
 summary: Learn how to quickly deploy a DM cluster using binary packages.
-aliases: ['/docs/tidb-data-migration/dev/get-started/','/tidb-data-migration/dev/get-started']
+aliases: ['/docs/tidb-data-migration/dev/get-started/']
 ---
 
 # Quick Start Guide for TiDB Data Migration

--- a/dm/task-configuration-file-full.md
+++ b/dm/task-configuration-file-full.md
@@ -1,6 +1,6 @@
 ---
 title: DM Advanced Task Configuration File
-aliases: ['/docs/tidb-data-migration/dev/task-configuration-file-full/','/docs/tidb-data-migration/dev/dm-portal/','/tidb-data-migration/dev/dm-portal']
+aliases: ['/docs/tidb-data-migration/dev/task-configuration-file-full/','/docs/tidb-data-migration/dev/dm-portal/']
 ---
 
 # DM Advanced Task Configuration File

--- a/dm/usage-scenario-simple-migration.md
+++ b/dm/usage-scenario-simple-migration.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate Data from Multiple Data Sources to TiDB
 summary: Learn how to use Data Migration to migrate data from multiple data sources to TiDB.
-aliases: ['/docs/tidb-data-migration/dev/usage-scenario-simple-replication/','/tidb-data-migration/dev/usage-scenario-simple-replication']
+aliases: ['/docs/tidb-data-migration/dev/usage-scenario-simple-replication/']
 ---
 
 # Using Migrate Data from Multiple Data Sources to TiDB


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR removes useless aliases that start with '/tidb-data-migration/dev/' for DM Dev docs. Those aliases are useless because all the existing DM Dev docs will be directed to https://docs.pingcap.com/tidb/dev/dm-overview so users could be aware of the doc location changes easily.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/8083
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
