### PR TITLE
ticdc add output old value config

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -228,6 +228,14 @@ enable-partition-separator = true
 # The default value is "json".
 # encoding-format = "json"
 
+[sink.open]
+# Whether to output the value before the row data changes. The default value is true. When it is disabled, the UPDATE event does not output the "p" field.
+# output-old-value = true
+
+[sink.debezium]
+# Whether to output the value before the row data changes. The default value is true. When it is disabled, the UPDATE event does not output the "before" field.
+# output-old-value = true
+
 # Specifies the replication consistency configurations for a changefeed when using the redo log. For more information, see https://docs.pingcap.com/tidb/stable/ticdc-sink-to-mysql#eventually-consistent-replication-in-disaster-scenarios.
 # Note: The consistency-related configuration items only take effect when the downstream is a database and the redo log feature is enabled.
 [consistent]

--- a/ticdc/ticdc-open-api-v2.md
+++ b/ticdc/ticdc-open-api-v2.md
@@ -316,6 +316,8 @@ The `sink` parameters are described as follows:
 | `transaction_atomicity` | `STRING` type. The atomicity level of the transaction. (Optional)                                                                                                                                              |
 | `only_output_updated_columns` | `BOOLEAN` type. For MQ sinks using the `canal-json` or `open-protocol` protocol, you can specify whether only output the modified columns. The default value is `false`. (Optional) |
 | `cloud_storage_config` | The storage sink configuration. (Optional) |
+| `open`                        | The Open Protocol configuration. (Optional)                                                                             |
+| `debezium`                    | The Debezium Protocol configuration. (Optional)                                                                             |
 
 `sink.column_selectors` is an array. The parameters are described as follows:
 
@@ -349,7 +351,7 @@ The `sink.csv` parameters are described as follows:
 | `partition` | `STRING` type. The target partition for dispatching events.    |
 | `topic`     | `STRING` type. The target topic for dispatching events.        |
 
-`sink.cloud_storage_config`  parameters are described as follows:
+`sink.cloud_storage_config` parameters are described as follows:
 
 | Parameter name | Description |
 |:-----------------|:---------------------------------------|
@@ -359,6 +361,18 @@ The `sink.csv` parameters are described as follows:
 | `file_expiration_days`   | `INT` type. The duration to retain files, which takes effect only when `date-separator` is configured as `day`. |
 | `file_cleanup_cron_spec`   | `STRING` type. The running cycle of the scheduled cleanup task, compatible with the crontab configuration, with a format of `<Second> <Minute> <Hour> <Day of the month> <Month> <Day of the week (Optional)>`. |
 | `flush_concurrency`   | `INT` type. The concurrency for uploading a single file. |
+
+`sink.open` parameters are described as follows:
+
+| Parameter name     | Description                                                                                                                                                                |
+|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `output_out_value` | `BOOLEAN` type. Whether to output the value before the row data changes. The default value is `true`. When it is disabled, the UPDATE event does not output the "p" field. |
+
+`sink.debezium` parameters are described as follows:
+
+| Parameter name     | Description                                                                                                                                                                   |
+|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `output_out_value` | `BOOLEAN` type. Whether to output the value before the row data changes. The default value is true. When it is disabled, the UPDATE event does not output the "before" field. |
 
 ### Example
 

--- a/ticdc/ticdc-open-api-v2.md
+++ b/ticdc/ticdc-open-api-v2.md
@@ -366,13 +366,13 @@ The `sink.csv` parameters are described as follows:
 
 | Parameter name     | Description                                                                                                                                                                |
 |:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `output_out_value` | `BOOLEAN` type. Whether to output the value before the row data changes. The default value is `true`. When it is disabled, the UPDATE event does not output the "p" field. |
+| `output_old_value` | `BOOLEAN` type. It controls whether to output the value before the row data changes. The default value is `true`. When it is disabled, the UPDATE event does not output the "p" field. |
 
 `sink.debezium` parameters are described as follows:
 
 | Parameter name     | Description                                                                                                                                                                   |
 |:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `output_out_value` | `BOOLEAN` type. Whether to output the value before the row data changes. The default value is true. When it is disabled, the UPDATE event does not output the "before" field. |
+| `output_old_value` | `BOOLEAN` type. It controls whether to output the value before the row data changes. The default value is true. When it is disabled, the UPDATE event does not output the "before" field. |
 
 ### Example
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add sink.open.output-old-value and sink.debezium.output-old-value to control whether to output the value before the row data changes.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.6 (TiDB 7.6 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/17140
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
