### PR TITLE
Replace route with mydumper.files due to route feature not GA yet

### DIFF
--- a/migrate-large-mysql-shards-to-tidb.md
+++ b/migrate-large-mysql-shards-to-tidb.md
@@ -134,7 +134,7 @@ For more information, see [TiDB Lightning Checkpoints](/tidb-lightning/tidb-ligh
 
 ### Create the target schema
 
-Run the following command and edit the `my_db1-schema-create.sql` file to create `mydb.table5` in downstream:
+Run the following command and edit the `my_db1-schema-create.sql` file. Then run the `my_db1-schema-create.sql` file downstream to create `mydb.table5`:
 
 {{< copyable "shell-regular" >}}
 

--- a/migrate-large-mysql-shards-to-tidb.md
+++ b/migrate-large-mysql-shards-to-tidb.md
@@ -45,6 +45,8 @@ If the migration involves merging data from different sharded tables, primary ke
 
 Assume that tables 1~4 have the same table structure as follows.
 
+{{< copyable "sql" >}}
+
 ```sql
 CREATE TABLE `table1` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -57,6 +59,8 @@ CREATE TABLE `table1` (
 ```
 
 For those four tables, the `id` column is the primary key. It is auto-incremental, which will cause different sharded tables to generate duplicated `id` ranges and cause the primary key conflict on the target table during the migration. On the other hand, the `sid` column is the sharding key, which ensures that the index is unique globally. So you can remove the unique constraint of the `id` column in the target `table5` to avoid the data merge conflicts.
+
+{{< copyable "sql" >}}
 
 ```sql
 CREATE TABLE `table5` (
@@ -132,14 +136,21 @@ If the TiDB Lightning task crashes due to unrecoverable errors (for example, dat
 
 For more information, see [TiDB Lightning Checkpoints](/tidb-lightning/tidb-lightning-checkpoints.md).
 
-### Create the target schema
+### Create a target schema
 
-Create `mydb.table5` at downstream. For example, you can change the table name to `mydb.table5` in the `my_db1-schema-create.sql` and then execute the file at downstream:
+Create `mydb.table5` at downstream.
 
-{{< copyable "shell-regular" >}}
+{{< copyable "sql" >}}
 
-```shell
-vim ${data-path}/my_db1/my_db1-schema-create.sql
+```sql
+CREATE TABLE `table5` (
+  `id` bigint(20) NOT NULL,
+  `sid` bigint(20) NOT NULL,
+  `pid` bigint(20) NOT NULL,
+  `comment` varchar(255) DEFAULT NULL,
+  INDEX (`id`),
+  UNIQUE KEY `sid` (`sid`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 ```
 
 ### Start the migration task
@@ -154,6 +165,9 @@ Follow these steps to start `tidb-lightning`:
     level = "info"
     file = "tidb-lightning.log"
 
+    [mydumper]
+    data-source-dir = ${data-path}
+
     [tikv-importer]
     # Choose a local backend.
     # "local": The default mode. It is used for large data volumes greater than 1 TiB. During migration, downstream TiDB cannot provide services.
@@ -167,13 +181,13 @@ Follow these steps to start `tidb-lightning`:
 
     # Set the renaming rules ('routes') from source to target tables, in order to support merging different table shards into a single target table. Here you migrate `table1` and `table2` in `my_db1`, and `table3` and `table4` in `my_db2`, to the target `table5` in downstream `my_db`.
     [[mydumper.files]]
-    pattern = '(^|/)my_db1\.table[1-2].*\.sql$'
+    pattern = '(^|/)my_db1\.table[1-2]\..*\.sql$'
     schema = "my_db"
     table = "table5"
     type = "sql"
 
     [[mydumper.files]]
-    pattern = '(^|/)my_db2\.table[3-4].*\.sql$'
+    pattern = '(^|/)my_db2\.table[3-4]\..*\.sql$'
     schema = "my_db"
     table = "table5"
     type = "sql"

--- a/migrate-large-mysql-shards-to-tidb.md
+++ b/migrate-large-mysql-shards-to-tidb.md
@@ -134,7 +134,7 @@ For more information, see [TiDB Lightning Checkpoints](/tidb-lightning/tidb-ligh
 
 ### Create the target schema
 
-Run the following command and edit the `my_db1-schema-create.sql` file. Then run the `my_db1-schema-create.sql` file downstream to create `mydb.table5`:
+Create `mydb.table5` at downstream. For example, you can change the table name to `mydb.table5` in the `my_db1-schema-create.sql` and then execute the file at downstream:
 
 {{< copyable "shell-regular" >}}
 

--- a/tidb-lightning/tidb-lightning-configuration.md
+++ b/tidb-lightning/tidb-lightning-configuration.md
@@ -243,19 +243,6 @@ trim-last-separator = false
 # schema = '$1'
 # table = '$2'
 # type = '$3'
-# 
-# Sets rules for merging sharded schemas and tables. Specifically, import `table1` and `table2` from `my_db1`, and `table3` and `table4` from `my_db2` to `table5` in `my_db`.
-# [[routes]]
-# schema-pattern = "my_db1"
-# table-pattern = "table[1-2]"
-# target-schema = "my_db"
-# target-table = "table5"
-# 
-# [[routes]]
-# schema-pattern = "my_db2"
-# table-pattern = "table[3-4]"
-# target-schema = "my_db"
-# target-table = "table5"
 
 [tidb]
 # Configuration of any TiDB server from the cluster.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.1 (TiDB 6.1 versions)
- [x] v6.0 (TiDB 6.0 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/8925
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
