### PR TITLE
Fix doc wrong related with `substring` which can be pushed down now

### DIFF
--- a/predicate-push-down.md
+++ b/predicate-push-down.md
@@ -74,20 +74,20 @@ In addition, This SQL statement has an inner join executed, and the `ON` conditi
 ### Case 4: predicates that are not supported by storage layers cannot be pushed down
 
 ```sql
-create table t(id int primary key, a int not null);
-desc select * from t where substring('123', a, 1) = '1';
-+-------------------------+---------+-----------+---------------+----------------------------------------+
-| id                      | estRows | task      | access object | operator info                          |
-+-------------------------+---------+-----------+---------------+----------------------------------------+
-| Selection_7             | 2.00    | root      |               | eq(substring("123", test.t.a, 1), "1") |
-| └─TableReader_6         | 2.00    | root      |               | data:TableFullScan_5                   |
-|   └─TableFullScan_5     | 2.00    | cop[tikv] | table:t       | keep order:false, stats:pseudo         |
-+-------------------------+---------+-----------+---------------+----------------------------------------+
+create table t(id int primary key, a varchar(10) not null);
+desc select * from t where truncate(a, " ") = '1';
++-------------------------+----------+-----------+---------------+---------------------------------------------------+
+| id                      | estRows  | task      | access object | operator info                                     |
++-------------------------+----------+-----------+---------------+---------------------------------------------------+
+| Selection_5             | 8000.00  | root      |               | eq(truncate(cast(test.t.a, double BINARY), 0), 1) |
+| └─TableReader_7         | 10000.00 | root      |               | data:TableFullScan_6                              |
+|   └─TableFullScan_6     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo                    |
++-------------------------+----------+-----------+---------------+---------------------------------------------------+
 ```
 
-In this query, there is a predicate `substring('123', a, 1) = '1'`.
+In this query, there is a predicate `truncate(a, " ") = '1'`.
 
-From the `explain` results, we can see that the predicate is not pushed down to TiKV for calculation. This is because the TiKV coprocessor does not support the built-in function `substring`.
+From the `explain` results, we can see that the predicate is not pushed down to TiKV for calculation. This is because the TiKV coprocessor does not support the built-in function `truncate`.
 
 ### Case 5: predicates of inner tables on the outer join can't be pushed down
 

--- a/predicate-push-down.md
+++ b/predicate-push-down.md
@@ -87,7 +87,7 @@ desc select * from t where truncate(a, " ") = '1';
 
 In this query, there is a predicate `truncate(a, " ") = '1'`.
 
-From the `explain` results, we can see that the predicate is not pushed down to TiKV for calculation. This is because the TiKV coprocessor does not support the built-in function `truncate`.
+From the `explain` results, you can see that the predicate is not pushed down to TiKV for calculation. This is because the TiKV coprocessor does not support the built-in function `truncate`.
 
 ### Case 5: predicates of inner tables on the outer join can't be pushed down
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
