### PR TITLE
tiflash: update config description of max_memory_usage_for_all_queries

### DIFF
--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -178,13 +178,19 @@ delta_index_cache_size = 0
     ## see known issue [#5576](https://github.com/pingcap/tiflash/issues/5576).
     # dt_enable_logical_split = false
 
-    ## The memory usage limit for the generated intermediate data when a single
-    ## coprocessor query is executed. The default value is 0, which means no limit.
+    ## The memory usage limit for the generated intermediate data in a single query.
+    ## When the value is an integer, the unit is byte. For example, 34359738368 means 32 GiB of memory limit, and 0 means no limit.
+    ## When the value is a floating-point number in the range of [0.0, 1.0), it means the ratio of the allowed memory usage to the total memory of the node. For example, 0.8 means 80% of the total memory, and 0.0 means no limit.
+    ## The default value is 0, which means no limit.
+    ## When a query attempts to consume memory that exceeds the limit of this parameter, the query is terminated and an error is reported.
     max_memory_usage = 0
 
-    ## The memory usage limit for the generated intermediate data when all queries
-    ## are executed. The default value is 0 (in bytes), which means no limit.
-    max_memory_usage_for_all_queries = 0
+    ## The memory usage limit for the generated intermediate data in all queries.
+    ## When the value is an integer, the unit is byte. For example, 34359738368 means 32 GiB of memory limit, and 0 means no limit.
+    ## When the value is a floating-point number in the range of [0.0, 1.0), it means the ratio of the allowed memory usage to the total memory of the node. For example, 0.8 means 80% of the total memory, and 0.0 means no limit.
+    ## The default value is 0.8, which means 80% of the total memory.
+    ## When the queries attempt to consume memory that exceeds the limit of this parameter, the queries are terminated and an error is reported.
+    max_memory_usage_for_all_queries = 0.8
 
     ## New in v5.0. This item specifies the maximum number of cop requests that TiFlash Coprocessor executes at the same time. If the number of requests exceeds the specified value, the exceeded requests will queue. If the configuration value is set to 0 or not set, the default value is used, which is twice the number of physical cores.
     cop_pool_size = 0

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -182,7 +182,7 @@ delta_index_cache_size = 0
     ## When the value is an integer, the unit is byte. For example, 34359738368 means 32 GiB of memory limit, and 0 means no limit.
     ## When the value is a floating-point number in the range of [0.0, 1.0), it means the ratio of the allowed memory usage to the total memory of the node. For example, 0.8 means 80% of the total memory, and 0.0 means no limit.
     ## The default value is 0, which means no limit.
-    ## When a query attempts to consume memory that exceeds the limit of this parameter, the query is terminated and an error is reported.
+    ## When a query attempts to consume memory that exceeds the limit, the query is terminated and an error is reported.
     max_memory_usage = 0
 
     ## The memory usage limit for the generated intermediate data in all queries.

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -182,14 +182,14 @@ delta_index_cache_size = 0
     ## When the value is an integer, the unit is byte. For example, 34359738368 means 32 GiB of memory limit, and 0 means no limit.
     ## When the value is a floating-point number in the range of [0.0, 1.0), it means the ratio of the allowed memory usage to the total memory of the node. For example, 0.8 means 80% of the total memory, and 0.0 means no limit.
     ## The default value is 0, which means no limit.
-    ## When a query attempts to consume memory that exceeds the limit, the query is terminated and an error is reported.
+    ## When a query attempts to consume memory that exceeds this limit, the query is terminated and an error is reported.
     max_memory_usage = 0
 
     ## The memory usage limit for the generated intermediate data in all queries.
     ## When the value is an integer, the unit is byte. For example, 34359738368 means 32 GiB of memory limit, and 0 means no limit.
     ## When the value is a floating-point number in the range of [0.0, 1.0), it means the ratio of the allowed memory usage to the total memory of the node. For example, 0.8 means 80% of the total memory, and 0.0 means no limit.
     ## The default value is 0.8, which means 80% of the total memory.
-    ## When the queries attempt to consume memory that exceeds the limit of this parameter, the queries are terminated and an error is reported.
+    ## When the queries attempt to consume memory that exceeds this limit, the queries are terminated and an error is reported.
     max_memory_usage_for_all_queries = 0.8
 
     ## New in v5.0. This item specifies the maximum number of cop requests that TiFlash Coprocessor executes at the same time. If the number of requests exceeds the specified value, the exceeded requests will queue. If the configuration value is set to 0 or not set, the default value is used, which is twice the number of physical cores.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
Starting from v6.6, the default value of `max_memory_usage_for_all_queries` changes to 0.8.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/12663
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
