### PR TITLE
add description for enable-table-lock

### DIFF
--- a/experimental-features.md
+++ b/experimental-features.md
@@ -34,6 +34,7 @@ This document introduces the experimental features of TiDB in different versions
 + [Generated Columns](/generated-columns.md) (Introduced in v2.1)
 + [User-Defined Variables](/user-defined-variables.md) (Introduced in v2.1)
 + [Cascades Planner](/system-variables.md#tidb_enable_cascades_planner): a cascades framework-based top-down query optimizer (Introduced in v3.0)
++ [Table Lock](/tidb-configuration-file.md) (Introduced in v4.0.0)
 + [Metadata Lock](/metadata-lock.md) (Introduced in v6.3.0)
 + [Range INTERVAL partitioning](/partitioned-table.md#range-interval-partitioning) (Introduced in v6.3.0)
 + [Add index acceleration](/system-variables.md#tidb_ddl_enable_fast_reorg-new-in-v630) (Introduced in v6.3.0)

--- a/experimental-features.md
+++ b/experimental-features.md
@@ -34,7 +34,7 @@ This document introduces the experimental features of TiDB in different versions
 + [Generated Columns](/generated-columns.md) (Introduced in v2.1)
 + [User-Defined Variables](/user-defined-variables.md) (Introduced in v2.1)
 + [Cascades Planner](/system-variables.md#tidb_enable_cascades_planner): a cascades framework-based top-down query optimizer (Introduced in v3.0)
-+ [Table Lock](/tidb-configuration-file.md) (Introduced in v4.0.0)
++ [Table Lock](/tidb-configuration-file.md#enable-table-lock-new-in-v400) (Introduced in v4.0.0)
 + [Metadata Lock](/metadata-lock.md) (Introduced in v6.3.0)
 + [Range INTERVAL partitioning](/partitioned-table.md#range-interval-partitioning) (Introduced in v6.3.0)
 + [Add index acceleration](/system-variables.md#tidb_ddl_enable_fast_reorg-new-in-v630) (Introduced in v6.3.0)

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -174,7 +174,7 @@ The TiDB configuration file supports more options than command-line parameters. 
 
 + Controls whether to enable the table lock feature.
 + Default value: `false`
-+ The table lock is used to coordinate concurrent access to the same table with multiple sessions. Currently, the `READ`, `WRITE`, and `WRITE LOCAL` lock types are supported. When the configuration item is set to `false`, executing the `LOCK TABLE` or `UNLOCK TABLE` statement does not take effect and returns the "LOCK/UNLOCK TABLES is not supported" warning.
++ The table lock is used to coordinate concurrent access to the same table among multiple sessions. Currently, the `READ`, `WRITE`, and `WRITE LOCAL` lock types are supported. When the configuration item is set to `false`, executing the `LOCK TABLE` or `UNLOCK TABLE` statement does not take effect and returns the "LOCK/UNLOCK TABLES is not supported" warning.
 
 ## Log
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -166,6 +166,16 @@ The TiDB configuration file supports more options than command-line parameters. 
 + If the environment might have isolated network, enabling this parameter can reduce the window of service unavailability.
 + If you cannot accurately determine whether isolation, network interruption, or downtime has occurred, using this mechanism has the risk of misjudgment and causes reduced availability and performance. If network failure has never occurred, it is not recommended to enable this parameter.
 
+### `enable-table-lock` <span class="version-mark">New in v4.0.0</span>
+
+> **Warning:**
+>
+> The table lock is an experimental feature. It is not recommended that you use it in the production environment.
+
++ Controls whether to enable the table lock feature.
++ Default value: `false`
++ The table lock is used to coordinate concurrent access to the same table with multiple sessions. Currently, the `READ`, `WRITE`, and `WRITE LOCAL` lock types are supported. When the configuration item is set to `false`, executing the `LOCK TABLE` or `UNLOCK TABLE` statement does not take effect and returns the "LOCK/UNLOCK TABLES is not supported" warning.
+
 ## Log
 
 Configuration items related to log.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Since TiDB v4.0.0, LOCK TABLE is introduced as an experimental feature and you can use the `LOCK TABLE` or `UNLOCK TABLE` when setting the `enable-table-lock` to `true`.

Fix https://github.com/pingcap/docs/issues/6831

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.3 (TiDB 6.3 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/11808
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
