### PR TITLE
add max sleep second limitation for serverless

### DIFF
--- a/tidb-cloud/serverless-tier-limitations.md
+++ b/tidb-cloud/serverless-tier-limitations.md
@@ -23,7 +23,7 @@ We are constantly filling in the feature gaps between Serverless Tier and Dedica
 
 - [Time to live (TTL)](/time-to-live.md) is not available for Serverless Tier clusters currently.
 - The [`FLASHBACK CLUSTER TO TIMESTAMP`](/sql-statements/sql-statement-flashback-to-timestamp.md) syntax is not applicable to TiDB Cloud [Serverless Tier](/tidb-cloud/select-cluster-tier.md#serverless-tier-beta) clusters.
-- The [`SLEEP()` function](/functions-and-operators/miscellaneous-functions.md) supports a maximum sleep time of 300 seconds.
+- The [`SLEEP()` function](/functions-and-operators/miscellaneous-functions.md) only supports a maximum sleep time of 300 seconds.
 
 ## System tables
 

--- a/tidb-cloud/serverless-tier-limitations.md
+++ b/tidb-cloud/serverless-tier-limitations.md
@@ -23,6 +23,7 @@ We are constantly filling in the feature gaps between Serverless Tier and Dedica
 
 - [Time to live (TTL)](/time-to-live.md) is not available for Serverless Tier clusters currently.
 - The [`FLASHBACK CLUSTER TO TIMESTAMP`](/sql-statements/sql-statement-flashback-to-timestamp.md) syntax is not applicable to TiDB Cloud [Serverless Tier](/tidb-cloud/select-cluster-tier.md#serverless-tier-beta) clusters.
+- The [`SLEEP()` function](/functions-and-operators/miscellaneous-functions.md) supports a maximum sleep time of 300 seconds.
 
 ## System tables
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ x ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
Add `max sleep seconds` limitation for serverless tidb

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)
Serverless TiDB 6.6.0
<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
