### PR TITLE
Revert "tidb lightning: expose [tidb.session-vars] in lightning config (#17864)"

### DIFF
--- a/tidb-lightning/tidb-lightning-configuration.md
+++ b/tidb-lightning/tidb-lightning-configuration.md
@@ -274,10 +274,6 @@ distsql-scan-concurrency = 15
 index-serial-scan-concurrency = 20
 checksum-table-concurrency = 2
 
-# Sets other TiDB session variables
-# [tidb.session-vars]
-# tidb_enable_clustered_index = "OFF"
-
 # The default SQL mode used to parse and execute the SQL statements.
 sql-mode = "ONLY_FULL_GROUP_BY,NO_AUTO_CREATE_USER"
 # Sets maximum packet size allowed for SQL connections.


### PR DESCRIPTION
Reverts pingcap/docs#17866

PR is not merged into v6.5 yet

https://github.com/pingcap/tidb/pull/47500