### PR TITLE
ticdc: remove only-output-updated-columns from v7.0 and earlier versions

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -159,11 +159,6 @@ enable-partition-separator = false
 # The default value is false.
 # enable-kafka-sink-v2 = false
 
-# Specifies whether to only output the updated columns.
-# Note: This configuration item only applies to the MQ downstream using the open-protocol and canal-json.
-# The default value is false.
-# only-output-updated-columns = false
-
 # Since v6.5.0, TiCDC supports saving data changes to storage services in CSV format. Ignore the following configurations if you replicate data to MQ or MySQL sinks.
 [sink.csv]
 # The character used to separate fields in the CSV file. The value must be an ASCII character and defaults to `,`.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB v7.1.0 introduces only-output-updated-columns. This PR removes only-output-updated-columns from v7.0 and earlier versions.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/14174
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
