### PR TITLE
tiflash: dt_enable_read_thread deprecated

### DIFF
--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -207,7 +207,6 @@ delta_index_cache_size = 0
     ## New in v6.2.0. This item specifies the minimum ratio of valid data in a PageStorage data file. When the ratio of valid data in a PageStorage data file is less than the value of this configuration, GC is triggered to compact data in the file. The default value is 0.5.
     dt_page_gc_threshold = 0.5
 
-    ## This parameter has been deprecated since v6.3.0. It is enabled by default and cannot be disabled.
     # dt_enable_read_thread = false
 
 ## Security settings take effect starting from v4.0.5.

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -207,9 +207,7 @@ delta_index_cache_size = 0
     ## New in v6.2.0. This item specifies the minimum ratio of valid data in a PageStorage data file. When the ratio of valid data in a PageStorage data file is less than the value of this configuration, GC is triggered to compact data in the file. The default value is 0.5.
     dt_page_gc_threshold = 0.5
 
-    ## New in v6.2.0. Use the thread pool to handle read requests from the storage engine. The default value is false.
-    ## Warning: This is still an experimental feature. It is NOT recommended that you use it in the production environment.
-
+    ## This parameter has been deprecated since v6.3.0. It is enabled by default and cannot be disabled.
     # dt_enable_read_thread = false
 
 ## Security settings take effect starting from v4.0.5.

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -207,7 +207,6 @@ delta_index_cache_size = 0
     ## New in v6.2.0. This item specifies the minimum ratio of valid data in a PageStorage data file. When the ratio of valid data in a PageStorage data file is less than the value of this configuration, GC is triggered to compact data in the file. The default value is 0.5.
     dt_page_gc_threshold = 0.5
 
-    # dt_enable_read_thread = false
 
 ## Security settings take effect starting from v4.0.5.
 [security]


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

dt_enable_read_thread is deprecated. Enabled by default and cannot be changed. 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.3 (TiDB 6.3 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/11203
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
