### PR TITLE
Revert "ddl: add admin pause/resume commands"

### DIFF
--- a/basic-features.md
+++ b/basic-features.md
@@ -124,7 +124,6 @@ This document lists the features supported in different TiDB versions, including
 | [Acceleration of `ADD INDEX` and `CREATE INDEX`](/system-variables.md#tidb_ddl_enable_fast_reorg-new-in-v630) | Y | Y | N | N | N | N | N | N | N |
 | [Metadata lock](/metadata-lock.md) | Y | Y | N | N | N | N | N | N | N |
 | [`FLASHBACK CLUSTER TO TIMESTAMP`](/sql-statements/sql-statement-flashback-to-timestamp.md) | Y | Y | N | N | N | N | N | N | N |
-| [Pause/Resume DDL](/ddl-introduction.md#ddl-related-commands) | E | N | N | N | N | N | N | N | N |
 
 ## Transactions
 

--- a/ddl-introduction.md
+++ b/ddl-introduction.md
@@ -178,14 +178,6 @@ When TiDB is adding an index, the phase of backfilling data will cause read and 
 
     If a completed DDL task is canceled, you can see the `DDL Job:90 not found` error in the `RESULT` column, which means that the task has been removed from the DDL waiting queue.
 
-- `ADMIN PAUSE DDL JOBS job_id [, job_id]`: Used to pause the DDL tasks that are being executed. After the command is executed, the SQL statement that executes the DDL task is displayed as being executed, and the background task is paused. (Experimental feature)
-
-    You can pause only DDL tasks that are in progress or still in the queue. Otherwise, the `Job 3 can't be paused now` error is shown in the `RESULT` column.
-
-- `ADMIN RESUME DDL JOBS job_id [, job_id]`: Used to resume the DDL tasks that have been paused. After the command is executed, the SQL statement that executes the DDL task is displayed as being executed, and the background task is resumed. (Experimental feature)
-
-    You can only resume a paused DDL task. Otherwise, the `Job 3 can't be resumed` error is shown in the `RESULT` column.
-
 ## Common questions
 
 For common questions about DDL execution, see [SQL FAQ - DDL execution](/faq/sql-faq.md#ddl-execution).

--- a/releases/release-7.1.0.md
+++ b/releases/release-7.1.0.md
@@ -154,21 +154,6 @@ In v7.1.0, the key new features and improvements are as follows:
 
     For more information, see [documentation](/generated-columns.md).
 
-### DB operations
-
-* DDL tasks support pause and resume operations (experimental) [#18015](https://github.com/pingcap/tidb/issues/18015) @[godouxm](https://github.com/godouxm)
-
-    Before TiDB v7.1.0, when a DDL task encounters a business peak period during execution, you can only manually cancel the DDL task to reduce its impact on the business. In v7.1.0, TiDB introduces pause and resume operations for DDL tasks. These operations let you pause DDL tasks during peak periods and resume them after the peak ends, thus avoiding any impact on your application workloads.
-
-    For example, you can pause and resume multiple DDL tasks using `ADMIN PAUSE DDL JOBS` or `ADMIN RESUME DDL JOBS`:
-
-    ```sql
-    ADMIN PAUSE DDL JOBS 1,2;
-    ADMIN RESUME DDL JOBS 1,2;
-    ```
-
-    For more information, see [documentation](/ddl-introduction.md#ddl-related-commands).
-
 ### Observability
 
 * Enhance optimizer diagnostic information [#43122](https://github.com/pingcap/tidb/issues/43122) @[time-and-fate](https://github.com/time-and-fate)

--- a/smooth-upgrade-tidb.md
+++ b/smooth-upgrade-tidb.md
@@ -42,7 +42,7 @@ When using the smooth upgrade feature, note the following limitations.
 * During the upgrade, the following operations are not allowed:
 
     * Run DDL operations on system tables (`mysql.*`, `information_schema.*`, `performance_schema.*`, and `metrics_schema.*`).
-    * Manually cancel, pause, or resume DDL jobs: `ADMIN CANCEL/PAUSE/RESUME DDL JOBS job_id [, job_id] ...;`.
+    * Manually cancel DDL jobs: `ADMIN CANCEL DDL JOBS job_id [, job_id] ...;`.
     * Import data.
 
 ### Limitations on tools


### PR DESCRIPTION
Reverts pingcap/docs#13294

Remove `ADMIN PAUSE DDL JOBS job_id [, job_id]` and `ADMIN RESUME DDL JOBS job_id [, job_id]` in TiDB v7.1.0

Translate from https://github.com/pingcap/docs-cn/pull/14078