### PR TITLE
*: always enable block cache

### DIFF
--- a/hybrid-deployment-topology.md
+++ b/hybrid-deployment-topology.md
@@ -48,15 +48,9 @@ This section introduces the key parameters when you deploy multiple instances on
             ```
             readpool.unified.max-thread-count = cores * 0.8 / the number of TiKV instances
             ```
-        
+
     - To configure the storage CF (all RocksDB column families) to be self-adaptive to memory. By configuring the `storage.block-cache.capacity` parameter, you can make CF automatically balance the memory usage.
 
-        - `storage.block-cache` enables the CF self-adaptation by default. You do not need to modify it.
-
-            ```yaml
-            storage.block-cache.shared: true
-            ```
-        
         - The calculation method:
 
             ```

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1262,7 +1262,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 ### `block-cache-size`
 
-+ The cache size of a RocksDB block. Starting from v6.6.0, this configuration is only used to set the default value of `storage.block-cache.capacity`.
++ The cache size of a RocksDB block. Starting from v6.6.0, this configuration is only used to calculate the default value of `storage.block-cache.capacity`.
 + Default value for `defaultcf`: `Total machine memory * 25%`
 + Default value for `writecf`: `Total machine memory * 15%`
 + Default value for `lockcf`: `Total machine memory * 2%`

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -491,12 +491,7 @@ Configuration items related to storage.
 
 ## storage.block-cache
 
-Configuration items related to the sharing of block cache among multiple RocksDB Column Families (CF). When these configuration items are enabled, block cache separately configured for each column family is disabled.
-
-### `shared`
-
-+ Enables or disables the sharing of block cache.
-+ Default value: `true`
+Configuration items related to the sharing of block cache among multiple RocksDB Column Families (CF).
 
 ### `capacity`
 
@@ -1267,7 +1262,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 ### `block-cache-size`
 
-+ The cache size of a RocksDB block
++ The cache size of a RocksDB block. Starting from v6.6.0, this configuration is only used to set the default value of `storage.block-cache.capacity`.
 + Default value for `defaultcf`: `Total machine memory * 25%`
 + Default value for `writecf`: `Total machine memory * 15%`
 + Default value for `lockcf`: `Total machine memory * 2%`

--- a/tune-tikv-memory-performance.md
+++ b/tune-tikv-memory-performance.md
@@ -22,7 +22,7 @@ TiKV implements `Column Families` (CF) from RocksDB.
 
     - The `default` CF stores the Raft log. The corresponding parameters are in `[raftdb.defaultcf]`.
 
-After TiKV 3.0, by default, all CFs share one block cache instance. You can configure the size of the cache by setting the `capacity` parameter under `[storage.block-cache]`. The bigger the block cache, the more hot data can be cached, and the easier to read data, in the meantime, the more system memory is occupied. To use a separate block cache instance for each CF, set `shared=false` under `[storage.block-cache]`, and configure individual block cache size for each CF. For example, you can configure the size of `write` CF by setting the `block-cache-size` parameter under `[rocksdb.writecf]`.
+After TiKV 3.0, by default, all CFs share one block cache instance. You can configure the size of the cache by setting the `capacity` parameter under `[storage.block-cache]`. The bigger the block cache, the more hot data can be cached, and the easier to read data, in the meantime, the more system memory is occupied.
 
 Before TiKV 3.0, shared block cache is not supported, and you need to configure block cache for each CF individually.
 
@@ -73,6 +73,7 @@ log-level = "info"
 ##
 ## The rest of config in the storage.block-cache session is effective only when shared block cache
 ## is on.
+## Starting from v6.6.0, the `shared` option is always enabled and cannot be disabled.
 # shared = true
 
 ## Size of the shared block cache. Normally it should be tuned to 30%-50% of system's total memory.


### PR DESCRIPTION
Signed-off-by: Aolin <aolin.zhang@pingcap.com>

### What is changed, added or deleted? (Required)

- Remove `storage.block-cache.shared` in v6.6

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/12241
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
