### PR TITLE
hardware-and-software-requirements: explicitly exclude Ubuntu 21.10

### DIFF
--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -23,8 +23,9 @@ As an open source distributed NewSQL database with high performance, TiDB can be
 > - A large number of TiDB tests have been run on the CentOS 7.3 system, and in our community there are a lot of best practices in which TiDB is deployed on the Linux operating system. Therefore, it is recommended to deploy TiDB on CentOS 7.3 or later.
 > - The support for the Linux operating systems above includes the deployment and operation in physical servers as well as in major virtualized environments like VMware, KVM and XEN.
 > - Red Hat Enterprise Linux 8.0, CentOS 8 Stream, and Oracle Enterprise Linux 8.0 are not supported yet as the testing of these platforms is in progress.
-> - Support for CentOS 8 Linux is not planned because its upstream support ends on December 31, 2021.
-> - Support for Ubuntu 16.04 will be removed in future versions of TiDB. Upgrading to Ubuntu 18.04 or later is strongly recommended.
+> - Support for CentOS 8 Linux is not planned because its upstream support ended on December 31, 2021.
+> - Support for Ubuntu 16.04 LTS will be removed in future versions of TiDB. Upgrading to Ubuntu 18.04 or later is strongly recommended.
+> - Ubuntu 21.10 and newer are not supported.
 
 Other Linux OS versions such as Debian Linux and Fedora Linux might work but are not officially supported.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Explictly exclude Ubuntu 21.10 from the list of supported operating systems as current TiFlash versions can't work with new glibc versions.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)
