### PR TITLE
TiKV config: Add new online configurations and update value ranges

### DIFF
--- a/dynamic-config.md
+++ b/dynamic-config.md
@@ -126,7 +126,7 @@ The following TiKV configuration items can be modified online:
 
 | Configuration item | Description |
 | :--- | :--- |
-| `raftstore.raft-max-inflight-msgs` | The number of logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending. |
+| `raftstore.raft-max-inflight-msgs` | The number of Raft logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending. |
 | `raftstore.raft-log-gc-tick-interval` | The time interval at which the polling task of deleting Raft logs is scheduled |
 | `raftstore.raft-log-gc-threshold` | The soft limit on the maximum allowable number of residual Raft logs |
 | `raftstore.raft-log-gc-count-limit` | The hard limit on the allowable number of residual Raft logs |
@@ -157,7 +157,7 @@ The following TiKV configuration items can be modified online:
 | `raftstore.hibernate-timeout` | The shortest wait duration before entering hibernation upon start. Within this duration, TiKV does not hibernate (not released). |
 | `raftstore.apply-pool-size` | The number of apply thread pool size |
 | `raftstore.store-pool-size` | The number of store thread pool size |
-| `readpool.unified.max-thread-count` | The maximum number of threads in the thread pool that uniformly executes read requests, which is the size of the UnifyReadPool thread pool |
+| `readpool.unified.max-thread-count` | The maximum number of threads in the thread pool that uniformly processes read requests, which is the size of the UnifyReadPool thread pool |
 | `coprocessor.split-region-on-table` | Enables to split Region by table |
 | `coprocessor.batch-split-limit` | The threshold of Region split in batches |
 | `coprocessor.region-max-size` | The maximum size of a Region |

--- a/dynamic-config.md
+++ b/dynamic-config.md
@@ -126,7 +126,7 @@ The following TiKV configuration items can be modified online:
 
 | Configuration item | Description |
 | :--- | :--- |
-| `raftstore.raft-entry-max-size` | The maximum size of a single log |
+| `raftstore.raft-max-inflight-msgs` | The number of logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending. |
 | `raftstore.raft-log-gc-tick-interval` | The time interval at which the polling task of deleting Raft logs is scheduled |
 | `raftstore.raft-log-gc-threshold` | The soft limit on the maximum allowable number of residual Raft logs |
 | `raftstore.raft-log-gc-count-limit` | The hard limit on the allowable number of residual Raft logs |
@@ -157,6 +157,7 @@ The following TiKV configuration items can be modified online:
 | `raftstore.hibernate-timeout` | The shortest wait duration before entering hibernation upon start. Within this duration, TiKV does not hibernate (not released). |
 | `raftstore.apply-pool-size` | The number of apply thread pool size |
 | `raftstore.store-pool-size` | The number of store thread pool size |
+| `readpool.unified.max-thread-count` | The maximum number of threads in the thread pool that uniformly executes read requests, which is the size of the UnifyReadPool thread pool |
 | `coprocessor.split-region-on-table` | Enables to split Region by table |
 | `coprocessor.batch-split-limit` | The threshold of Region split in batches |
 | `coprocessor.region-max-size` | The maximum size of a Region |

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -211,7 +211,8 @@ Configuration items related to the single thread pool serving read requests. Thi
 ### `max-thread-count`
 
 + The maximum working thread count of the unified read pool or the UnifyReadPool thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
-+ Default value: `MAX(4, CPU * 0.8)`
++ Value range: `[min-thread-count, MAX(4, CPU)]`. `MAX(4, CPU)` means the following: if the number of your CPU cores is less than `4`, take `4`; if the number of your CPU cores is greater than `4`, take the number of CPU cores.
++ Default value: MAX(4, CPU * 0.8)
 
 ### `stack-size`
 
@@ -495,7 +496,7 @@ Configuration items related to Raftstore.
 
 ### `raft-max-inflight-msgs`
 
-+ The number of Raft logs to be confirmed. If this number is exceeded, log sending slows down.
++ The number of logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending.
 + Default value: `256`
 + Minimum value: greater than `0`
 
@@ -733,7 +734,7 @@ Configuration items related to Raftstore.
 
 ### `apply-pool-size`
 
-+ The allowable number of threads in the pool that flushes data to storage. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
++ The allowable number of threads in the pool that flushes data to storage, which is the size of the Apply thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: `2`
 + Minimum value: greater than `0`
 
@@ -1456,7 +1457,8 @@ Configuration items related to BR backup.
 ### `num-threads`
 
 + The number of worker threads to process backup
-+ Default value: `MIN(CPU * 0.5, 8)`.
++ Default value: `MIN(CPU * 0.5, 8)`
++ Value range: [1, CPU]
 + Minimum value: `1`
 
 ### `enable-auto-tune` <span class="version-mark">New in v5.4.0</span>

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -211,7 +211,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 ### `max-thread-count`
 
 + The maximum working thread count of the unified read pool or the UnifyReadPool thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
-+ Value range: `[min-thread-count, MAX(4, CPU)]`. `MAX(4, CPU)` means the following: if the number of your CPU cores is less than `4`, take `4`; if the number of your CPU cores is greater than `4`, take the number of CPU cores.
++ Value range: `[min-thread-count, MAX(4, CPU)]`. `MAX(4, CPU)` means that if the number of your CPU cores is less than `4`, take `4`; if the number of your CPU cores is greater than `4`, take the number of CPU cores.
 + Default value: MAX(4, CPU * 0.8)
 
 ### `stack-size`

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -211,7 +211,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 ### `max-thread-count`
 
 + The maximum working thread count of the unified read pool or the UnifyReadPool thread pool. When you modify the size of this thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
-+ Value range: `[min-thread-count, MAX(4, CPU)]`. `MAX(4, CPU)` means that if the number of your CPU cores is less than `4`, take `4`; if the number of your CPU cores is greater than `4`, take the number of CPU cores.
++ Value range: `[min-thread-count, MAX(4, CPU)]`. In `MAX(4, CPU)`, `CPU` means the number of your CPU cores. `MAX(4, CPU)` takes the greater value out of `4` and the `CPU`.
 + Default value: MAX(4, CPU * 0.8)
 
 ### `stack-size`

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -496,7 +496,7 @@ Configuration items related to Raftstore.
 
 ### `raft-max-inflight-msgs`
 
-+ The number of logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending.
++ The number of Raft logs to be confirmed. If this number is exceeded, the Raft state machine slows down log sending.
 + Default value: `256`
 + Minimum value: greater than `0`
 
@@ -1458,7 +1458,7 @@ Configuration items related to BR backup.
 
 + The number of worker threads to process backup
 + Default value: `MIN(CPU * 0.5, 8)`
-+ Value range: [1, CPU]
++ Value range: `[1, CPU]`
 + Minimum value: `1`
 
 ### `enable-auto-tune` <span class="version-mark">New in v5.4.0</span>


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
- Added new TiKV configurations that can be configured dynamically: `raftstore.raft-max-inflight-msgs`, `readpool.unified.max-thread-count`
- Updated value ranges for some TiKV configurations: `max-thread-count`, `num-threads`
- Updated descriptions of some TiKV configurations: `raft-max-inflight-msgs`, `apply-pool-size`(the changes for this configuration's description are the same as changes in PR #7963, line 738).
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/8676
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
