### PR TITLE
status-variables: Add conditional status that are not available with unistore

### DIFF
--- a/status-variables.md
+++ b/status-variables.md
@@ -90,3 +90,33 @@ Additionally, the [FLUSH STATUS](/sql-statements/sql-statement-flush-status.md) 
 - Scope: SESSION | GLOBAL
 - Type: String
 - The UUID of the server.
+
+### tidb_gc_last_run_time
+
+- Scope: SESSION | GLOBAL
+- Type: String
+- The timestamp of the last run of [GC](/garbage-collection-overview.md).
+
+### tidb_gc_leader_desc
+
+- Scope: SESSION | GLOBAL
+- Type: String
+- Information about [GC](/garbage-collection-overview.md) leader, including the hostname and process id (pid).
+
+### tidb_gc_leader_lease
+
+- Scope: SESSION | GLOBAL
+- Type: String
+- The timestamp of the [GC](/garbage-collection-overview.md) lease.
+
+### tidb_gc_leader_uuid
+
+- Scope: SESSION | GLOBAL
+- Type: String
+- The UUID of the [GC](/garbage-collection-overview.md) leader.
+
+### tidb_gc_safe_point
+
+- Scope: SESSION | GLOBAL
+- Type: String
+- The timestamp of the [GC](/garbage-collection-overview.md) safe point.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

When running TiDB with tiup playground, tiup cluster, tidb-operator or other situations where it runs with at least PD, TiKV and TiDB there are more status variables available than when running with only TiDB (`./bin/tidb-server`, unistore). This adds the missing variables.

See also https://github.com/pingcap/tidb/pull/22286

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v7.6 (TiDB 7.6 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
