### PR TITLE
data-type-string: Corrections

### DIFF
--- a/data-type-string.md
+++ b/data-type-string.md
@@ -62,7 +62,7 @@ MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ### `LONGTEXT` type
 
-The `LONGTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `LONGTEXT` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
+The `LONGTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `LONGTEXT` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be increased to 120 MiB by changing the configuration.
 
 ```sql
 LONGTEXT [CHARACTER SET charset_name] [COLLATE collation_name]

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -54,7 +54,7 @@ TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ### `MEDIUMTEXT` type
 
-The `MEDIUMTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `MEDIUMTEXT` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
+The `MEDIUMTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `MEDIUMTEXT` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be increased to 120 MiB by changing the configuration.
 
 ```sql
 MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -110,7 +110,7 @@ MEDIUMBLOB
 
 ### `LONGBLOB` type
 
-The `LONGBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `LONGBLOB` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
+The `LONGBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `LONGBLOB` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be increased to 120 MiB by changing the configuration.
 
 ```sql
 LONGBLOB

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -38,7 +38,7 @@ The space occupied by a single character might differ for different character se
 
 ### `TEXT` type
 
-`TEXT` is a string of variable-length. M represents the maximum column length in characters, ranging from 0 to 65,535. The maximum row length and the character set being used determine the `TEXT` length.
+`TEXT` is a string of variable-length. The maxium column length is 65,535 bytes. The optional M is in characters and is used to select the best type of `TEXT` column. For example `TEXT(60)` will yield a `TINYTEXT` data type that can hold up to 255 bytes, which fits a 60 character UTF-8 string that has up to 4 bytes per character (4×60=240). Using the M argument is not recommended.
 
 ```sql
 TEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]
@@ -54,7 +54,7 @@ TINYTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ### `MEDIUMTEXT` type
 
-The `MEDIUMTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `MEDIUMTEXT` is 16,777,215.
+The `MEDIUMTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `MEDIUMTEXT` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
 
 ```sql
 MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
@@ -62,7 +62,7 @@ MEDIUMTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
 
 ### `LONGTEXT` type
 
-The `LONGTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `LONGTEXT` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MB.
+The `LONGTEXT` type is similar to the [`TEXT` type](#text-type). The difference is that the maximum column length of `LONGTEXT` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
 
 ```sql
 LONGTEXT [CHARACTER SET charset_name] [COLLATE collation_name]
@@ -102,7 +102,7 @@ TINYBLOB
 
 ### `MEDIUMBLOB` type
 
-The `MEDIUMBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `MEDIUMBLOB` is 16,777,215.
+The `MEDIUMBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `MEDIUMBLOB` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
 
 ```sql
 MEDIUMBLOB
@@ -110,7 +110,7 @@ MEDIUMBLOB
 
 ### `LONGBLOB` type
 
-The `LONGBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `LONGBLOB` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MB.
+The `LONGBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `LONGBLOB` is 4,294,967,295. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
 
 ```sql
 LONGBLOB

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -102,7 +102,7 @@ TINYBLOB
 
 ### `MEDIUMBLOB` type
 
-The `MEDIUMBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `MEDIUMBLOB` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be raised to 120 MiB by changing the configuration.
+The `MEDIUMBLOB` type is similar to the [`BLOB` type](#blob-type). The difference is that the maximum column length of `MEDIUMBLOB` is 16,777,215. But due to the [Limitation on a single column in TiDB](/tidb-limitations.md#limitation-on-a-single-column), the maximum storage size of a single column in TiDB is 6 MiB by default and can be increased to 120 MiB by changing the configuration.
 
 ```sql
 MEDIUMBLOB

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -38,7 +38,7 @@ The space occupied by a single character might differ for different character se
 
 ### `TEXT` type
 
-`TEXT` is a string of variable-length. The maxium column length is 65,535 bytes. The optional M is in characters and is used to select the best type of `TEXT` column. For example `TEXT(60)` will yield a `TINYTEXT` data type that can hold up to 255 bytes, which fits a 60 character UTF-8 string that has up to 4 bytes per character (4×60=240). Using the M argument is not recommended.
+`TEXT` is a string of variable-length. The maximum column length is 65,535 bytes. The optional M argument is in characters and is used to automatically select the fittest type of a `TEXT` column. For example `TEXT(60)` will yield a `TINYTEXT` data type that can hold up to 255 bytes, which fits a 60-character UTF-8 string that has up to 4 bytes per character (4×60=240). Using the M argument is not recommended.
 
 ```sql
 TEXT[(M)] [CHARACTER SET charset_name] [COLLATE collation_name]


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Add remark about default row/column sizes for types that are over the default 6 MiB.
- Correct the text for `TEXT(M)`

From [the mysql docs on string data types](https://dev.mysql.com/doc/refman/8.0/en/string-type-syntax.html):

> An optional length M can be given for this type. If this is done, MySQL creates the column as the smallest TEXT type large enough to hold values M characters long. 

```
sql> CREATE TABLE t1 (id int primary key, c1 TEXT(60), c2 TEXT(70), c3 TEXT(70) CHARSET ASCII);
Query OK, 0 rows affected (0.1513 sec)

sql> SHOW CREATE TABLE t1\G
*************************** 1. row ***************************
       Table: t1
Create Table: CREATE TABLE `t1` (
  `id` int(11) NOT NULL,
  `c1` tinytext DEFAULT NULL,
  `c2` text DEFAULT NULL,
  `c3` tinytext CHARACTER SET ascii COLLATE ascii_bin DEFAULT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
1 row in set (0.0003 sec)

sql> CREATE TABLE t1 (id int primary key, c1 TEXT(0));
ERROR: 1050 (42S01): Table 'test.t1' already exists
```
So:
- `TEXT(60)` results in `TINYTEXT` (60×4=240, which is less than 255)
- `TEXT(70)` results in `TEXT` (70×4=280, which is more than 255)
- `TEXT(70) CHARACTER SET ASCII` results in `TINYTEXT` (70×1=70, which is less than 255)

```
sql> CREATE TABLE t2 (id int primary key, c1 TEXT(0));
Query OK, 0 rows affected (0.1293 sec)

sql> INSERT INTO t2 VALUES (1, 'some text');
Query OK, 1 row affected (0.0112 sec)

sql> TABLE t2;
+----+-----------+
| id | c1        |
+----+-----------+
|  1 | some text |
+----+-----------+
1 row in set (0.0011 sec)

sql> SHOW CREATE TABLE t2\G
*************************** 1. row ***************************
       Table: t2
Create Table: CREATE TABLE `t2` (
  `id` int(11) NOT NULL,
  `c1` tinytext DEFAULT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
1 row in set (0.0003 sec)
```
This is to show that a `TEXT(0)` can actually hold a string of 9 characters (and 9 bytes).

```
sql> CREATE TABLE t3 (id int primary key, c1 TEXT(4294967296));
ERROR: 1439 (42000): Display width out of range for column 'c1' (max = 4294967295)

sql> CREATE TABLE t3 (id int primary key, c1 TEXT(4294967295));
Query OK, 0 rows affected (0.1685 sec)
```
This error says this is the display width, but I don't think that's really true as that is only used for integer types.

Closes #4014

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.3 (TiDB 6.3 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/docs/pull/10629

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


