### PR TITLE
include limitation of LIKE when it works with non-binary collation

### DIFF
--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -114,7 +114,7 @@ SHOW COLLATION;
 >
 > TiDB incorrectly treats latin1 as a subset of utf8. This can lead to unexpected behaviors when you store characters that differ between latin1 and utf8 encodings. It is strongly recommended to the utf8mb4 character set. See [TiDB #18955](https://github.com/pingcap/tidb/issues/18955) for more details.
 >
-> If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a non-binary collation (the suffix does not end with `_bin`), the optimizer cannot convert this predicate into a range scan for now. Instead, it goes to a full scan. Such SQL queries may result in unexpected resource consumption.
+> If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a non-binary collation (the suffix does not end with `_bin`), the optimizer currently cannot convert this predicate into a range scan. Instead, it performs a full scan. As a result, such SQL queries might lead to unexpected resource consumption.
 
 > **Note:**
 >

--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -113,6 +113,8 @@ SHOW COLLATION;
 > **Warning:**
 >
 > TiDB incorrectly treats latin1 as a subset of utf8. This can lead to unexpected behaviors when you store characters that differ between latin1 and utf8 encodings. It is strongly recommended to the utf8mb4 character set. See [TiDB #18955](https://github.com/pingcap/tidb/issues/18955) for more details.
+>
+> If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a non-binary collation (the suffix does not end with `_bin`), the optimizer cannot convert this predicate into a range scan for now. Instead, it goes to a full scan. Such SQL queries may result in unexpected resource consumption.
 
 > **Note:**
 >

--- a/character-set-gbk.md
+++ b/character-set-gbk.md
@@ -98,7 +98,7 @@ In the above table, the result of `SELECT HEX('a');` in the `utf8mb4` byte set i
 
 - Currently, for binary characters of the `ENUM` and `SET` types, TiDB deals with them as the `utf8mb4` character set.
 
-- > If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a gbk collation (either `gbk_bin` or `gbk_chinese_ci`), the optimizer cannot convert this predicate into a range scan for now. Instead, it goes to a full scan. Such SQL queries may result in unexpected resource consumption.
+- If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a GBK collation (either `gbk_bin` or `gbk_chinese_ci`), the optimizer currently cannot convert this predicate into a range scan. Instead, it performs a full scan. As a result, such SQL queries might lead to unexpected resource consumption.
 
 ## Component compatibility
 

--- a/character-set-gbk.md
+++ b/character-set-gbk.md
@@ -98,6 +98,8 @@ In the above table, the result of `SELECT HEX('a');` in the `utf8mb4` byte set i
 
 - Currently, for binary characters of the `ENUM` and `SET` types, TiDB deals with them as the `utf8mb4` character set.
 
+- > If the predicates include `LIKE` for string prefixes, such as `LIKE 'prefix%'`, and the target column is set to a gbk collation (either `gbk_bin` or `gbk_chinese_ci`), the optimizer cannot convert this predicate into a range scan for now. Instead, it goes to a full scan. Such SQL queries may result in unexpected resource consumption.
+
 ## Component compatibility
 
 - Currently, TiFlash does not support the GBK character set.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

There's a limitation when LIKE 'prefix%' works with non-binary collation. This could cause performance regression.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/15443
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
