### PR TITLE
auto-increment: Mention `FORCE`

### DIFF
--- a/auto-increment.md
+++ b/auto-increment.md
@@ -340,3 +340,4 @@ Currently, `AUTO_INCREMENT` has the following restrictions when used in TiDB:
 - It cannot be specified on the same column with the `DEFAULT` column value.
 - `ALTER TABLE` cannot be used to add the `AUTO_INCREMENT` attribute.
 - `ALTER TABLE` can be used to remove the `AUTO_INCREMENT` attribute. However, starting from v2.1.18 and v3.0.4, TiDB uses the session variable `@@tidb_allow_remove_auto_inc` to control whether `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` can be used to remove the `AUTO_INCREMENT` attribute of a column. By default, you cannot use `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` to remove the `AUTO_INCREMENT` attribute.
+- `ALTER TABLE` requires the `FORCE` option to set the `AUTO_INCREMENT` value to a lower value.

--- a/auto-increment.md
+++ b/auto-increment.md
@@ -341,3 +341,4 @@ Currently, `AUTO_INCREMENT` has the following restrictions when used in TiDB:
 - `ALTER TABLE` cannot be used to add the `AUTO_INCREMENT` attribute.
 - `ALTER TABLE` can be used to remove the `AUTO_INCREMENT` attribute. However, starting from v2.1.18 and v3.0.4, TiDB uses the session variable `@@tidb_allow_remove_auto_inc` to control whether `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` can be used to remove the `AUTO_INCREMENT` attribute of a column. By default, you cannot use `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` to remove the `AUTO_INCREMENT` attribute.
 - `ALTER TABLE` requires the `FORCE` option to set the `AUTO_INCREMENT` value to a lower value.
+- Setting the `AUTO_INCREMENT` to a value less than `MAX(<auto_increment_column>)` leads to duplicate keys as pre-existing values are not skipped.

--- a/auto-increment.md
+++ b/auto-increment.md
@@ -340,5 +340,5 @@ Currently, `AUTO_INCREMENT` has the following restrictions when used in TiDB:
 - It cannot be specified on the same column with the `DEFAULT` column value.
 - `ALTER TABLE` cannot be used to add the `AUTO_INCREMENT` attribute.
 - `ALTER TABLE` can be used to remove the `AUTO_INCREMENT` attribute. However, starting from v2.1.18 and v3.0.4, TiDB uses the session variable `@@tidb_allow_remove_auto_inc` to control whether `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` can be used to remove the `AUTO_INCREMENT` attribute of a column. By default, you cannot use `ALTER TABLE MODIFY` or `ALTER TABLE CHANGE` to remove the `AUTO_INCREMENT` attribute.
-- `ALTER TABLE` requires the `FORCE` option to set the `AUTO_INCREMENT` value to a lower value.
-- Setting the `AUTO_INCREMENT` to a value less than `MAX(<auto_increment_column>)` leads to duplicate keys as pre-existing values are not skipped.
+- `ALTER TABLE` requires the `FORCE` option to set the `AUTO_INCREMENT` value to a smaller value.
+- Setting the `AUTO_INCREMENT` to a value smaller than `MAX(<auto_increment_column>)` leads to duplicate keys because pre-existing values are not skipped.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add mention of the `FORCE` keyword that can be used like `ALTER TABLE t FORCE AUTO_INCREMENT=100` to reset the auto increment value of a table.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

- [x] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- https://github.com/pingcap/tidb/issues/25400

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
