### PR TITLE
tiup version constraint added to faq

### DIFF
--- a/tiup/tiup-faq.md
+++ b/tiup/tiup-faq.md
@@ -63,8 +63,9 @@ MaxStartups 1000
 ## How do I specify the latest patch version for a specific major.minor version?
 
 Use the format `~{Major}.{Minor}`, like `~5.1` which would currently give `v5.1.3` (the initial `v` is optional)
+Or use a `x` or `*` as wild card, like `v5.1.x` or `v5.1.*` to get `v5.1.3`
 You can use different constraints when specifying which version to use.
 vA[.B[.C]] => String match of version resulting in lowest version matching the string (v5.1 => v5.1.0)
 ^A[.B[.C]] => Match highest version with Major version >= A and < A+1 (^5.1 => v5.4.0)
 ~A[.B[.C]] => Match highest version with Minor version >= B and < B+1 (~5.1 => v5.1.3)
-(at the time of writing latest version in 5.1 series is 5.1.3 and 5.4 series is 5.4.0)
+(at the time of writing latest version in 5.1 series is 5.1.3 and 5 series is 5.4.0)

--- a/tiup/tiup-faq.md
+++ b/tiup/tiup-faq.md
@@ -59,3 +59,12 @@ vi /etc/ssh/sshd_config
 MaxSessions 1000
 MaxStartups 1000
 ```
+
+## How do I specify the latest patch version for a specific major.minor version?
+
+Use the format `~{Major}.{Minor}`, like `~5.1` which would currently give `v5.1.3` (the initial `v` is optional)
+You can use different constraints when specifying which version to use.
+vA[.B[.C]] => String match of version resulting in lowest version matching the string (v5.1 => v5.1.0)
+^A[.B[.C]] => Match highest version with Major version >= A and < A+1 (^5.1 => v5.4.0)
+~A[.B[.C]] => Match highest version with Minor version >= B and < B+1 (~5.1 => v5.1.3)
+(at the time of writing latest version in 5.1 series is 5.1.3 and 5.4 series is 5.4.0)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->



### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Added an answer about tiup version constraints

close #7565

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [X] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

https://github.com/pingcap/tiup/blob/382d0e95f1c68e2fe272266d77abd57f273f7f31/pkg/utils/semver.go#L120

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
