### PR TITLE
lock-cf-compact-interval: fix the default value to 10m

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -790,7 +790,6 @@ Configuration items related to Raftstore.
 ### `lock-cf-compact-interval`
 
 + The time interval at which TiKV triggers a manual compaction for the Lock Column Family
-+ Default value: `"256MB"`
 + Default value: `"10m"`
 + Minimum value: `0`
 


### PR DESCRIPTION
Signed-off-by: Aolin <aolin.zhang@pingcap.com>

### What is changed, added or deleted? (Required)

There are two default values for `lock-cf-compact-interval` and line 793 `+ Default value: "256MB"` should be removed.

This PR applies to v3.0 and later versions

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
