### PR TITLE
lightning: add a limitation during data migration

### DIFF
--- a/tidb-lightning/tidb-lightning-physical-import-mode.md
+++ b/tidb-lightning/tidb-lightning-physical-import-mode.md
@@ -63,6 +63,7 @@ It is recommended that you allocate CPU more than 32 cores and memory greater th
 - Do not use the physical import mode to directly import data to TiDB clusters in production. It has severe performance implications. If you need to do so, refer to [Import data into a cluster in production](/tidb-lightning/tidb-lightning-physical-import-mode-usage.md#import-data-into-a-cluster-in-production).
 - Do not use multiple TiDB Lightning instances to import data to the same TiDB cluster by default. Use [Parallel Import](/tidb-lightning/tidb-lightning-distributed-import.md) instead.
 - When you use multiple TiDB Lightning to import data to the same target, do not mix the backends. That is, do not use the physical import mode and the logical import mode at the same time.
+- During the process of importing data, do not perform read or write operations in the target table. Otherwise the import will fail or the data will be inconsistent. You can perform read and write operations after the import operation is completed.
 - A single Lightning process can import a single table of 10 TB at most. Parallel import can use 10 Lightning instances at most.
 
 ### Tips for using with other components

--- a/tidb-lightning/tidb-lightning-physical-import-mode.md
+++ b/tidb-lightning/tidb-lightning-physical-import-mode.md
@@ -63,7 +63,7 @@ It is recommended that you allocate CPU more than 32 cores and memory greater th
 - Do not use the physical import mode to directly import data to TiDB clusters in production. It has severe performance implications. If you need to do so, refer to [Import data into a cluster in production](/tidb-lightning/tidb-lightning-physical-import-mode-usage.md#import-data-into-a-cluster-in-production).
 - Do not use multiple TiDB Lightning instances to import data to the same TiDB cluster by default. Use [Parallel Import](/tidb-lightning/tidb-lightning-distributed-import.md) instead.
 - When you use multiple TiDB Lightning to import data to the same target, do not mix the backends. That is, do not use the physical import mode and the logical import mode at the same time.
-- During the process of importing data, do not perform write operations in the target table. Otherwise the import will fail or the data will be inconsistent. At the same time, it is not recommended to do read operations, because the data you read might be inconsistent. You can perform read and write operations after the import operation is completed.
+- During the process of importing data, do not perform write operations in the target table. Otherwise the import will fail or the data will be inconsistent. At the same time, it is not recommended to perform read operations, because the data you read might be inconsistent. You can perform read and write operations after the import operation is completed.
 - A single Lightning process can import a single table of 10 TB at most. Parallel import can use 10 Lightning instances at most.
 
 ### Tips for using with other components

--- a/tidb-lightning/tidb-lightning-physical-import-mode.md
+++ b/tidb-lightning/tidb-lightning-physical-import-mode.md
@@ -64,6 +64,7 @@ It is recommended that you allocate CPU more than 32 cores and memory greater th
 - Do not use multiple TiDB Lightning instances to import data to the same TiDB cluster by default. Use [Parallel Import](/tidb-lightning/tidb-lightning-distributed-import.md) instead.
 - When you use multiple TiDB Lightning to import data to the same target, do not mix the backends. That is, do not use the physical import mode and the logical import mode at the same time.
 - During the process of importing data, do not perform read or write operations in the target table. Otherwise the import will fail or the data will be inconsistent. You can perform read and write operations after the import operation is completed.
+During the process of importing data, do not perform write operations in the target table. Otherwise the import will fail or the data will be inconsistent. At the same time, it is not recommended to do read operations, because the data you read might be inconsistent. You can perform read and write operations after the import operation is completed.
 - A single Lightning process can import a single table of 10 TB at most. Parallel import can use 10 Lightning instances at most.
 
 ### Tips for using with other components

--- a/tidb-lightning/tidb-lightning-physical-import-mode.md
+++ b/tidb-lightning/tidb-lightning-physical-import-mode.md
@@ -63,8 +63,7 @@ It is recommended that you allocate CPU more than 32 cores and memory greater th
 - Do not use the physical import mode to directly import data to TiDB clusters in production. It has severe performance implications. If you need to do so, refer to [Import data into a cluster in production](/tidb-lightning/tidb-lightning-physical-import-mode-usage.md#import-data-into-a-cluster-in-production).
 - Do not use multiple TiDB Lightning instances to import data to the same TiDB cluster by default. Use [Parallel Import](/tidb-lightning/tidb-lightning-distributed-import.md) instead.
 - When you use multiple TiDB Lightning to import data to the same target, do not mix the backends. That is, do not use the physical import mode and the logical import mode at the same time.
-- During the process of importing data, do not perform read or write operations in the target table. Otherwise the import will fail or the data will be inconsistent. You can perform read and write operations after the import operation is completed.
-During the process of importing data, do not perform write operations in the target table. Otherwise the import will fail or the data will be inconsistent. At the same time, it is not recommended to do read operations, because the data you read might be inconsistent. You can perform read and write operations after the import operation is completed.
+- During the process of importing data, do not perform write operations in the target table. Otherwise the import will fail or the data will be inconsistent. At the same time, it is not recommended to do read operations, because the data you read might be inconsistent. You can perform read and write operations after the import operation is completed.
 - A single Lightning process can import a single table of 10 TB at most. Parallel import can use 10 Lightning instances at most.
 
 ### Tips for using with other components


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add a limitation that users do not perform read/writer operations during data migration.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/13071
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
