### PR TITLE
command-line-flags-for-tidb-configuration: Add missing flags

### DIFF
--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -14,11 +14,6 @@ When you start the TiDB cluster, you can use command-line options or environment
 - Default: `""`
 - This address must be accessible by the rest of the TiDB cluster and the user.
 
-## `--alsologtostderr`
-
-- Also send logging to standard error when a log file is supplied.
-- Default: `false`
-
 ## `--config`
 
 - The configuration file
@@ -72,21 +67,6 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 - The duration of the schema lease. It is **dangerous** to change the value unless you know what you do.
 - Default: `45s`
-
-## `--log_backtrace_at`
-
-- When logging hits line `file:N`, emit a stack trace.
-- Default: `""`
-
-## `--log_dir`
-
-- If non-empty, write log files in this directory
-- Default: `""`
-
-## `--logtostderr`
-
-- Log to standard error instead of files.
-- Default: `false`
 
 ## `--log-file`
 
@@ -237,13 +217,3 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 + The names of the tables to be repaired in the repair mode.
 + Default: `""`
-
-## `-v`
-
-- log level for V logs
-- Default: `""`
-
-## `-vmodule`
-
-- comma-separated list of `pattern=N` settings for file-filtered logging
-- Default: `""`

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -166,11 +166,6 @@ When you start the TiDB cluster, you can use command-line options or environment
 - The `HOST` used to monitor the status of TiDB service
 - Default: `0.0.0.0`
 
-## `-stderrthreshold`
-
-- Logs at or above this threshold go to stderr.
-- Default: `""`
-
 ## `--store`
 
 - Specifies the storage engine used by TiDB in the bottom layer

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -35,6 +35,11 @@ When you start the TiDB cluster, you can use command-line options or environment
 - Specifies the `Access-Control-Allow-Origin` value for Cross-Origin Request Sharing (CORS) request of the TiDB HTTP status service
 - Default: `""`
 
+## `--enable-binlog`
+
++ Enables or disables TiDB binlog generation
++ Default: `false`
+
 ## `--host`
 
 - The host address that the TiDB server monitors
@@ -44,18 +49,13 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 ## `--initialize-insecure`
 
-- Bootstrap tidb-server in insecure mode
+- Bootstraps tidb-server in insecure mode
 - Default: `true`
 
 ## `--initialize-secure`
 
-- Bootstrap tidb-server in secure mode
+- Bootstraps tidb-server in secure mode
 - Default: `false`
-
-## `--enable-binlog`
-
-+ Enables or disables TiDB binlog generation
-+ Default: `false`
 
 ## `-L`
 
@@ -174,7 +174,7 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 ## `--temp-dir`
 
-- TiDB temporary directory
+- The temporary directory of TiDB
 - Default: `"/tmp/tidb"`
 
 ## `--token-limit`

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -14,6 +14,11 @@ When you start the TiDB cluster, you can use command-line options or environment
 - Default: `""`
 - This address must be accessible by the rest of the TiDB cluster and the user.
 
+## `--alsologtostderr`
+
+- Also send logging to standard error when a log file is supplied.
+- Default: `false`
+
 ## `--config`
 
 - The configuration file
@@ -42,6 +47,16 @@ When you start the TiDB cluster, you can use command-line options or environment
 - The TiDB server monitors this address.
 - The `"0.0.0.0"` address monitors all network cards by default. If you have multiple network cards, specify the network card that provides service, such as `192.168.100.113`.
 
+## `--initialize-insecure`
+
+- Bootstrap tidb-server in insecure mode
+- Default: `true`
+
+## `--initialize-secure`
+
+- Bootstrap tidb-server in secure mode
+- Default: `false`
+
 ## `--enable-binlog`
 
 + Enables or disables TiDB binlog generation
@@ -57,6 +72,21 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 - The duration of the schema lease. It is **dangerous** to change the value unless you know what you do.
 - Default: `45s`
+
+## `--log_backtrace_at`
+
+- When logging hits line `file:N`, emit a stack trace.
+- Default: `""`
+
+## `--log_dir`
+
+- If non-empty, write log files in this directory
+- Default: `""`
+
+## `--logtostderr`
+
+- Log to standard error instead of files.
+- Default: `false`
 
 ## `--log-file`
 
@@ -156,11 +186,21 @@ When you start the TiDB cluster, you can use command-line options or environment
 - The `HOST` used to monitor the status of TiDB service
 - Default: `0.0.0.0`
 
+## `-stderrthreshold`
+
+- Logs at or above this threshold go to stderr.
+- Default: `""`
+
 ## `--store`
 
 - Specifies the storage engine used by TiDB in the bottom layer
 - Default: `"unistore"`
 - You can choose "unistore" or "tikv". ("unistore" is the local storage engine; "tikv" is a distributed storage engine)
+
+## `--temp-dir`
+
+- TiDB temporary directory
+- Default: `"/tmp/tidb"`
 
 ## `--token-limit`
 
@@ -197,3 +237,13 @@ When you start the TiDB cluster, you can use command-line options or environment
 
 + The names of the tables to be repaired in the repair mode.
 + Default: `""`
+
+## `-v`
+
+- log level for V logs
+- Default: `""`
+
+## `-vmodule`
+
+- comma-separated list of `pattern=N` settings for file-filtered logging
+- Default: `""`


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add missing flags for `tidb-server`.

```
$ diff <(path/to/tidb/bin/tidb-server -h 2>&1 | awk '/^  -/ { print $1 }' | sort) <(awk '/^##/ { print $2 }' command-line-flags-for-tidb-configuration.md | cut -d\` -f2 | sed -e 's/--/-/g' | sort)
3d2
< -alsologtostderr
9d7
< -help
11,12d8
< -initialize-insecure
< -initialize-secure
15,16d10
< -log_backtrace_at
< -log_dir
19d12
< -logtostderr
35d27
< -stderrthreshold
37d28
< -temp-dir
39d29
< -v
41d30
< -vmodule
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->


- [x] master (the latest development version)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.3 (TiDB 6.3 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/tidb/pull/28482
  - https://github.com/pingcap/tidb/pull/28487
  - https://github.com/pingcap/tidb/pull/36088

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
