### PR TITLE
ALTER TABLE .. CHANGE COLUMS is affected by metadata lock

### DIFF
--- a/metadata-lock.md
+++ b/metadata-lock.md
@@ -24,6 +24,7 @@ The metadata lock in TiDB applies to all DDL statements, such as:
 - [`DROP PARTITION`](/partitioned-table.md#partition-management)
 - [`TRUNCATE TABLE`](/sql-statements/sql-statement-truncate.md)
 - [`EXCHANGE PARTITION`](/partitioned-table.md#partition-management)
+- [`CHANGE COLUMN`](/sql-statements/sql-statement-change-column.md)
 - [`MODIFY COLUMN`](/sql-statements/sql-statement-modify-column.md)
 
 Enabling metadata lock might have some performance impact on the execution of the DDL task in TiDB. To reduce the impact, the following lists some scenarios that do not require metadata lock:


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add link to `CHANGE COLUMN` from `Metadata Lock`. 
Because while investigating https://github.com/pingcap/tidb/issues/40838 , I've found the link to `CHANGE COLUMN` from `Metadata Lock` is missing. 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
