### PR TITLE
system-variables: add system variable tidb_gc_max_wait_time 

### DIFF
--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -39,9 +39,9 @@ For information on changes in previous releases, refer to earlier versions of th
 
 ## Changes in TiDB 6.1.0
 
-In versions before TiDB 6.1.0, the internal transaction does not affect the GC safe point. Since TiDB 6.1.0, the internal transaction's startTS is considered when calculating the GC safe point, to resolve the access problem of cleaned data. When the internal transaction is too long, the safe point will be blocked for a long time, which affect the performance of application.
+Before TiDB v6.1.0, the transaction in TiDB does not affect the GC safe point. Since v6.1.0,  TiDB considers the startTS of the transaction when calculating the GC safe point, to resolve the problem that the data to be accessed has been cleared. If the transaction is too long, the safe point will be blocked for a long time, which affects the application peformance.
 
-TiDB v6.1.0 introduces the system variable [`tidb_gc_max_wait_time`](/system-variables.md#tidb_gc_max_wait_time-new-in-v610)to control the maximum time that active transactions block the GC safe point. After the value is exceeded, the GC safe point is forwarded forcefully.
+In TiDB v6.1.0, the system variable [`tidb_gc_max_wait_time`](/system-variables.md#tidb_gc_max_wait_time-new-in-v610) is introduced to control the maximum time that active transactions block the GC safe point. After the value is exceeded, the GC safe point is forwarded forcefully.
 
 ### GC in Compaction Filter
 

--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -39,7 +39,7 @@ For information on changes in previous releases, refer to earlier versions of th
 
 ## Changes in TiDB 6.1.0
 
-Before TiDB v6.1.0, the transaction in TiDB does not affect the GC safe point. Since v6.1.0,  TiDB considers the startTS of the transaction when calculating the GC safe point, to resolve the problem that the data to be accessed has been cleared. If the transaction is too long, the safe point will be blocked for a long time, which affects the application peformance.
+Before TiDB v6.1.0, the transaction in TiDB does not affect the GC safe point. Since v6.1.0, TiDB considers the startTS of the transaction when calculating the GC safe point, to resolve the problem that the data to be accessed has been cleared. If the transaction is too long, the safe point will be blocked for a long time, which affects the application performance.
 
 In TiDB v6.1.0, the system variable [`tidb_gc_max_wait_time`](/system-variables.md#tidb_gc_max_wait_time-new-in-v610) is introduced to control the maximum time that active transactions block the GC safe point. After the value is exceeded, the GC safe point is forwarded forcefully.
 

--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -13,7 +13,7 @@ Garbage collection is configured via the following system variables:
 * [`tidb_gc_life_time`](/system-variables.md#tidb_gc_life_time-new-in-v50)
 * [`tidb_gc_concurrency`](/system-variables.md#tidb_gc_concurrency-new-in-v50)
 * [`tidb_gc_scan_lock_mode`](/system-variables.md#tidb_gc_scan_lock_mode-new-in-v50)
-* [`tidb_gc_max_wait_time`](system-variables.md#tidb_gc_max_wait_time-new-in-v610)
+* [`tidb_gc_max_wait_time`](/system-variables.md#tidb_gc_max_wait_time-new-in-v610)
 
 ## GC I/O limit
 

--- a/garbage-collection-configuration.md
+++ b/garbage-collection-configuration.md
@@ -13,6 +13,7 @@ Garbage collection is configured via the following system variables:
 * [`tidb_gc_life_time`](/system-variables.md#tidb_gc_life_time-new-in-v50)
 * [`tidb_gc_concurrency`](/system-variables.md#tidb_gc_concurrency-new-in-v50)
 * [`tidb_gc_scan_lock_mode`](/system-variables.md#tidb_gc_scan_lock_mode-new-in-v50)
+* [`tidb_gc_max_wait_time`](system-variables.md#tidb_gc_max_wait_time-new-in-v610)
 
 ## GC I/O limit
 
@@ -35,6 +36,12 @@ In previous releases of TiDB, garbage collection was configured via the `mysql.t
 The `CENTRAL` garbage collection mode is no longer supported. The `DISTRIBUTED` GC mode (which has been the default since TiDB 3.0) will automatically be used in its place. This mode is more efficient, since TiDB no longer needs to send requests to each TiKV region to trigger garbage collection.
 
 For information on changes in previous releases, refer to earlier versions of this document using the _TIDB version selector_ in the left hand menu.
+
+## Changes in TiDB 6.1.0
+
+In versions before TiDB 6.1.0, the internal transaction does not affect the GC safe point. Since TiDB 6.1.0, the internal transaction's startTS is considered when calculating the GC safe point, to resolve the access problem of cleaned data. When the internal transaction is too long, the safe point will be blocked for a long time, which affect the performance of application.
+
+TiDB v6.1.0 introduces the system variable [`tidb_gc_max_wait_time`](/system-variables.md#tidb_gc_max_wait_time-new-in-v610)to control the maximum time that active transactions block the GC safe point. After the value is exceeded, the GC safe point is forwarded forcefully.
 
 ### GC in Compaction Filter
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1131,6 +1131,7 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 - Range: `[600, 31536000]`
 - Unit: Seconds
 - This variable is used to set the maximum time of GC safe point blocked by uncommitted transactions. During GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of uncommitted transactions does not exceed this value, GC safe point will be blocked until the runtime exceeds this value.
+
 ### tidb_gc_run_interval <span class="version-mark">New in v5.0</span>
 
 - Scope: GLOBAL

--- a/system-variables.md
+++ b/system-variables.md
@@ -1123,6 +1123,14 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 >     - A large amount of history data may affect performance to a certain degree, especially for range queries such as `select count(*) from t`
 > - If there is any transaction that has been running longer than `tidb_gc_life_time`, during GC, the data since `start_ts` is retained for this transaction to continue execution. For example, if `tidb_gc_life_time` is configured to 10 minutes, among all transactions being executed, the transaction that starts earliest has been running for 15 minutes, GC will retain data of the recent 15 minutes.
 
+### tidb_gc_max_wait_time <span class="version-mark">New in v6.1.0</span>
+
+- Scope: GLOBAL
+- Persists to cluster: Yes
+- Default value: `86400`
+- Range: `[600, 31536000]`
+- This variable is used to set the maximum time of GC safe point blocked by uncommitted transactions. The type is an integer and the unit is seconds. During GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of uncommitted transactions does not exceed this value, GC safe point will be blocked until the runtime exceeds this value.
+
 ### tidb_gc_run_interval <span class="version-mark">New in v5.0</span>
 
 - Scope: GLOBAL

--- a/system-variables.md
+++ b/system-variables.md
@@ -1129,8 +1129,8 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 - Persists to cluster: Yes
 - Default value: `86400`
 - Range: `[600, 31536000]`
-- This variable is used to set the maximum time of GC safe point blocked by uncommitted transactions. The type is an integer and the unit is seconds. During GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of uncommitted transactions does not exceed this value, GC safe point will be blocked until the runtime exceeds this value.
-
+- Unit: Seconds
+- This variable is used to set the maximum time of GC safe point blocked by uncommitted transactions. During GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of uncommitted transactions does not exceed this value, GC safe point will be blocked until the runtime exceeds this value.
 ### tidb_gc_run_interval <span class="version-mark">New in v5.0</span>
 
 - Scope: GLOBAL

--- a/system-variables.md
+++ b/system-variables.md
@@ -1130,7 +1130,7 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 - Default value: `86400`
 - Range: `[600, 31536000]`
 - Unit: Seconds
-- This variable is used to set the maximum time of GC safe point blocked by uncommitted transactions. During GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of uncommitted transactions does not exceed this value, GC safe point will be blocked until the runtime exceeds this value.
+- This variable is used to set the maximum time that active transactions block the GC safe point. During each time of GC, the safe point does not exceed the start time of the ongoing transactions by default. If the runtime of active transactions does not exceed this variable value, the GC safe point will be blocked until the runtime exceeds this value. This variable value is an integer type.
 
 ### tidb_gc_run_interval <span class="version-mark">New in v5.0</span>
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
add system variable `tidb_gc_max_wait_time` 
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/9496
https://github.com/pingcap/docs-cn/pull/9670
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
