### PR TITLE
Note that GC Disabling is a must despite Dumpling's auto extend feature

### DIFF
--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. This is a must step since even though Dumpling may [auto-extend the GC](/dumpling-overview.md#manually-set-the-tidb-gc-time) for TiDB v4.0.0 and later versions, after the Dumpling exits, GC may kick in, leading to failure in migrating the incremental change.
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. For TiDB v4.0.0 and later versions, Dumpling might [automatically extend the GC time](/dumpling-overview.md#manually-set-the-tidb-gc-time). Nevertheless, manually disable GC is still necessary because the GC process might begin after Dumpling exits, leading to the failure of incremental changes migration.
 
     Run the following command to disable GC:
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. (This step can be skipped if the TiDB version is later than or equal to v4.0.0 and certain conditions are met. For more details, please refer [here](/dumpling-overview.md#manually-set-the-tidb-gc-time))
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. For TiDB v4.0.0 and later versions, you can skip this step under specific conditions. For more details, see [Manually set the TiDB GC time](/dumpling-overview.md#manually-set-the-tidb-gc-time).
 
     Run the following command to disable GC:
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. For TiDB v4.0.0 and later versions, you can skip this step under specific conditions. For more details, see [Manually set the TiDB GC time](/dumpling-overview.md#manually-set-the-tidb-gc-time).
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. This is a must step since even though Dumpling may [auto-extend the GC](/dumpling-overview.md#manually-set-the-tidb-gc-time) for TiDB v4.0.0 and later versions, after the Dumpling exits, GC may kick in, leading to failure in migrating the incremental change.
 
     Run the following command to disable GC:
 
@@ -83,7 +83,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
     1 row in set (0.00 sec)
     ```
 
-2. Back up data.
+3. Back up data.
 
     1. Export data in SQL format using Dumpling:
 
@@ -106,7 +106,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
         Finished dump at: 2022-06-28 17:49:57
         ```
 
-3. Restore data.
+4. Restore data.
 
     Use MyLoader (an open-source tool) to import data to the downstream MySQL instance. For details about how to install and use MyLoader, see [MyDumpler/MyLoader](https://github.com/mydumper/mydumper). Note that you need to use MyLoader v0.10 or earlier versions. Higher versions cannot process metadata files exported by Dumpling.
 
@@ -116,7 +116,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
     myloader -h 127.0.0.1 -P 3306 -d ./dumpling_output/
     ```
 
-4. (Optional) Validate data.
+5. (Optional) Validate data.
 
     You can use [sync-diff-inspector](/sync-diff-inspector/sync-diff-inspector-overview.md) to check data consistency between upstream and downstream at a certain time.
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -83,7 +83,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
     1 row in set (0.00 sec)
     ```
 
-3. Back up data.
+2. Back up data.
 
     1. Export data in SQL format using Dumpling:
 
@@ -106,7 +106,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
         Finished dump at: 2022-06-28 17:49:57
         ```
 
-4. Restore data.
+3. Restore data.
 
     Use MyLoader (an open-source tool) to import data to the downstream MySQL instance. For details about how to install and use MyLoader, see [MyDumpler/MyLoader](https://github.com/mydumper/mydumper). Note that you need to use MyLoader v0.10 or earlier versions. Higher versions cannot process metadata files exported by Dumpling.
 
@@ -116,7 +116,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
     myloader -h 127.0.0.1 -P 3306 -d ./dumpling_output/
     ```
 
-5. (Optional) Validate data.
+4. (Optional) Validate data.
 
     You can use [sync-diff-inspector](/sync-diff-inspector/sync-diff-inspector-overview.md) to check data consistency between upstream and downstream at a certain time.
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. For TiDB v4.0.0 and later versions, Dumpling might [automatically extend the GC time](/dumpling-overview.md#manually-set-the-tidb-gc-time). Nevertheless, manually disable GC is still necessary because the GC process might begin after Dumpling exits, leading to the failure of incremental changes migration.
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. For TiDB v4.0.0 and later versions, Dumpling might [automatically extend the GC time](/dumpling-overview.md#manually-set-the-tidb-gc-time). Nevertheless, manually disabling GC is still necessary because the GC process might begin after Dumpling exits, leading to the failure of incremental changes migration.
 
     Run the following command to disable GC:
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. (This step can be skipped if the TiDB version is later than or equal to v4.0.0 and certain conditions are met. For more details, please refer [here](/dumpling-overview#manually-set-the-tidb-gc-time))
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. (This step can be skipped if the TiDB version is later than or equal to v4.0.0 and certain conditions are met. For more details, please refer [here](/dumpling-overview.md#manually-set-the-tidb-gc-time))
 
     Run the following command to disable GC:
 

--- a/migrate-from-tidb-to-mysql.md
+++ b/migrate-from-tidb-to-mysql.md
@@ -56,7 +56,7 @@ After setting up the environment, you can use [Dumpling](/dumpling-overview.md) 
 
 1. Disable Garbage Collection (GC).
 
-    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted.
+    To ensure that newly written data is not deleted during incremental migration, you should disable GC for the upstream cluster before exporting full data. In this way, history data is not deleted. (This step can be skipped if the TiDB version is later than or equal to v4.0.0 and certain conditions are met. For more details, please refer [here](/dumpling-overview#manually-set-the-tidb-gc-time))
 
     Run the following command to disable GC:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

I was reading the guide to migrate from TiDB to MySQL.
The guide advised to disable the GC before Dumpling is run.
However, I read in the Dumpling overview that this is now only necessary in certain conditions in the latest TiDB version.
If this section was potentially not up to date with that, I thought it will be nicer to note on that.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

https://docs-archive.pingcap.com/tidb/v7.2/dumpling-overview#manually-set-the-tidb-gc-time
https://docs-archive.pingcap.com/tidb/v7.2/migrate-from-tidb-to-mysql

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
