### PR TITLE
security-compatibility-with-mysql: add info about account locking

### DIFF
--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -9,6 +9,7 @@ aliases: ['/docs/dev/security-compatibility-with-mysql/','/docs/dev/reference/se
 TiDB supports similar security functionality to MySQL 5.7, with the following exceptions:
 
 - Column level permissions are not supported
+- Account locking is not supported
 - Password expiry, as well as password last-changed tracking and password lifetime are not supported [#9709](https://github.com/pingcap/tidb/issues/9709)
 - The permission attributes `max_questions`, `max_updated`, `max_connections`, `max_user_connections` are not supported
 - Password validation is not currently supported [#9741](https://github.com/pingcap/tidb/issues/9741)


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Explicitly list support of `ALTER USER ... ACCOUNT LOCK`.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


### Example

```
mysql> CREATE USER 'test'@'%' IDENTIFIED BY 'test';
Query OK, 0 rows affected (0.05 sec)

mysql> SHOW CREATE USER 'test'@'%'\G
*************************** 1. row ***************************
CREATE USER for test@%: CREATE USER 'test'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*94BDCEBE19083CE2A1F959FD02F964C7AF4CFC29' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK
1 row in set (0.00 sec)

mysql> ALTER USER 'test'@'%' ACCOUNT LOCK;
Query OK, 0 rows affected, 1 warning (0.01 sec)

mysql> SHOW WARNINGS;
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                                                                                                                                         |
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1064 | You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 34 near ""TiDB does not support PASSWORD EXPIRE and ACCOUNT LOCK now, they would be parsed but ignored.  |
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> SHOW CREATE USER 'test'@'%'\G
*************************** 1. row ***************************
CREATE USER for test@%: CREATE USER 'test'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*94BDCEBE19083CE2A1F959FD02F964C7AF4CFC29' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK
1 row in set (0.00 sec)

mysql> SELECT tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v6.2.0-alpha
Edition: Community
Git Commit Hash: 7f023bd61b6228a40d626f49e1cb0c37c8222b85
Git Branch: heads/refs/tags/v6.2.0-alpha
UTC Build Time: 2022-05-29 14:59:48
GoVersion: go1.18.2
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
1 row in set (0.01 sec)
```