### PR TITLE
planner: add doc for the new variable tidb_plan_cache_max_plan_size

### DIFF
--- a/sql-non-prepared-plan-cache.md
+++ b/sql-non-prepared-plan-cache.md
@@ -22,6 +22,8 @@ To enable or disable the non-prepared plan cache, you can set the [`tidb_enable_
 
 Before TiDB v7.1.0, the default value of `tidb_enable_non_prepared_plan_cache` is `OFF`, which means that the non-prepared plan cache is disabled by default. Starting from v7.1.0, the default value is `ON`, which means that the non-prepared plan cache is enabled by default.
 
+Starting from v7.1.0, you can control the maximum size of a plan that can be cached using the system variable [`tidb_plan_cache_max_plan_size`](/system-variables.md#tidb_plan_cache_max_plan_size-new-in-v710). The default value is 2 MB. If the size of a plan exceeds this value, the plan will not be cached.
+
 > **Note:**
 >
 > The memory specified by `tidb_session_plan_cache_size` is shared between the prepared and non-prepared plan cache. If you have enabled the prepared plan cache for the current cluster, enabling the non-prepared plan cache might reduce the hit rate of the original prepared plan cache.

--- a/sql-prepared-plan-cache.md
+++ b/sql-prepared-plan-cache.md
@@ -199,6 +199,8 @@ You can control the maximum number of plans that can be cached in each session b
 - When the memory threshold of the TiDB server instance is <= 64 GiB, set `tidb_session_plan_cache_size` to `50`.
 - When the memory threshold of the TiDB server instance is > 64 GiB, set `tidb_session_plan_cache_size` to `100`.
 
+Starting from v7.1.0, you can control the maximum size of a plan that can be cached using the system variable [`tidb_plan_cache_max_plan_size`](/system-variables.md#tidb_plan_cache_max_plan_size-new-in-v710). The default value is 2 MB. If the size of a plan exceeds this value, the plan will not be cached.
+
 When the unused memory of the TiDB server is less than a certain threshold, the memory protection mechanism of plan cache is triggered, through which some cached plans will be evicted.
 
 You can control the threshold by configuring the system variable `tidb_prepared_plan_cache_memory_guard_ratio`. The threshold is 0.1 by default, which means when the unused memory of the TiDB server is less than 10% of the total memory (90% of the memory is used), the memory protection mechanism is triggered.

--- a/system-variables.md
+++ b/system-variables.md
@@ -3692,10 +3692,10 @@ SHOW WARNINGS;
 - Type: Boolean
 - Default value: `ON`
 - This variable controls whether to invalidate the plan cache automatically when statistics on related tables are updated.
-- After enabling this variable, plan cache can make use of statistics more sufficiently to generate the execution plan. For example:
-    - Sometimes execution plans are generated before statistics are available for the plan cache. After enabling this variable, plan cache will re-generate the execution plan after the statistics are available.
-    - Sometimes the changes in data distribution of a table make the previously optimal execution plan become non-optimal. After enabling this variable, plan cache will re-generate the execution plan after the statistics are re-collected.
-- This variable is disabled by default for TiDB clusters that are upgraded from versions earlier than v7.1.0 to v7.1.0 or later versions.
+- After enabling this variable, plan cache can make use of statistics more sufficiently to generate execution plans. For example:
+    - If execution plans are generated before statistics are available, plan cache re-generates execution plans once the statistics are available.
+    - If the data distribution of a table changes, causing the previously optimal execution plan to become non-optimal, plan cache re-generates execution plans after the statistics are re-collected.
+- This variable is disabled by default for TiDB clusters that are upgraded from a version earlier than v7.1.0 to v7.1.0 or later.
 
 ### `tidb_plan_cache_max_plan_size` <span class="version-mark">New in v7.1.0</span>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -3685,6 +3685,18 @@ SHOW WARNINGS;
 
 - It is intended to be used by logical dump/restore tools to ensure that tables can always be created even if invalid placement rules are assigned. This is similar to how mysqldump writes `SET FOREIGN_KEY_CHECKS=0;` to the start of every dump file.
 
+### `tidb_plan_cache_invalidation_on_fresh_stats` <span class="version-mark">从 v7.1.0 版本开始引入</span>
+
+- Scope: SESSION | GLOBAL
+- Persists to cluster: Yes
+- Type: Boolean
+- Default value: `ON`
+- This variable controls whether to invalidate the plan cache automatically when statistics on related tables are updated.
+- After enabling this variable, plan cache can make use of statistics more sufficiently to generate the execution plan. For example:
+    - Sometimes execution plans are generated before statistics are available for the plan cache. After enabling this variable, plan cache will re-generate the execution plan after the statistics are available.
+    - Sometimes the changes in data distribution of a table make the previously optimal execution plan become non-optimal. After enabling this variable, plan cache will re-generate the execution plan after the statistics are re-collected.
+- This variable is disabled by default for TiDB clusters that are upgraded from versions earlier than v7.1.0 to v7.1.0 or later versions.
+
 ### `tidb_plan_cache_max_plan_size` <span class="version-mark">New in v7.1.0</span>
 
 - Scope: SESSION | GLOBAL

--- a/system-variables.md
+++ b/system-variables.md
@@ -3685,7 +3685,7 @@ SHOW WARNINGS;
 
 - It is intended to be used by logical dump/restore tools to ensure that tables can always be created even if invalid placement rules are assigned. This is similar to how mysqldump writes `SET FOREIGN_KEY_CHECKS=0;` to the start of every dump file.
 
-### `tidb_plan_cache_invalidation_on_fresh_stats` <span class="version-mark">从 v7.1.0 版本开始引入</span>
+### `tidb_plan_cache_invalidation_on_fresh_stats` <span class="version-mark">New in v7.1.0</span>
 
 - Scope: SESSION | GLOBAL
 - Persists to cluster: Yes

--- a/system-variables.md
+++ b/system-variables.md
@@ -3685,6 +3685,14 @@ SHOW WARNINGS;
 
 - It is intended to be used by logical dump/restore tools to ensure that tables can always be created even if invalid placement rules are assigned. This is similar to how mysqldump writes `SET FOREIGN_KEY_CHECKS=0;` to the start of every dump file.
 
+### `tidb_plan_cache_max_plan_size` <span class="version-mark">New in v7.1.0</span>
+
+- Scope: SESSION | GLOBAL
+- Persists to cluster: Yes
+- Default value: `2097152` (which is 2 MB)
+- Range: `[0, 9223372036854775807]`, in bytes. The memory format with the units "KB|MB|GB|TB" is also supported. `0` means no limit.
+- This variable controls the maximum size of a plan that can be cached in prepared or non-prepared plan cache. If the size of a plan exceeds this value, the plan will not be cached. For more details, see [Memory management of prepared plan cache](/sql-prepared-plan-cache.md#memory-management-of-prepared-plan-cache) and [Non-prepared plan cache](/sql-plan-management.md#usage).
+
 ### tidb_pprof_sql_cpu <span class="version-mark">New in v4.0</span>
 
 <CustomContent platform="tidb-cloud">


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

In v7.1.0, TiDB introduces a new system variable tidb_plan_cache_max_plan_size.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [x] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/13807
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
