### PR TITLE
cloud: add limitation about using keywords as column names

### DIFF
--- a/tidb-cloud/tidb-cloud-import-local-files.md
+++ b/tidb-cloud/tidb-cloud-import-local-files.md
@@ -15,6 +15,7 @@ Currently, this method supports importing one CSV file for one task into either 
 - Importing local files is supported only for TiDB Serverless clusters, not for TiDB Dedicated clusters.
 - You cannot run more than one import task at the same time.
 - If you import a CSV file into an existing table in TiDB Cloud, make sure that the first line of the CSV file contains the column names, and the order of the columns in the CSV file must be the same as that in the target table.
+- If a column name is a reserved [keyword](/keywords.md), TiDB Cloud automatically adds backticks `` ` `` to the column name. For example, if the column name is `order`, TiDB Cloud automatically adds backticks `` ` `` to the column name and import the data into the target table.
 
 ## Import local files
 
@@ -94,3 +95,7 @@ LOAD DATA LOCAL INFILE 'load.txt' INTO TABLE import_test FIELDS TERMINATED BY ',
 ```
 
 If you use `mysql` and encounter `ERROR 2068 (HY000): LOAD DATA LOCAL INFILE file request rejected due to restrictions on access.`, you can add `--local-infile=true` in the connection string.
+
+### Why can't I query a column with a reserved keyword after importing data into TiDB Cloud?
+
+If a column name is a reserved [keyword](/keywords.md), TiDB Cloud automatically adds backticks `` ` `` to the column name and then import the data into the target table. When you query the column, you need to add backticks `` ` `` to the column name. For example, if the column name is `order`, you need to query the column with `` `order` ``.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

If a column name is a reserved [keyword](/keywords.md), TiDB Cloud automatically adds backticks `` ` `` to the column name and then import the data into the target table.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.2 (TiDB 7.2 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
