### PR TITLE
tiup: update the default value of transfer-timeout from 300 to 600

### DIFF
--- a/dm/maintain-dm-using-tiup.md
+++ b/dm/maintain-dm-using-tiup.md
@@ -240,7 +240,7 @@ Flags:
   -N, --node strings           Specify the nodes
       --overwrite              Use this package in the future scale-out operations
   -R, --role strings           Specify the role
-      --transfer-timeout int   Timeout in seconds when transferring dm-master leaders (default 300)
+      --transfer-timeout int   Timeout in seconds when transferring dm-master leaders (default 600)
 
 Global Flags:
       --native-ssh         Use the native SSH client installed on local system instead of the build-in one.

--- a/maintain-tidb-using-tiup.md
+++ b/maintain-tidb-using-tiup.md
@@ -156,7 +156,7 @@ Flags:
   -N, --node strings           Specify the nodes
       --overwrite              Use this package in the future scale-out operations
   -R, --role strings           Specify the role
-      --transfer-timeout int   Timeout in seconds when transferring PD and TiKV store leaders (default 300)
+      --transfer-timeout int   Timeout in seconds when transferring PD and TiKV store leaders (default 600)
 
 Global Flags:
 

--- a/tiup/tiup-cluster.md
+++ b/tiup/tiup-cluster.md
@@ -381,7 +381,7 @@ Usage:
 Flags:
       --force                  Force upgrade won't transfer leader
   -h, --help                   help for upgrade
-      --transfer-timeout int   Timeout in seconds when transferring PD and TiKV store leaders (default 300)
+      --transfer-timeout int   Timeout in seconds when transferring PD and TiKV store leaders (default 600)
 
 Global Flags:
       --ssh string          (Experimental) The executor type. Optional values are 'builtin', 'system', and 'none'.
@@ -473,17 +473,20 @@ Usage:
   cluster patch <cluster-name> <package-path> [flags]
 
 Flags:
-  -h, --help                   help for patch
-  -N, --node strings           Specify the nodes
-      --overwrite              Use this package in the future scale-out operations
-  -R, --role strings           Specify the role
-      --transfer-timeout int   Timeout in seconds when transferring PD and TiKV store leaders (default 300)
+  -h, --help                    help for patch
+  -N, --node strings            Specify the nodes
+      --offline                 Patch a stopped cluster
+      --overwrite               Use this package in the future scale-out operations
+  -R, --role strings            Specify the roles
+      --transfer-timeout uint   Timeout in seconds when transferring PD and TiKV store leaders, also for TiCDC drain one capture (default 600)
 
 Global Flags:
-      --ssh string          (Experimental) The executor type. Optional values are 'builtin', 'system', and 'none'.
-      --wait-timeout int  Timeout of waiting the operation
-      --ssh-timeout int   Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection. (default 5)
-  -y, --yes               Skip all confirmations and assumes 'yes'
+  -c, --concurrency int     max number of parallel tasks allowed (default 5)
+      --format string       (EXPERIMENTAL) The format of output, available values are [default, json] (default "default")
+      --ssh string          (EXPERIMENTAL) The executor type: 'builtin', 'system', 'none'.
+      --ssh-timeout uint    Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection. (default 5)
+      --wait-timeout uint   Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit. (default 120)
+  -y, --yes                 Skip all confirmations and assumes 'yes'
 ```
 
 If a TiDB hotfix package is in `/tmp/tidb-hotfix.tar.gz` and you want to replace all the TiDB packages in the cluster, run the following command:

--- a/tiup/tiup-component-cluster-patch.md
+++ b/tiup/tiup-component-cluster-patch.md
@@ -77,7 +77,7 @@ After you have completed the preceding steps, you can use `/tmp/${component}-hot
 
 - When restarting the PD or TiKV service, TiKV/PD first transfers the leader of the node to be restarted to another node. Because the transfer process takes some time, you can use the option `--transfer-timeout` to set the maximum waiting time (in seconds). After the timeout, TiUP directly restarts the service.
 - Data type: `UINT`
-- If this option is not specified, TiUP directly restarts the service after waiting for `300` seconds.
+- If this option is not specified, TiUP directly restarts the service after waiting for `600` seconds.
 
 > **Note:**
 >

--- a/tiup/tiup-component-cluster-reload.md
+++ b/tiup/tiup-component-cluster-reload.md
@@ -26,7 +26,7 @@ tiup cluster reload <cluster-name> [flags]
 
 - When restarting PD or TiKV, the leader of the restarted node is migrated to other nodes first, and the migration process takes some time. You can set the maximum wait time (in seconds) by setting `-transfer-timeout`. After the timeout, the service can be restarted directly without waiting.
 - Data type: `UINT`
-- Default: 300
+- Default: 600
 
 > **Note:**
 >

--- a/tiup/tiup-component-cluster-scale-in.md
+++ b/tiup/tiup-component-cluster-scale-in.md
@@ -55,7 +55,7 @@ tiup cluster scale-in <cluster-name> [flags]
 
 - When a PD or TiKV node is to be removed, the Region leader on the node will be transferred to another node first. Because the transferring process takes some time, you can set the maximum waiting time (in seconds) by configuring `--transfer-timeout`. After the timeout, the `tiup cluster scale-in` command skips waiting and starts the scaling-in directly.
 - Data type: `UINT`
-- The option is enabled by default with `300` seconds (the default value) passed in.
+- The option is enabled by default with `600` seconds (the default value) passed in.
 
 > **Note:**
 >

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -31,7 +31,7 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 - When upgrading PD or TiKV, the leader of the upgraded node is migrated to other nodes first. The migration process takes some time, and you can set the maximum wait time (in seconds) by the `-transfer-timeout` option. After the timeout, the wait is skipped and the service is upgraded directly.
 - Data type: `uint`
-- Default: 300
+- Default: 600
 
 > **Note:**
 >


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The default value of transfer-timeout is 600.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/13808
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
