### PR TITLE
List Amazon Linux 2 as supported

### DIFF
--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -15,6 +15,7 @@ As an open source distributed NewSQL database with high performance, TiDB can be
 | Red Hat Enterprise Linux | 7.3 or later 7.x releases |
 | CentOS                   | 7.3 or later 7.x releases |
 | Oracle Enterprise Linux  | 7.3 or later 7.x releases |
+| Amazon Linux             | 2 |
 | Ubuntu LTS               | 16.04 or later |
 
 > **Note:**


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

List Amazon Linux 2 (CentOS 7 based) as supported. This is common OS when deploying on ARM64 (AWS Graviton 2)

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- https://github.com/pingcap/tiup/pull/1740
