### PR TITLE
Update issue number to show `GET_LOCK()` and `RELEASE_LOCK()` status

### DIFF
--- a/functions-and-operators/miscellaneous-functions.md
+++ b/functions-and-operators/miscellaneous-functions.md
@@ -31,7 +31,7 @@ TiDB supports most of the [miscellaneous functions](https://dev.mysql.com/doc/re
 
 | Name | Description  |
 |:------------|:-----------------------------------------------------------------------------------------------|
-| [`GET_LOCK()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock)                | Get a named lock [TiDB #10929](https://github.com/pingcap/tidb/issues/10929) |
-| [`RELEASE_LOCK()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_release-lock)        | Releases the named lock [TiDB #10929](https://github.com/pingcap/tidb/issues/10929) |
+| [`GET_LOCK()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock)                | Get a named lock [TiDB #10929](https://github.com/pingcap/tidb/issues/14994) |
+| [`RELEASE_LOCK()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_release-lock)        | Releases the named lock [TiDB #10929](https://github.com/pingcap/tidb/issues/14994) |
 | [`UUID_SHORT()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_uuid-short)            | Provides a UUID that is unique given certain assumptions not present in TiDB [TiDB #4620](https://github.com/pingcap/tidb/issues/4620) |
 | [`MASTER_WAIT_POS()`](https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_master-pos-wait)  | Relates to MySQL replication |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The current linked issue https://github.com/pingcap/tidb/issues/10929 has been closed because it asks to show errors when non-supported `GET_LOCK()` and `RELEASE_LOCK()` are executed. If someone click this link and they may misunderstand this issue has been resolved, like these functions are available in TiDB.

This commit updates the linked issue number to show the current status of `GET_LOCK()` and `RELEASE_LOCK()` functions, which is not supported yet.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
