### PR TITLE
Revert "*: rename tikv config server.snap-max-write-bytes-per-sec"

### DIFF
--- a/dynamic-config.md
+++ b/dynamic-config.md
@@ -209,7 +209,7 @@ The following TiKV configuration items can be modified dynamically:
 | `{db-name}.{cf-name}.titan.blob-run-mode` | The mode of processing blob files |
 | `server.grpc-memory-pool-quota` | Limits the memory size that can be used by gRPC |
 | `server.max-grpc-send-msg-len` | Sets the maximum length of a gRPC message that can be sent |
-| `server.snap-io-max-bytes-per-sec` | Sets the maximum allowable disk bandwidth when processing snapshots |
+| `server.snap-max-write-bytes-per-sec` | Sets the maximum allowable disk bandwidth when processing snapshots |
 | `server.concurrent-send-snap-limit` | Sets the maximum number of snapshots sent at the same time |
 | `server.concurrent-recv-snap-limit` | Sets the maximum number of snapshots received at the same time |
 | `server.raft-msg-max-batch-size` | Sets the maximum number of Raft messages that are contained in a single gRPC message |

--- a/tiflash/create-tiflash-replicas.md
+++ b/tiflash/create-tiflash-replicas.md
@@ -147,7 +147,7 @@ Before TiFlash replicas are added, each TiKV instance performs a full table scan
 
    ```sql
    -- The default value for both configurations are 100MiB, i.e. the maximum disk bandwidth used for writing snapshots is no more than 100MiB/s.
-   SET CONFIG tikv `server.snap-io-max-bytes-per-sec` = '300MiB';
+   SET CONFIG tikv `server.snap-max-write-bytes-per-sec` = '300MiB';
    SET CONFIG tiflash `raftstore-proxy.server.snap-max-write-bytes-per-sec` = '300MiB';
    ```
 
@@ -186,7 +186,7 @@ Before TiFlash replicas are added, each TiKV instance performs a full table scan
    Execute the following SQL statements to restore the default snapshot write speed limit:
 
    ```sql
-   SET CONFIG tikv `server.snap-io-max-bytes-per-sec` = '100MiB';
+   SET CONFIG tikv `server.snap-max-write-bytes-per-sec` = '100MiB';
    SET CONFIG tiflash `raftstore-proxy.server.snap-max-write-bytes-per-sec` = '100MiB';
    ```
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -220,7 +220,7 @@ This document only describes the parameters that are not included in command-lin
 + Default value: `"60s"`
 + Minimum value: `"1s"`
 
-### `snap-io-max-bytes-per-sec`
+### `snap-max-write-bytes-per-sec`
 
 + The maximum allowable disk bandwidth when processing snapshots
 + Default value: `"100MB"`


### PR DESCRIPTION
Reverts pingcap/docs#12962

translate from: https://github.com/pingcap/docs-cn/pull/13540