### PR TITLE
tikv: Fix storage.api-version position

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -390,21 +390,6 @@ Configuration items related to storage.
 + If the recovery fails to finish within this time window, TiKV will panic.
 + Default value: 1h
 
-## storage.block-cache
-
-Configuration items related to the sharing of block cache among multiple RocksDB Column Families (CF). When these configuration items are enabled, block cache separately configured for each column family is disabled.
-
-### `shared`
-
-+ Enables or disables the sharing of block cache.
-+ Default value: `true`
-
-### `capacity`
-
-+ The size of the shared block cache.
-+ Default value: 45% of the size of total system memory
-+ Unit: KB|MB|GB
-
 ### `api-version` <span class="version-mark">New in v6.1.0</span>
 
 + The storage format and interface version used by TiKV when TiKV serves as the raw key-value store.
@@ -422,6 +407,21 @@ Configuration items related to the sharing of block cache among multiple RocksDB
 > - TiKV API V2 is still an experimental feature. It is not recommended to use it in production environments.
 > - You can set the value of `api-version` to `2` **only when** deploying a new TiKV cluster. **Do not** modify the value of this configuration item in an existing TiKV cluster. TiKV clusters with different `api-version` values use different data formats. Therefore, if you modify the value of this item in an existing TiKV cluster, the cluster will store data in different formats and causes data corruption. It will raise the "unable to switch storage.api_version" error when you start the TiKV cluster.
 > - After API V2 is enabled, you **cannot** downgrade the TiKV cluster to a version earlier than v6.1.0. Otherwise, data corruption might occur.
+
+## storage.block-cache
+
+Configuration items related to the sharing of block cache among multiple RocksDB Column Families (CF). When these configuration items are enabled, block cache separately configured for each column family is disabled.
+
+### `shared`
+
++ Enables or disables the sharing of block cache.
++ Default value: `true`
+
+### `capacity`
+
++ The size of the shared block cache.
++ Default value: 45% of the size of total system memory
++ Unit: KB|MB|GB
 
 ## storage.flow-control
 


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
Fix configuration item storage.api-version to right position.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/9718
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
