### PR TITLE
Remove statistics information and change firewalld description in TiSpark Overview

### DIFF
--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -140,14 +140,14 @@ cd $SPARKPATH
 ./sbin/start-master.sh
 ```
 
-After the above step is completed, a log file will be printed on the screen. Check the log file to confirm whether the Spark-Master is started successfully. You can open the <http://spark-master-hostname:8080> to view the cluster information (if you does not change the Spark-Master default port number). When you start Spark-Worker, you can also use this panel to confirm whether the Worker is joined to the cluster.
+After the above step is completed, a log file will be printed on the screen. Check the log file to confirm whether the Spark-Master is started successfully. You can open the <http://${spark-master-hostname}:8080> to view the cluster information (if you does not change the Spark-Master default port number). When you start Spark-Worker, you can also use this panel to confirm whether the Worker is joined to the cluster.
 
 ### Start a Worker node
 
 Similarly, you can start a Spark-Worker node with the following command:
 
 ```sh
-./sbin/start-slave.sh spark://spark-master-hostname:7077
+./sbin/start-slave.sh spark://${spark-master-hostname}:7077
 ```
 
 Note that if you run the master node and worker node on the same host, you cannot use `127.0.0.1` or `localhost` because the master process only listens to the external interface by default.

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -354,14 +354,6 @@ If you would like TiSpark to use statistic information, first you need to make s
 
 Starting from TiSpark 2.0, statistics information is default to auto load.
 
-Note that table statistics are cached in the memory of your Spark driver node, so you need to make sure that your memory size is large enough for your statistics information.
-
-Currently, you can adjust these configurations in your `spark-defaults.conf` file.
-
-| Property name | Default | Description |
-| :--------   | :-----  | :---- |
-| spark.tispark.statistics.auto_load | true | Whether to load statistics information automatically during database mapping. |
-
 ## Security
 
 If you are using TiSpark v2.5.0 or a later version, you can authenticate and authorize TiSpark users by using TiDB.

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -144,7 +144,7 @@ cd $SPARKPATH
 ./sbin/start-master.sh
 ```
 
-After the above step is completed, a log file will be printed on the screen. Check the log file to confirm whether the Spark-Master is started successfully. You can open the [http://spark-master-hostname:8080](http://spark-master-hostname:8080) to view the cluster information (if you does not change the Spark-Master default port number). When you start Spark-Worker, you can also use this panel to confirm whether the Worker is joined to the cluster.
+After the above step is completed, a log file will be printed on the screen. Check the log file to confirm whether the Spark-Master is started successfully. You can open the <http://spark-master-hostname:8080> to view the cluster information (if you does not change the Spark-Master default port number). When you start Spark-Worker, you can also use this panel to confirm whether the Worker is joined to the cluster.
 
 ### Start a Worker node
 

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -209,13 +209,21 @@ Besides Spark Shell, there is also Spark SQL available. To use Spark SQL, run:
 ./bin/spark-sql
 ```
 
-You can run the same query
+You can run the same query:
 
-```sh
-spark-sql> use tpch;
+```scala
+use tpch;
+```
+
+```
 Time taken: 0.015 seconds
+```
 
-spark-sql> select count(*) from lineitem;
+```scala
+select count(*) from lineitem;
+```
+
+```
 2000
 Time taken: 0.673 seconds, Fetched 1 row(s)
 ```

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -77,7 +77,7 @@ To co-deploy TiKV and TiSpark, add TiSpark required resources to the TiKV reserv
 
 ### Deploy TiSpark with a standalone Spark cluster
 
-For more information, see the [official configuration](https://spark.apache.org/docs/latest/spark-standalone.html) on the Spark website. 
+For more information, see the [official configuration](https://spark.apache.org/docs/latest/spark-standalone.html) on the Spark website.
 
 You are advised to use a standalone Spark cluster. To install Spark Standalone mode, you can simply place a compiled version of Spark on each node on the cluster. If you encounter any problem, see its [official website](https://spark.apache.org/docs/latest/spark-standalone.html). And you are welcome to [file an issue](https://github.com/pingcap/tispark/issues/new) on our GitHub.
 
@@ -102,7 +102,7 @@ cd spark
 Download TiSpark's jar package [here](https://github.com/pingcap/tispark/releases) and place it in the `$SPARKPATH/jars` folder.
 
 > **Note:**
-> 
+>
 > TiSpark v2.1.x and older versions have file names that look like `tispark-core-2.1.9-spark_2.4-jar-with-dependencies.jar`. Please check the [releases page on GitHub](https://github.com/pingcap/tispark/releases) for the exact file name for the version you want.
 
 ```
@@ -168,7 +168,7 @@ spark-shell --jars $TISPARK_FOLDER/tispark-${name_with_version}.jar
 
 ## Using Spark Shell and Spark SQL
 
-Assume that you have successfully started the TiSpark cluster as described above. The following describes how to use Spark SQL for OLAP analysis on a table named `lineitem` in the `tpch` database. 
+Assume that you have successfully started the TiSpark cluster as described above. The following describes how to use Spark SQL for OLAP analysis on a table named `lineitem` in the `tpch` database.
 
 To generate the test data via a TiDB server available on 192.168.1.101:
 

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -127,13 +127,9 @@ The `spark.tispark.pd.addresses` configuration allows you to put in multiple PD 
 
 For example, when you have multiple PD servers on `10.16.20.1,10.16.20.2,10.16.20.3` with the port 2379, put it as `10.16.20.1:2379,10.16.20.2:2379,10.16.20.3:2379`.
 
-The default setup of `firewalld` on CentOS blocks the traffic needed by TiSpark. Therefore, disable `firewalld` to ensure normal running of TiSpark.
-
-```bash
-sudo systemctl stop firewalld.service
-sudo systemctl disable firewalld.service
-sudo systemctl mask --now firewalld.service
-```
+> **Note:**
+>
+> If TiSpark could not communicate properly, please check your firewall configuration. You can adjust the firewall rules or disable it on your need.
 
 ### Start a Master node
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Fix format: white space, spark-sql code format, link of http://spark-master-hostname:8080
- Remove note and config in statistics information
- Change firewalld description to a note
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.0 (TiDB 6.0 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/tispark/pull/2300

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
