### PR TITLE
Add info about compatibility issues with Connector/J 8.0 with TiDB v7.5

### DIFF
--- a/develop/dev-guide-choose-driver-or-orm.md
+++ b/develop/dev-guide-choose-driver-or-orm.md
@@ -29,10 +29,10 @@ Support level: **Full**
 
 You can follow the [MySQL documentation](https://dev.mysql.com/doc/connector-j/en/) to download and configure a Java JDBC driver. It is recommended to use MySQL Connector/J 8.0.33 or later with TiDB v6.3.0 and newer.
 
-> **Tip:**
+> **Note:**
 >
 > - There is a [bug](https://bugs.mysql.com/bug.php?id=106252) in the Connector/J 8.0 versions before 8.0.32, which might cause threads to hang when using TiDB versions earlier than v6.3.0. To avoid this issue, it is recommended that you use either MySQL Connector/J 8.0.32 or a later version, or the TiDB JDBC (see the *TiDB-JDBC* tab).
-> - When using MySQL Connector/J 8.0 with TiDB v7.5.0, it is recommended to set the TiDB configuration item [`server-version`](/tidb-configuration-file.md#server-version) to `"5.7.25-TiDB-v7.5.0"`. MySQL Connector/J attempts to access the `information_schema.KEYWORDS` table if the TiDB server reports a version of MySQL 8.0.11 or later. However, this table is not present in TiDB v7.5.0.
+> - When using MySQL Connector/J 8.0 with TiDB v7.5.0, it is recommended to set the TiDB configuration item [`server-version`](https://docs.pingcap.com/tidb/v7.5/tidb-configuration-file#server-version) to `"5.7.25-TiDB-v7.5.0"`. MySQL Connector/J attempts to access the `information_schema.KEYWORDS` table if the TiDB server reports a version of MySQL 8.0.11 or later. However, this table is not present in TiDB v7.5.0.
 
 For an example of how to build a complete application, see [Build a simple CRUD app with TiDB and JDBC](/develop/dev-guide-sample-application-java-jdbc.md).
 

--- a/develop/dev-guide-choose-driver-or-orm.md
+++ b/develop/dev-guide-choose-driver-or-orm.md
@@ -31,11 +31,8 @@ You can follow the [MySQL documentation](https://dev.mysql.com/doc/connector-j/e
 
 > **Tip:**
 >
-> There is a [bug](https://bugs.mysql.com/bug.php?id=106252) in the Connector/J 8.0 versions before 8.0.32, which might cause threads to hang when using TiDB versions earlier than v6.3.0. To avoid this issue, it is recommended that you use either MySQL Connector/J 8.0.32 or a later version, or the TiDB JDBC (see the *TiDB-JDBC* tab).
-
-> **Note:**
->
-> When using MySQL Connector/J 8.0 with TiDB v7.5.0 it is recommended to set [`server-version`](/tidb-configuration-file.md#server-version) in the configuration file for TiDB to "5.7.25-TiDB-v7.5.0" as MySQL Connector/J tries to use the `information_schema.KEYWORDS` table if the server announces a MySQL version that is 8.0.11 or newer and this table isn't present in TiDB v7.5.0. This is not needed with TiDB v7.6.0 and newer as that version comes with an `information_schema.KEYWORDS` table. This is also not needed with TiDB v7.4.0 and earlier as those versions identify themselves as MySQL 5.7.
+> - There is a [bug](https://bugs.mysql.com/bug.php?id=106252) in the Connector/J 8.0 versions before 8.0.32, which might cause threads to hang when using TiDB versions earlier than v6.3.0. To avoid this issue, it is recommended that you use either MySQL Connector/J 8.0.32 or a later version, or the TiDB JDBC (see the *TiDB-JDBC* tab).
+> - When using MySQL Connector/J 8.0 with TiDB v7.5.0, it is recommended to set the TiDB configuration item [`server-version`](/tidb-configuration-file.md#server-version) to `"5.7.25-TiDB-v7.5.0"`. MySQL Connector/J attempts to access the `information_schema.KEYWORDS` table if the TiDB server reports a version of MySQL 8.0.11 or later. However, this table is not present in TiDB v7.5.0.
 
 For an example of how to build a complete application, see [Build a simple CRUD app with TiDB and JDBC](/develop/dev-guide-sample-application-java-jdbc.md).
 

--- a/develop/dev-guide-choose-driver-or-orm.md
+++ b/develop/dev-guide-choose-driver-or-orm.md
@@ -33,6 +33,10 @@ You can follow the [MySQL documentation](https://dev.mysql.com/doc/connector-j/e
 >
 > There is a [bug](https://bugs.mysql.com/bug.php?id=106252) in the Connector/J 8.0 versions before 8.0.32, which might cause threads to hang when using TiDB versions earlier than v6.3.0. To avoid this issue, it is recommended that you use either MySQL Connector/J 8.0.32 or a later version, or the TiDB JDBC (see the *TiDB-JDBC* tab).
 
+> **Note:**
+>
+> When using MySQL Connector/J 8.0 with TiDB v7.5.0 it is recommended to set [`server-version`](/tidb-configuration-file.md#server-version) in the configuration file for TiDB to "5.7.25-TiDB-v7.5.0" as MySQL Connector/J tries to use the `information_schema.KEYWORDS` table if the server announces a MySQL version that is 8.0.11 or newer and this table isn't present in TiDB v7.5.0. This is not needed with TiDB v7.6.0 and newer as that version comes with an `information_schema.KEYWORDS` table. This is also not needed with TiDB v7.4.0 and earlier as those versions identify themselves as MySQL 5.7.
+
 For an example of how to build a complete application, see [Build a simple CRUD app with TiDB and JDBC](/develop/dev-guide-sample-application-java-jdbc.md).
 
 </div>

--- a/develop/dev-guide-choose-driver-or-orm.md
+++ b/develop/dev-guide-choose-driver-or-orm.md
@@ -32,7 +32,7 @@ You can follow the [MySQL documentation](https://dev.mysql.com/doc/connector-j/e
 > **Note:**
 >
 > - There is a [bug](https://bugs.mysql.com/bug.php?id=106252) in the Connector/J 8.0 versions before 8.0.32, which might cause threads to hang when using TiDB versions earlier than v6.3.0. To avoid this issue, it is recommended that you use either MySQL Connector/J 8.0.32 or a later version, or the TiDB JDBC (see the *TiDB-JDBC* tab).
-> - When using MySQL Connector/J 8.0 with TiDB v7.5.0, it is recommended to set the TiDB configuration item [`server-version`](https://docs.pingcap.com/tidb/v7.5/tidb-configuration-file#server-version) to `"5.7.25-TiDB-v7.5.0"`. MySQL Connector/J attempts to access the `information_schema.KEYWORDS` table if the TiDB server reports a version of MySQL 8.0.11 or later. However, this table is not present in TiDB v7.5.0.
+> - When you are using MySQL Connector/J 8.0 with TiDB v7.5.0, it is recommended to set the TiDB configuration item [`server-version`](https://docs.pingcap.com/tidb/v7.5/tidb-configuration-file#server-version) to `"5.7.25-TiDB-v7.5.0"`. MySQL Connector/J attempts to access the `information_schema.KEYWORDS` table if the TiDB server reports a version of MySQL 8.0.11 or later. However, this table is not present in TiDB v7.5.0.
 
 For an example of how to build a complete application, see [Build a simple CRUD app with TiDB and JDBC](/develop/dev-guide-sample-application-java-jdbc.md).
 


### PR DESCRIPTION


### What is changed, added or deleted? (Required)

MySQL Connector/J 8.0 has compatibility issues with TiDB v7.5. Earlier versions of TiDB are fine as they announce themselves as MySQL v5.7. Later versions are fine as they implement the `information_schema.KEYWORD` table.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v7.6 (TiDB 7.6 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
