### PR TITLE
tiup, tiproxy: add version flags to tiup cluster upgrade

### DIFF
--- a/tiproxy/tiproxy-configuration.md
+++ b/tiproxy/tiproxy-configuration.md
@@ -192,7 +192,7 @@ A client TLS object. It is used to access TiDB or PD.
 
 + Default value: `false`
 + Support hot-reload: yes, but only for new connections
-+ Require TLS between TiProxy and TiDB servers. If the TiDB server doesn't support TLS, clients will report an error when connecting to TiProxy.
++ Require TLS between TiProxy and TiDB servers. If the TiDB server does not support TLS, clients will report an error when connecting to TiProxy.
 
 #### `sql-tls`
 

--- a/tiproxy/tiproxy-configuration.md
+++ b/tiproxy/tiproxy-configuration.md
@@ -84,12 +84,6 @@ Configuration for SQL port.
 + Possible values: ``, `v2`
 + Enable the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) on the port. By enabling the PROXY protocol, TiProxy can pass the real client IP address to TiDB. `v2` indicates using the PROXY protocol version 2, and `` indicates disabling the PROXY protocol. If the PROXY protocol is enabled on TiProxy, you need to also enable the [PROXY protocol](/tidb-configuration-file.md#proxy-protocol) on the TiDB server.
 
-#### `require-backend-tls`
-
-+ Default value: `true`
-+ Support hot-reload: yes, but only for new connections
-+ Require TLS between TiProxy and TiDB servers. If the TiDB server doesn't support TLS, clients will report an error when connecting to TiProxy.
-
 ### api
 
 Configurations for HTTP gateway.
@@ -193,6 +187,12 @@ For server TLS object:
 #### `cluster-tls`
 
 A client TLS object. It is used to access TiDB or PD.
+
+#### `require-backend-tls`
+
++ Default value: `false`
++ Support hot-reload: yes, but only for new connections
++ Require TLS between TiProxy and TiDB servers. If the TiDB server doesn't support TLS, clients will report an error when connecting to TiProxy.
 
 #### `sql-tls`
 

--- a/tiproxy/tiproxy-overview.md
+++ b/tiproxy/tiproxy-overview.md
@@ -55,7 +55,7 @@ It is recommended that you use TiProxy for the scenarios that TiProxy is suitabl
 
 ## Installation and usage
 
-This section describes how to deploy and change TiProxy using TiUP. For how to deploy TiProxy using TiDB Operator in Kubernetes, see [TiDB Operator documentation](https://docs.pingcap.com/tidb-in-kubernetes/stable).
+This section describes how to deploy and change TiProxy using TiUP. For how to deploy TiProxy using TiDB Operator in Kubernetes, see [TiDB Operator documentation](https://docs.pingcap.com/tidb-in-kubernetes/stable/deploy-tiproxy).
 
 ### Deploy TiProxy
 
@@ -126,7 +126,7 @@ When using TiUP to change the TiProxy configuration, if the configuration item t
 
 When you deploy TiProxy, it is recommended to specify the version of TiProxy so that TiProxy will not be upgraded when you upgrade the TiDB cluster.
 
-If you need to upgrade TiProxy, add [`--tiproxy-version`](/tiup/tiup-component-cluster-upgrade.md) in the upgrade command to specify the version of TiProxy:
+If you need to upgrade TiProxy, add [`--tiproxy-version`](/tiup/tiup-component-cluster-upgrade.md#--tiproxy-version) in the upgrade command to specify the version of TiProxy:
 
 ```shell
 tiup cluster upgrade <cluster-name> <version> --tiproxy-version <tiproxy-version>

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -120,7 +120,7 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 - Prints the help information.
 - Data type: `BOOLEAN`
-- Default: false
+- This option is disabled by default with the `false` value. To enable this option, add this option to the command, and either pass the `true` value or do not pass any value.
 
 ## Output
 

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -44,11 +44,77 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 - Data type: `BOOLEAN`
 - Default: false
 
+### --ignore-version-check
+
+- Before upgrading, TiUP checks whether the target version is greater than or equal to the current version. To skip this check, you can use the `--ignore-version-check` option.
+- Data type: `BOOLEAN`
+- This option is disabled by default with the `false` value. To enable this option, add this option to the command, and either pass the `true` value or do not pass any value.
+
 ### --offline
 
 - Declares that the current cluster is not running. When this option is specified, TiUP does not evict the service leader to another node or restart the service, but only replaces the binary files of the cluster components.
 - Data type: `BOOLEAN`
 - This option is disabled by default with the `false` value. To enable this option, add this option to the command, and either pass the `true` value or do not pass any value.
+
+### --pd-version
+
+- Specifies the version of PD. If this option is set, the version of PD will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of PD remains consistent with the cluster version.
+
+### --tikv-version
+
+- Specifies the version of TiKV. If this option is set, the version of TiKV will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiKV remains consistent with the cluster version.
+
+### --tikv-cdc-version
+
+- Specifies the version of TiKV CDC. If this option is set, the version of TiKV CDC will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiKV CDC remains consistent with the cluster version.
+
+### --tiflash-version
+
+- Specifies the version of TiFlash. If this option is set, the version of TiFlash will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiFlash remains consistent with the cluster version.
+
+### --cdc-version
+
+- Specifies the version of TiCDC. If this option is set, the version of TiCDC will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiCDC remains consistent with the cluster version.
+
+### --tiproxy-version
+
+- Specifies the version of TiProxy. If this option is set, the version of TiProxy will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiProxy remains consistent with the cluster version.
+
+### --tidb-dashboard-version
+
+- Specifies the version of TiDB Dashboard. If this option is set, the version of TiDB Dashboard will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of TiDB Dashboard remains consistent with the cluster version.
+
+### --alertmanager-version
+
+- Specifies the version of alert manager. If this option is set, the version of alert manager will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of alert manager remains consistent with the cluster version.
+
+### --blackbox-exporter-version
+
+- Specifies the version of Blackbox Exporter. If this option is set, the version of Blackbox Exporter will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of Blackbox Exporter remains consistent with the cluster version.
+
+### --node-exporter-version
+
+- Specifies the version of Node Exporter. If this option is set, the version of Node Exporter will no longer be consistent with the cluster version.
+- Data type: `STRINGS`
+- If this option is not set, the version of Node Exporter remains consistent with the cluster version.
 
 ### -h, --help
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

- TiUP Cluster supports specifying versions of specific components:

```
Flags:
      --alertmanager-version string        Fix the version of alertmanager and no longer follows the cluster version.
      --blackbox-exporter-version string   Fix the version of blackbox-exporter and no longer follows the cluster version.
      --cdc-version string                 Fix the version of cdc and no longer follows the cluster version.
      --force                              Force upgrade without transferring PD leader
  -h, --help                               help for upgrade
      --ignore-config-check                Ignore the config check result
      --ignore-version-check               Ignore checking if target version is bigger than current version
      --node-exporter-version string       Fix the version of node-exporter and no longer follows the cluster version.
      --offline                            Upgrade a stopped cluster
      --pd-version string                  Fix the version of pv and no longer follows the cluster version.
      --post-upgrade-script string         (EXPERIMENTAL) Custom script to be executed on each server after the server is upgraded
      --pre-upgrade-script string          (EXPERIMENTAL) Custom script to be executed on each server before the server is upgraded
      --tidb-dashboard-version string      Fix the version of tidb-dashboard and no longer follows the cluster version.
      --tiflash-version string             Fix the version of tiflash and no longer follows the cluster version.
      --tikv-cdc-version string            Fix the version of tikv-cdc and no longer follows the cluster version.
      --tikv-version string                Fix the version of tikv and no longer follows the cluster version.
      --tiproxy-version string             Fix the version of tiproxy and no longer follows the cluster version.
      --transfer-timeout uint              Timeout in seconds when transferring PD and TiKV store leaders, also for TiCDC drain one capture (default 600)
```

- Update the links in TiProxy overview doc

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/16243 and https://github.com/pingcap/docs-cn/pull/17081
- Other reference link(s): 

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
