### PR TITLE
clustered-indexes.md: change the system variable default value to `ON`

### DIFF
--- a/clustered-indexes.md
+++ b/clustered-indexes.md
@@ -67,7 +67,7 @@ For statements that do not explicitly specify the keyword `CLUSTERED`/`NONCLUSTE
 - `ON` indicates that primary keys are created as clustered indexes by default.
 - `INT_ONLY` indicates that the behavior is controlled by the configuration item `alter-primary-key`. If `alter-primary-key` is set to `true`, primary keys are created as non-clustered indexes by default. If it is set to `false`, only the primary keys which consist of an integer column are created as clustered indexes.
 
-The default value of `@@global.tidb_enable_clustered_index` is `INT_ONLY`.
+The default value of `@@global.tidb_enable_clustered_index` is `ON`.
 
 ### Add or drop clustered indexes
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1012,7 +1012,7 @@ Constraint checking is always performed in place for pessimistic transactions (d
 - Scope: SESSION | GLOBAL
 - Persists to cluster: Yes
 - Type: Enumeration
-- Default value: `INT_ONLY`
+- Default value: `ON`
 - Possible values: `OFF`, `ON`, `INT_ONLY`
 - This variable is used to control whether to create the primary key as a [clustered index](/clustered-indexes.md) by default. "By default" here means that the statement does not explicitly specify the keyword `CLUSTERED`/`NONCLUSTERED`. Supported values are `OFF`, `ON`, and `INT_ONLY`:
     - `OFF` indicates that primary keys are created as non-clustered indexes by default.


### PR DESCRIPTION
Signed-off-by: Aolin <aolin.zhang@pingcap.com>

### What is changed, added or deleted? (Required)

Since TiDB v6.3.0, the default value of `tidb_enable_clustered_index` is modified from `INT_ONLY` to `ON`.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.3 (TiDB 6.3 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/11177
- Other reference link(s): https://github.com/pingcap/tidb/pull/37384

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
