### PR TITLE
Remove `/bin` from toolkit commands

### DIFF
--- a/deploy-monitoring-services.md
+++ b/deploy-monitoring-services.md
@@ -182,8 +182,10 @@ url = https://grafana.net
 
 Start the Grafana service:
 
+{{< copyable "shell-regular" >}}
+
 ```bash
-  ./bin/grafana-server \
+./bin/grafana-server \
     --config="./conf/grafana.ini" &
 ```
 

--- a/deploy-monitoring-services.md
+++ b/deploy-monitoring-services.md
@@ -183,7 +183,7 @@ url = https://grafana.net
 Start the Grafana service:
 
 ```bash
-$ ./bin/grafana-server \
+  ./bin/grafana-server \
     --config="./conf/grafana.ini" &
 ```
 

--- a/dm/deploy-a-dm-cluster-using-binary.md
+++ b/dm/deploy-a-dm-cluster-using-binary.md
@@ -66,7 +66,7 @@ You can configure DM-master by using [command-line parameters](#dm-master-comman
 The following is the description of DM-master command-line parameters:
 
 ```bash
-./bin/dm-master --help
+./dm-master --help
 ```
 
 ```
@@ -131,7 +131,7 @@ The following is the configuration file of DM-master. It is recommended that you
       {{< copyable "shell-regular" >}}
 
       ```bash
-      ./bin/dm-master -config conf/dm-master1.toml
+      ./dm-master -config conf/dm-master1.toml
       ```
 
       > **Note:**
@@ -151,7 +151,7 @@ The following is the description of the DM-worker command-line parameters:
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/dm-worker --help
+./dm-worker --help
 ```
 
 ```
@@ -207,7 +207,7 @@ The following is the DM-worker configuration file. It is recommended that you co
       {{< copyable "shell-regular" >}}
 
       ```bash
-      ./bin/dm-worker -config conf/dm-worker1.toml
+      ./dm-worker -config conf/dm-worker1.toml
       ```
 
 3. For DM-worker2, change `name` in the configuration file to `worker2`. Then repeat Step 2.

--- a/dm/quick-start-create-task.md
+++ b/dm/quick-start-create-task.md
@@ -100,7 +100,7 @@ For safety reasons, it is recommended to configure and use encrypted passwords. 
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/dmctl encrypt "123456"
+./dmctl encrypt "123456"
 ```
 
 ```
@@ -137,7 +137,7 @@ To load the data source configurations of MySQL1 into the DM cluster using dmctl
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/dmctl --master-addr=127.0.0.1:8261 operate-source create conf/source1.yaml
+./dmctl --master-addr=127.0.0.1:8261 operate-source create conf/source1.yaml
 ```
 
 For MySQL2, replace the configuration file in the above command with that of MySQL2.
@@ -198,7 +198,7 @@ Now, suppose that you need to migrate these sharded tables to the `db_target.t_t
     {{< copyable "shell-regular" >}}
 
     ```bash
-    ./bin/dmctl --master-addr 127.0.0.1:8261 start-task conf/task.yaml
+    ./dmctl --master-addr 127.0.0.1:8261 start-task conf/task.yaml
     ```
 
     ```

--- a/get-started-with-tidb-lightning.md
+++ b/get-started-with-tidb-lightning.md
@@ -28,7 +28,7 @@ First, use [`dumpling`](/dumpling-overview.md) to export data from MySQL:
 {{< copyable "shell-regular" >}}
 
 ```sh
-./bin/dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
+./dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
 ```
 
 In the above command:

--- a/sync-diff-inspector/sync-diff-inspector-overview.md
+++ b/sync-diff-inspector/sync-diff-inspector-overview.md
@@ -160,7 +160,7 @@ Run the following command:
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/sync_diff_inspector --config=./config.toml
+./sync_diff_inspector --config=./config.toml
 ```
 
 This command outputs a check report `summary.txt` in the `output-dir` of `config.toml` and the log `sync_diff.log`. In the `output-dir`, a folder named by the hash value of the `config. toml` file is also generated. This folder includes the checkpoint node information of breakpoints and the SQL file generated when the data is inconsistent.

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -78,7 +78,7 @@ The following part shows how to use Pump and Drainer based on the nodes above.
 
 1. Deploy Pump using the binary.
 
-    - To view the command line parameters of Pump, execute `./bin/pump -help`:
+    - To view the command line parameters of Pump, execute `./pump -help`:
 
         ```bash
         Usage of Pump:
@@ -173,14 +173,14 @@ The following part shows how to use Pump and Drainer based on the nodes above.
         {{< copyable "shell-regular" >}}
 
         ```bash
-        ./bin/pump -config pump.toml
+        ./pump -config pump.toml
         ```
 
         If the command line parameters is the same with the configuration file parameters, the values of command line parameters are used.
 
 2. Deploy Drainer using binary.
 
-    - To view the command line parameters of Drainer, execute `./bin/drainer -help`:
+    - To view the command line parameters of Drainer, execute `./drainer -help`:
 
         ```bash
         Usage of Drainer:
@@ -391,7 +391,7 @@ The following part shows how to use Pump and Drainer based on the nodes above.
         {{< copyable "shell-regular" >}}
 
         ```bash
-        ./bin/drainer -config drainer.toml -initial-commit-ts {initial-commit-ts}
+        ./drainer -config drainer.toml -initial-commit-ts {initial-commit-ts}
         ```
 
         If the command line parameter and the configuration file parameter are the same, the parameter value in the command line is used.

--- a/tidb-binlog/get-started-with-tidb-binlog.md
+++ b/tidb-binlog/get-started-with-tidb-binlog.md
@@ -131,7 +131,7 @@ Start all the services using:
 ```bash
 ./bin/pd-server --config=pd.toml &>pd.out &
 ./bin/tikv-server --config=tikv.toml &>tikv.out &
-./bin/pump --config=pump.toml &>pump.out &
+./pump --config=pump.toml &>pump.out &
 sleep 3
 ./bin/tidb-server --config=tidb.toml &>tidb.out &
 ```
@@ -143,7 +143,7 @@ Expected output:
 [1] 20935
 [kolbe@localhost tidb-latest-linux-amd64]$ ./bin/tikv-server --config=tikv.toml &>tikv.out &
 [2] 20944
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/pump --config=pump.toml &>pump.out &
+[kolbe@localhost tidb-latest-linux-amd64]$ ./pump --config=pump.toml &>pump.out &
 [3] 21050
 [kolbe@localhost tidb-latest-linux-amd64]$ sleep 3
 [kolbe@localhost tidb-latest-linux-amd64]$ ./bin/tidb-server --config=tidb.toml &>tidb.out &
@@ -156,7 +156,7 @@ If you execute `jobs`, you should see a list of running daemons:
 [kolbe@localhost tidb-latest-linux-amd64]$ jobs
 [1]   Running                 ./bin/pd-server --config=pd.toml &>pd.out &
 [2]   Running                 ./bin/tikv-server --config=tikv.toml &>tikv.out &
-[3]-  Running                 ./bin/pump --config=pump.toml &>pump.out &
+[3]-  Running                 ./pump --config=pump.toml &>pump.out &
 [4]+  Running                 ./bin/tidb-server --config=tidb.toml &>tidb.out &
 ```
 
@@ -191,7 +191,7 @@ Start `drainer` using:
 
 ```bash
 sudo systemctl start mariadb
-./bin/drainer --config=drainer.toml &>drainer.out &
+./drainer --config=drainer.toml &>drainer.out &
 ```
 
 If you are using an operating system that makes it easier to install MySQL server, that's also OK. Just make sure it's listening on port 3306 and that you can either connect to it as user "root" with an empty password, or adjust drainer.toml as necessary.
@@ -331,17 +331,17 @@ Information about Pumps and Drainers that have joined the cluster is stored in P
 Use `binlogctl` to get a view of the current status of Pumps and Drainers in the cluster:
 
 ```bash
-./bin/binlogctl -cmd drainers
-./bin/binlogctl -cmd pumps
+./binlogctl -cmd drainers
+./binlogctl -cmd pumps
 ```
 
 Expected output:
 
 ```
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd drainers
+[kolbe@localhost tidb-latest-linux-amd64]$ ./binlogctl -cmd drainers
 [2019/04/11 17:44:10.861 -04:00] [INFO] [nodes.go:47] ["query node"] [type=drainer] [node="{NodeID: localhost.localdomain:8249, Addr: 192.168.236.128:8249, State: online, MaxCommitTS: 407638907719778305, UpdateTime: 2019-04-11 17:44:10 -0400 EDT}"]
 
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd pumps
+[kolbe@localhost tidb-latest-linux-amd64]$ ./binlogctl -cmd pumps
 [2019/04/11 17:44:13.904 -04:00] [INFO] [nodes.go:47] ["query node"] [type=pump] [node="{NodeID: localhost.localdomain:8250, Addr: 192.168.236.128:8250, State: online, MaxCommitTS: 407638914024079361, UpdateTime: 2019-04-11 17:44:13 -0400 EDT}"]
 ```
 
@@ -349,14 +349,14 @@ If you kill a Drainer, the cluster puts it in the "paused" state, which means th
 
 ```bash
 pkill drainer
-./bin/binlogctl -cmd drainers
+./binlogctl -cmd drainers
 ```
 
 Expected output:
 
 ```
 [kolbe@localhost tidb-latest-linux-amd64]$ pkill drainer
-[kolbe@localhost tidb-latest-linux-amd64]$ ./bin/binlogctl -cmd drainers
+[kolbe@localhost tidb-latest-linux-amd64]$ ./binlogctl -cmd drainers
 [2019/04/11 17:44:22.640 -04:00] [INFO] [nodes.go:47] ["query node"] [type=drainer] [node="{NodeID: localhost.localdomain:8249, Addr: 192.168.236.128:8249, State: paused, MaxCommitTS: 407638915597467649, UpdateTime: 2019-04-11 17:44:18 -0400 EDT}"]
 ```
 
@@ -369,15 +369,15 @@ There are 3 solutions to this issue:
 - Stop Drainer using `binlogctl` instead of killing the process:
 
     ```
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=drainers
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=offline-drainer --node-id=localhost.localdomain:8249
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=drainers
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=offline-drainer --node-id=localhost.localdomain:8249
     ```
 
 - Start Drainer _before_ starting Pump.
 - Use `binlogctl` after starting PD (but before starting Drainer and Pump) to update the state of the paused Drainer:
 
     ```
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=update-drainer --node-id=localhost.localdomain:8249 --state=offline
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=update-drainer --node-id=localhost.localdomain:8249 --state=offline
     ```
 
 ## Cleanup
@@ -393,8 +393,8 @@ Expected output:
 ```
 kolbe@localhost tidb-latest-linux-amd64]$ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1; done
 [4]-  Done                    ./bin/tidb-server --config=tidb.toml &>tidb.out
-[5]+  Done                    ./bin/drainer --config=drainer.toml &>drainer.out
-[3]+  Done                    ./bin/pump --config=pump.toml &>pump.out
+[5]+  Done                    ./drainer --config=drainer.toml &>drainer.out
+[3]+  Done                    ./pump --config=pump.toml &>pump.out
 [2]+  Done                    ./bin/tikv-server --config=tikv.toml &>tikv.out
 [1]+  Done                    ./bin/pd-server --config=pd.toml &>pd.out
 ```
@@ -404,9 +404,9 @@ If you wish to restart the cluster after all services exit, use the same command
 ```bash
 ./bin/pd-server --config=pd.toml &>pd.out &
 ./bin/tikv-server --config=tikv.toml &>tikv.out &
-./bin/drainer --config=drainer.toml &>drainer.out &
+./drainer --config=drainer.toml &>drainer.out &
 sleep 3
-./bin/pump --config=pump.toml &>pump.out &
+./pump --config=pump.toml &>pump.out &
 sleep 3
 ./bin/tidb-server --config=tidb.toml &>tidb.out &
 ```

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -117,7 +117,7 @@ password = ""
 ### Start example
 
 ```
-./bin/reparo -config reparo.toml
+./reparo -config reparo.toml
 ```
 
 > **Note:**

--- a/tidb-lightning/deploy-tidb-lightning.md
+++ b/tidb-lightning/deploy-tidb-lightning.md
@@ -43,7 +43,7 @@ With the default replica count of 3, this means the total free space should be a
 Use the [`dumpling` tool](/dumpling-overview.md) to export data from MySQL by using the following command:
 
 ```sh
-./bin/dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
+./dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
 ```
 
 In this command,


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Remove `/bin` from some toolkit commands: `dm-master`, `dm-worker`, `dmctl`, `dumpling`, `sync_diff_inspector`, `binlogctl`, `pump`, `drainer`.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.1 (TiDB 6.1 versions)
- [x] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
