### PR TITLE
functions-and-operators: Add UUID_TO_BIN and BIN_TO_UUID

### DIFF
--- a/functions-and-operators/miscellaneous-functions.md
+++ b/functions-and-operators/miscellaneous-functions.md
@@ -12,7 +12,8 @@ TiDB supports most of the [miscellaneous functions](https://dev.mysql.com/doc/re
 
 | Name | Description  |
 |:------------|:-----------------------------------------------------------------------------------------------|
-| [`ANY_VALUE()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value)              | Suppress `ONLY_FULL_GROUP_BY` value rejection       |
+| [`ANY_VALUE()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value)              | Suppress `ONLY_FULL_GROUP_BY` value rejection     |
+| [`BIN_TO_UUID()`](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_bin-to-uuid)          | Convert UUID from binary format to text format    |
 | [`DEFAULT()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_default)                  | Returns the default value for a table column      |
 | [`INET_ATON()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-aton)              | Return the numeric value of an IP address         |
 | [`INET_NTOA()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-ntoa)              | Return the IP address from a numeric value        |
@@ -25,6 +26,7 @@ TiDB supports most of the [miscellaneous functions](https://dev.mysql.com/doc/re
 | [`NAME_CONST()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_name-const)            | Can be used to rename a column name               |
 | [`SLEEP()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_sleep)                      | Sleep for a number of seconds                     |
 | [`UUID()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_uuid)                        | Return a Universal Unique Identifier (UUID)       |
+| [`UUID_TO_BIN()`](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin)          | Convert UUID from text format to binary format    |
 | [`VALUES()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values)                    | Defines the values to be used during an INSERT    |
 
 ## Unsupported functions


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add `UUID_TO_BIN()` and `BIN_TO_UUID()` to the list of supported miscellaneous functions.

Note that the links go the MySQL 8.0 reference manual as these are not available in MySQL 5.7.

I'm not closing #5920 yet as this doesn't yet explain how to deal with UUID and hotspots, that will be another PR.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- #5920
- https://github.com/pingcap/tidb/pull/20140

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
