### PR TITLE
Add `max-days` and `max-backups` default value 0 means for PD

### DIFF
--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -158,11 +158,13 @@ Configuration items related to the log file
 ### `max-days`
 
 + The maximum number of days in which a log is kept
++ If the configuration item is not set, or the value of it is set to the default value 0, PD does not clean log files.
 + Default value: `0`
 
 ### `max-backups`
 
 + The maximum number of log files to keep
++ If the configuration item is not set, or the value of it is set to the default value 0, PD keeps all log files.
 + Default value: `0`
 
 ## `metric`


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This pull request adds `max-days` and `max-backups` default value 0 means for PD configuration guide. There is a similar document for TiKV's `max-days` and `max-backups` via https://github.com/pingcap/docs/pull/7425 There is no PD one.


Here are the technical backgrounds for these documentation changes.

1. max-days at PD configuration

https://github.com/tikv/pd/blob/b5e113436c85f81d0e6ca2b5b592271114089db2/conf/config.toml#L97

```
# max-days = 0
```

https://github.com/tikv/pd/blob/b5e113436c85f81d0e6ca2b5b592271114089db2/pkg/logutil/log.go#L33-L34

```
// Max log keep days, default is never deleting.
  MaxDays int `toml:"max-days" json:"max-days"`
```
It says "default is never deleting."

2. max-backups at PD configuration

https://github.com/tikv/pd/blob/b5e113436c85f81d0e6ca2b5b592271114089db2/conf/config.toml#L99
```
# max-backups = 0
```

https://github.com/tikv/pd/blob/b5e113436c85f81d0e6ca2b5b592271114089db2/pkg/logutil/log.go#L35-L36
```
  // Maximum number of old log files to retain.
  MaxBackups int `toml:"max-backups" json:"max-backups"`
```
`log.go` does not anything about the default value. Based on the method lookup, I believe MaxBackups default behavior is defined by https://github.com/natefinch/lumberjack default value as follows.

https://github.com/pingcap/log/blob/07caf4f152b9d53fedb241dc5e5aaa282fdaa74b/log.go#L126
```
    MaxBackups: cfg.MaxBackups,
```

https://github.com/natefinch/lumberjack/blob/47ffae23317c5951a2a6267a069cf676edf53eb6/lumberjack.go#L96-L99
```
  // MaxBackups is the maximum number of old log files to retain.  The default
  // is to retain all old log files (though MaxAge may still cause them to get
  // deleted.)
  MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.2 (TiDB 6.2 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
