### PR TITLE
Update tikv rocksdb enum type configurations

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -817,14 +817,12 @@ Configuration items related to RocksDB
 ### `wal-recovery-mode`
 
 + WAL recovery mode
-+ Value options: `0`, `1`, `2`, `3`
-+ `0` (`TolerateCorruptedTailRecords`): tolerates and discards the records that have incomplete trailing data on all logs.
-+ `1` (`AbsoluteConsistency`): abandons recovery when corrupted logs are found.
-+ `2` (`PointInTimeRecovery`): recovers log sequentially until the first corrupted log is encountered.
-+ `3` (`SkipAnyCorruptedRecords`): recovery after a disaster. Corrupted records are skipped
-+ Default value: `2`
-+ Minimum value: `0`
-+ Maximum value: `3`
++ Value options:
++ `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs.
++ `"absolute-consistency"`: abandons recovery when corrupted logs are found.
++ `"point-in-time"`: recovers log sequentially until the first corrupted log is encountered.
++ `"skip-any-corrupted-records"`: recovery after a disaster. Corrupted records are skipped
++ Default value: `"point-in-time"`
 
 ### `wal-dir`
 
@@ -884,10 +882,8 @@ Configuration items related to RocksDB
 ### `rate-limiter-mode`
 
 + RocksDB's compaction rate limiter mode
-+ Optional values: `1` (`ReadOnly`), `2` (`WriteOnly`), `3` (`AllIo`)
-+ Default value: `2`
-+ Minimum value: `1`
-+ Maximum value: `3`
++ Optional values: `"read-only"`, `"write-only"`, `"all-io"`)
++ Default value: `"write-only"`
 
 ### `rate-limiter-auto-tuned` <span class="version-mark">New in v5.0</span>
 
@@ -1110,9 +1106,9 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 ### `compaction-pri`
 
 + The priority type of compaction
-+ Optional values: `0` (`ByCompensatedSize`), `1` (`OldestLargestSeqFirst`), `2` (`OldestSmallestSeqFirst`), `3` (`MinOverlappingRatio`)
-+ Default value for `defaultcf` and `writecf`: `3`
-+ Default value for `lockcf`: `0`
++ Optional values: `"by-compensated-size"`, `"oldest-largest-seq-first"`, `"oldest-smallest-seq-first"`, `"min-overlapping-ratio"`
++ Default value for `defaultcf` and `writecf`: `"min-overlapping-ratio"`
++ Default value for `lockcf`: `"by-compensated-size"`
 
 ### `dynamic-level-bytes`
 
@@ -1132,7 +1128,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 ### `compaction-style`
 
 + Compaction method
-+ Optional values: `"level"`, `"universal"`
++ Optional values: `"level"`, `"universal"`, `"fifo"`
 + Default value: `"level"`
 
 ### `disable-auto-compactions`

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -818,10 +818,10 @@ Configuration items related to RocksDB
 
 + WAL recovery mode
 + Value options:
-+ `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs.
-+ `"absolute-consistency"`: abandons recovery when corrupted logs are found.
-+ `"point-in-time"`: recovers log sequentially until the first corrupted log is encountered.
-+ `"skip-any-corrupted-records"`: recovery after a disaster. Corrupted records are skipped
++    - `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs
++    - `"absolute-consistency"`: abandons recovery when corrupted logs are found
++    - `"point-in-time"`: recovers log sequentially until the first corrupted log is encountered
++    - `"skip-any-corrupted-records"`: recovery after a disaster. Corrupted records are skipped
 + Default value: `"point-in-time"`
 
 ### `wal-dir`
@@ -882,7 +882,7 @@ Configuration items related to RocksDB
 ### `rate-limiter-mode`
 
 + RocksDB's compaction rate limiter mode
-+ Optional values: `"read-only"`, `"write-only"`, `"all-io"`)
++ Optional values: `"read-only"`, `"write-only"`, `"all-io"`
 + Default value: `"write-only"`
 
 ### `rate-limiter-auto-tuned` <span class="version-mark">New in v5.0</span>

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -817,11 +817,11 @@ Configuration items related to RocksDB
 ### `wal-recovery-mode`
 
 + WAL recovery mode
-+ Value options:
-+    - `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs
-+    - `"absolute-consistency"`: abandons recovery when corrupted logs are found
-+    - `"point-in-time"`: recovers log sequentially until the first corrupted log is encountered
-+    - `"skip-any-corrupted-records"`: recovery after a disaster. Corrupted records are skipped
++ Optional values:
+    + `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs
+    + `"absolute-consistency"`: abandons recovery when corrupted logs are found
+    + `"point-in-time"`: recovers logs sequentially until the first corrupted log is encountered
+    + `"skip-any-corrupted-records"`: recovers after a disaster. The data is recovered as much as possible, and the corrupted records are skipped.
 + Default value: `"point-in-time"`
 
 ### `wal-dir`

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -821,7 +821,7 @@ Configuration items related to RocksDB
     + `"tolerate-corrupted-tail-records"`: tolerates and discards the records that have incomplete trailing data on all logs
     + `"absolute-consistency"`: abandons recovery when corrupted logs are found
     + `"point-in-time"`: recovers logs sequentially until the first corrupted log is encountered
-    + `"skip-any-corrupted-records"`: recovers after a disaster. The data is recovered as much as possible, and the corrupted records are skipped.
+    + `"skip-any-corrupted-records"`: post-disaster recovery. The data is recovered as much as possible, and corrupted records are skipped.
 + Default value: `"point-in-time"`
 
 ### `wal-dir`


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What is changed, added or deleted? (Required)

Using string literals was supported in https://github.com/tikv/tikv/pull/11068.

This configuration change will **not** break backward compatibility. Old settings are still accepted.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?


### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
