### PR TITLE
system-variables: improve restricted-read-only docs

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -1655,9 +1655,9 @@ SET tidb_query_log_max_len = 20
 ### tidb_restricted_read_only <span class="version-mark">New in v5.2.0</span>
 
 - Scope: GLOBAL
-- Default value: `0`
-- Value options: `0`, `1`
-- This variable controls the read-only status of the entire cluster. If the variable is enabled (which means that the value is `1`), all TiDB servers in the entire cluster are in the read-only mode. In this case, TiDB only executes the statements that do not modify data, such as `SELECT`, `USE`, and `SHOW`. For other statements such as `INSERT` and `UPDATE`, TiDB rejects executing those statements in the read-only mode.
+- Persists to cluster: Yes
+- Default value: `OFF`
+- This variable controls the read-only status of the entire cluster. When the variable is `ON`, all TiDB servers in the entire cluster are in the read-only mode. In this case, TiDB only executes the statements that do not modify data, such as `SELECT`, `USE`, and `SHOW`. For other statements such as `INSERT` and `UPDATE`, TiDB rejects executing those statements in the read-only mode.
 - Enabling the read-only mode using this variable only ensures that the entire cluster finally enters the read-only status. If you have changed the value of this variable in a TiDB cluster but the change has not yet propagated to other TiDB servers, the un-updated TiDB servers are still **not** in the read-only mode.
 - When this variable is enabled, the SQL statements being executed are not affected. TiDB only performs the read-only check for the SQL statements **to be** executed.
 - When this variable is enabled, TiDB handles the uncommitted transactions in the following ways:


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The docs for `tidb_restricted_read_only` are inconsistent:

The type for this variable is a boolean, which in `SHOW VARIABLES` context will show `ON` or `OFF`. In `SELECT @@varname` context it will return `0` or `1`, so for docs context we have to chose one format. 

It looks like the original PR author chose `0`/`1`, but in the rest of the page we use `ON`/`OFF`, which is also consistent with the mysql docs: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html


### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v6.0 (TiDB 6.0 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

This was added in https://github.com/pingcap/docs/pull/7670 (2 days ago)


### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
