### PR TITLE
v7.6: update Rust version for compiling and running TiDB to nightly-2023-12-10

### DIFF
--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -101,7 +101,7 @@ As an open-source distributed SQL database with high performance, TiDB can be de
 |  Libraries required for compiling and running TiDB |  Version   |
 |   :---   |   :---   |
 |   Golang  |  1.21 or later |
-|   Rust    |   nightly-2022-07-31 or later  |
+|   Rust    |   nightly-2023-12-10 or later  |
 |  GCC      |   7.x      |
 |  LLVM     |  13.0 or later  |
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Starting from v7.6.0, the Rust version for compiling and running TiDB is updated to nightly-2023-12-10
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [x] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
