### PR TITLE
sql-faq: add missing DELAYED priority

### DIFF
--- a/faq/sql-faq.md
+++ b/faq/sql-faq.md
@@ -221,7 +221,7 @@ You can combine the above two parameters with the DML of TiDB to use them. For e
     REPLACE HIGH_PRIORITY | LOW_PRIORITY | DELAYED INTO table_name;
     ```
 
-2. The full table scan statement automatically adjusts itself to a low priority. `analyze` has a low priority by default.
+2. The full table scan statement automatically adjusts itself to a low priority. [`ANALYZE`](/sql-statements/sql-statement-analyze-table.md) has a low priority by default.
 
 ## What's the trigger strategy for `auto analyze` in TiDB?
 

--- a/faq/sql-faq.md
+++ b/faq/sql-faq.md
@@ -205,6 +205,8 @@ TiDB supports changing the priority on a [global](/system-variables.md#tidb_forc
 
 - `LOW_PRIORITY`: this statement has a low priority, that is, TiDB reduces the priority of this statement during the execution period.
 
+- `DELAYED`: this statement has normal priority. This is the same as the `NO_PRIORITY` setting for `tidb_force_priority`.
+
 You can combine the above two parameters with the DML of TiDB to use them. For example:
 
 1. Adjust the priority by writing SQL statements in the database:
@@ -212,11 +214,11 @@ You can combine the above two parameters with the DML of TiDB to use them. For e
     {{< copyable "sql" >}}
 
     ```sql
-    select HIGH_PRIORITY | LOW_PRIORITY count(*) from table_name;
-    insert HIGH_PRIORITY | LOW_PRIORITY into table_name insert_values;
-    delete HIGH_PRIORITY | LOW_PRIORITY from table_name;
-    update HIGH_PRIORITY | LOW_PRIORITY table_reference set assignment_list where where_condition;
-    replace HIGH_PRIORITY | LOW_PRIORITY into table_name;
+    SELECT HIGH_PRIORITY | LOW_PRIORITY | DELAYED COUNT(*) FROM table_name;
+    INSERT HIGH_PRIORITY | LOW_PRIORITY | DELAYED INTO table_name insert_values;
+    DELETE HIGH_PRIORITY | LOW_PRIORITY | DELAYED FROM table_name;
+    UPDATE HIGH_PRIORITY | LOW_PRIORITY | DELAYED table_reference SET assignment_list WHERE where_condition;
+    REPLACE HIGH_PRIORITY | LOW_PRIORITY | DELAYED INTO table_name;
     ```
 
 2. The full table scan statement automatically adjusts itself to a low priority. `analyze` has a low priority by default.

--- a/faq/sql-faq.md
+++ b/faq/sql-faq.md
@@ -205,7 +205,7 @@ TiDB supports changing the priority on a [global](/system-variables.md#tidb_forc
 
 - `LOW_PRIORITY`: this statement has a low priority, that is, TiDB reduces the priority of this statement during the execution period.
 
-- `DELAYED`: this statement has normal priority. This is the same as the `NO_PRIORITY` setting for `tidb_force_priority`.
+- `DELAYED`: this statement has normal priority and is the same as the `NO_PRIORITY` setting for `tidb_force_priority`.
 
 You can combine the above two parameters with the DML of TiDB to use them. For example:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add the missing `DELAYED` priority

```
sql> SELECT HIGH_PRIORITY 1;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.0014 sec)

sql> SELECT LOW_PRIORITY 1;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.0004 sec)

sql> SELECT DELAYED 1;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.0004 sec)
```


see also: https://github.com/pingcap/tidb/blob/1e0956d5ba41182e603295e02ae8f767d62979e4/distsql/request_builder.go#L257-L267 


<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)


- [x] master (the latest development version)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
