### PR TITLE
cloud: remove the built-in sample dataset

### DIFF
--- a/tidb-cloud/explore-data-with-chat2query.md
+++ b/tidb-cloud/explore-data-with-chat2query.md
@@ -11,9 +11,9 @@ In Chat2Query, you can either simply type `--` followed by your instructions to 
 
 > **Note:**
 >
-> Chat2Query is supported for TiDB clusters that are v6.5.0 or later and are hosted on AWS. 
+> Chat2Query is supported for TiDB clusters that are v6.5.0 or later and are hosted on AWS.
 >
-> - For [TiDB Serverless](/tidb-cloud/select-cluster-tier.md#tidb-serverless-beta) clusters, Chat2Query is available by default. 
+> - For [TiDB Serverless](/tidb-cloud/select-cluster-tier.md#tidb-serverless-beta) clusters, Chat2Query is available by default.
 > - For [TiDB Dedicated](/tidb-cloud/select-cluster-tier.md#tidb-dedicated) clusters, Chat2Query is only available upon request. To use Chat2Query on TiDB Dedicated clusters, contact [TiDB Cloud support](/tidb-cloud/tidb-cloud-support.md).
 
 ## Use cases
@@ -63,7 +63,7 @@ After the first-time access, you can still change the AI setting as follows:
 
 ## Write and run SQL queries
 
-In Chat2Query, you can write and run SQL queries using the pre-built sample dataset or your own dataset.
+In Chat2Query, you can write and run SQL queries using your own dataset.
 
 1. Write SQL queries.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB Cloud no longer imports a built-in sample dataset upon creation.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
