### PR TITLE
Correct MySQL Shell/Client section

### DIFF
--- a/develop/dev-guide-connect-to-tidb.md
+++ b/develop/dev-guide-connect-to-tidb.md
@@ -9,9 +9,19 @@ TiDB is highly compatible with the MySQL 5.7 protocol. For a full list of client
 
 TiDB supports the [MySQL Client/Server Protocol](https://dev.mysql.com/doc/internals/en/client-server-protocol.html), which allows most client drivers and ORM frameworks to connect to TiDB just as they connect to MySQL.
 
-## MySQL Shell
+You can choose to use MySQL Client or MySQL Shell based on your personal preferences.
 
-You can connect to TiDB using MySQL Shell, which can be used as a command-line tool for TiDB. To install MySQL Shell, follow the instructions in the [MySQL Shell documentation](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install.html). After the installation, you can connect to TiDB using the following command:
+## MySQL Client
+
+You can connect to TiDB using MySQL Client, which can be used as a command-line tool for TiDB. To install MySQL Client, follow the instructions below for YUM based Linux distributions.
+
+{{< copyable "shell-regular" >}}
+
+```shell
+sudo yum install mysql
+```
+
+After the installation, you can connect to TiDB using the following command:
 
 {{< copyable "shell-regular" >}}
 
@@ -19,9 +29,15 @@ You can connect to TiDB using MySQL Shell, which can be used as a command-line t
 mysql --host <tidb_server_host> --port 4000 -u root -p --comments
 ```
 
-> **Note:**
->
-> The MySQL Shell earlier than version 5.7.7 clears [Optimizer Hints](/optimizer-hints.md#optimizer-hints) by default. If you need to use the Hint syntax in an earlier MySQL Shell version, add the `--comments` option when starting the client.
+## MySQL Shell
+
+You can connect to TiDB using MySQL Shell, which can be used as a command-line tool for TiDB. To install MySQL Shell, follow the instructions in the [MySQL Shell documentation](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install.html). After the installation, you can connect to TiDB using the following command:
+
+{{< copyable "shell-regular" >}}
+
+```shell
+mysqlsh --sql mysql://root@<tidb_server_host>:4000
+```
 
 ## JDBC
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

There are two official commandline clients for MySQL, both opensource and released by the Oracle MySQL team.

1. MySQL Client (`mysql`), which is part of the MySQL Server code base, but can be installed separately via `yum install mysql` on most YUM based linux distributions. With [the offical YUM repo](https://dev.mysql.com/doc/refman/8.0/en/linux-installation-yum-repo.html) this becomes `yum install mysql-community-client`. This client is written in C and has existed for as long as MySQL does.

2. MySQL Shell (`mysqlsh`), which is a separate code base and can be installed separately. This is a newer tool and supports SQL, but also JS and Python. It has a more modern code base and is more extendable than the 'old' client.

It looks like these two were mixed up into a single section of the docs.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
