### PR TITLE
update Golang version to 1.20

### DIFF
--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -46,7 +46,7 @@ As an open-source distributed SQL database with high performance, TiDB can be de
 
 |  Libraries required for compiling and running TiDB |  Version   |
 |   :---   |   :---   |
-|   Golang  |  1.18.5 or later  |
+|   Golang  |  1.20 or later  |
 |   Rust    |   nightly-2022-07-31 or later  |
 |  GCC      |   7.x      |
 |  LLVM     |  13.0 or later  |

--- a/pd-control.md
+++ b/pd-control.md
@@ -33,7 +33,7 @@ To obtain `pd-ctl` of the latest version, download the TiDB server installation 
 
 ### Compile from source code
 
-1. [Go](https://golang.org/) 1.20 or later  is required  because the Go modules are used.
+1. [Go](https://golang.org/) 1.20 or later is required because the Go modules are used.
 2. In the root directory of the [PD project](https://github.com/pingcap/pd), use the `make` or `make pd-ctl` command to compile and generate `bin/pd-ctl`.
 
 ## Usage

--- a/pd-control.md
+++ b/pd-control.md
@@ -33,7 +33,7 @@ To obtain `pd-ctl` of the latest version, download the TiDB server installation 
 
 ### Compile from source code
 
-1. [Go](https://golang.org/) Version 1.19 or later because the Go modules are used.
+1. [Go](https://golang.org/) 1.20 or later  is required  because the Go modules are used.
 2. In the root directory of the [PD project](https://github.com/pingcap/pd), use the `make` or `make pd-ctl` command to compile and generate `bin/pd-ctl`.
 
 ## Usage

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -10,7 +10,7 @@ PD Recover is a disaster recovery tool of PD, used to recover the PD cluster whi
 
 ## Compile from source code
 
-+ [Go](https://golang.org/) Version 1.19 or later is required because the Go modules are used.
++ [Go](https://golang.org/) 1.20 or later is required because the Go modules are used.
 + In the root directory of the [PD project](https://github.com/pingcap/pd), use the `make pd-recover` command to compile and generate `bin/pd-recover`.
 
 > **Note:**

--- a/tidb-control.md
+++ b/tidb-control.md
@@ -22,7 +22,7 @@ After installing TiUP, you can use `tiup ctl:v<CLUSTER_VERSION> tidb` command to
 
 ### Compile from source code
 
-- Compilation environment requirement: [Go](https://golang.org/) Version 1.19 or later
+- Compilation environment requirement: [Go](https://golang.org/) 1.20 or later
 - Compilation procedures: Go to the root directory of the [TiDB Control project](https://github.com/pingcap/tidb-ctl), use the `make` command to compile, and generate `tidb-ctl`.
 - Compilation documentation: you can find the help files in the `doc` directory; if the help files are lost or you want to update them, use the `make doc` command to generate the help files.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Starting from v7.0.0, the Golang version required for compiling and running TiDB is **1.20 or later**.

This PR updates the Golang version from 1.18.5 to 1.20 and applies to v7.0 and master.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/14029
- Other reference link(s): https://github.com/pingcap/tidb/pull/41604

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
