### PR TITLE
ticdc:  add kafka oauth configurations

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -198,6 +198,7 @@ use-file-backend = false
 integrity-check-level = "none"
 # Specifies the log level of the Changefeed when the checksum validation for single-row data fails. The default value is "warn". Value options are "warn" and "error".
 corruption-handle-level = "warn"
+
 [sink.kafka-config]
 # The following configuration items only take effect when the downstream is Kafka.
 # The mechanism of Kafka SASL authentication. The default value is empty, indicating that SASL authentication is not used.

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -198,4 +198,20 @@ use-file-backend = false
 integrity-check-level = "none"
 # Specifies the log level of the Changefeed when the checksum validation for single-row data fails. The default value is "warn". Value options are "warn" and "error".
 corruption-handle-level = "warn"
+# The following configuration only takes effect when the downstream is Kafka.
+[sink.kafka-config]
+# Kafka SASL authentication mechanism. The default value of this parameter is null, indicating that SASL authentication is not used.
+sasl-mechanism = "OAUTHBEARER"
+# The client-id in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is required when using this authentication mechanism.
+sasl-oauth-client-id = "producer-kafka"
+# The client-secret in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is required when using this authentication mechanism.
+sasl-oauth-client-secret = "cHJvZHVjZXIta2Fma2E="
+# The token URL in the Kafka SASL OAUTHBEARER authentication mechanism to obtain the token. The default value is empty. This parameter is required when using this authentication mechanism.
+sasl-oauth-token-url = "http://127.0.0.1:4444/oauth2/token"
+# The scope in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is optional when using this authentication mechanism.
+sasl-oauth-scopes = ["producer.kafka", "consumer.kafka"]
+# The grant type in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is `client_credentials`. This parameter is optional when using this authentication mechanism.
+sasl-oauth-grant-type = "client_credentials"
+# The audience in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is optional when using this authentication mechanism.
+sasl-oauth-audience = "kafka"
 ```

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -198,20 +198,20 @@ use-file-backend = false
 integrity-check-level = "none"
 # Specifies the log level of the Changefeed when the checksum validation for single-row data fails. The default value is "warn". Value options are "warn" and "error".
 corruption-handle-level = "warn"
-# The following configuration only takes effect when the downstream is Kafka.
 [sink.kafka-config]
-# Kafka SASL authentication mechanism. The default value of this parameter is null, indicating that SASL authentication is not used.
+# The following configuration items only take effect when the downstream is Kafka.
+# The mechanism of Kafka SASL authentication. The default value is empty, indicating that SASL authentication is not used.
 sasl-mechanism = "OAUTHBEARER"
-# The client-id in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is required when using this authentication mechanism.
+# The client-id in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
 sasl-oauth-client-id = "producer-kafka"
-# The client-secret in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is required when using this authentication mechanism.
+# The client-secret in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
 sasl-oauth-client-secret = "cHJvZHVjZXIta2Fma2E="
-# The token URL in the Kafka SASL OAUTHBEARER authentication mechanism to obtain the token. The default value is empty. This parameter is required when using this authentication mechanism.
+# The token-url in the Kafka SASL OAUTHBEARER authentication to obtain the token. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
 sasl-oauth-token-url = "http://127.0.0.1:4444/oauth2/token"
-# The scope in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is optional when using this authentication mechanism.
+# The scopes in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when using OAUTHBEARER authentication.
 sasl-oauth-scopes = ["producer.kafka", "consumer.kafka"]
-# The grant type in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is `client_credentials`. This parameter is optional when using this authentication mechanism.
+# The grant-type in the Kafka SASL OAUTHBEARER authentication. The default value is "client_credentials". This parameter is optional when using OAUTHBEARER authentication.
 sasl-oauth-grant-type = "client_credentials"
-# The audience in the Kafka SASL OAUTHBEARER authentication mechanism. The default value is empty. This parameter is optional when using this authentication mechanism.
+# The audience in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when using OAUTHBEARER authentication.
 sasl-oauth-audience = "kafka"
 ```

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -199,8 +199,8 @@ integrity-check-level = "none"
 # Specifies the log level of the Changefeed when the checksum validation for single-row data fails. The default value is "warn". Value options are "warn" and "error".
 corruption-handle-level = "warn"
 
-[sink.kafka-config]
 # The following configuration items only take effect when the downstream is Kafka.
+[sink.kafka-config]
 # The mechanism of Kafka SASL authentication. The default value is empty, indicating that SASL authentication is not used.
 sasl-mechanism = "OAUTHBEARER"
 # The client-id in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when using OAUTHBEARER authentication.

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -203,16 +203,16 @@ corruption-handle-level = "warn"
 [sink.kafka-config]
 # The mechanism of Kafka SASL authentication. The default value is empty, indicating that SASL authentication is not used.
 sasl-mechanism = "OAUTHBEARER"
-# The client-id in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
+# The client-id in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when the OAUTHBEARER authentication is used.
 sasl-oauth-client-id = "producer-kafka"
-# The client-secret in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
+# The client-secret in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is required when the OAUTHBEARER authentication is used.
 sasl-oauth-client-secret = "cHJvZHVjZXIta2Fma2E="
-# The token-url in the Kafka SASL OAUTHBEARER authentication to obtain the token. The default value is empty. This parameter is required when using OAUTHBEARER authentication.
+# The token-url in the Kafka SASL OAUTHBEARER authentication to obtain the token. The default value is empty. This parameter is required when the OAUTHBEARER authentication is used.
 sasl-oauth-token-url = "http://127.0.0.1:4444/oauth2/token"
-# The scopes in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when using OAUTHBEARER authentication.
+# The scopes in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when the OAUTHBEARER authentication is used.
 sasl-oauth-scopes = ["producer.kafka", "consumer.kafka"]
-# The grant-type in the Kafka SASL OAUTHBEARER authentication. The default value is "client_credentials". This parameter is optional when using OAUTHBEARER authentication.
+# The grant-type in the Kafka SASL OAUTHBEARER authentication. The default value is "client_credentials". This parameter is optional when the OAUTHBEARER authentication is used.
 sasl-oauth-grant-type = "client_credentials"
-# The audience in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when using OAUTHBEARER authentication.
+# The audience in the Kafka SASL OAUTHBEARER authentication. The default value is empty. This parameter is optional when the OAUTHBEARER authentication is used.
 sasl-oauth-audience = "kafka"
 ```


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

add kafka oauth configurations

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/14198
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
