### PR TITLE
fix error message of 8028 in metadata lock

### DIFF
--- a/metadata-lock.md
+++ b/metadata-lock.md
@@ -64,7 +64,7 @@ Starting from v6.5.0, TiDB enables metadata lock by default. When you upgrade yo
     | `COMMIT;`                  |                                           |
     | `BEGIN;`                   |                                           |
     |                            | `ALTER TABLE t MODIFY COLUMN a CHAR(10);` |
-    | `SELECT * FROM t;` (returns `Error 8028: Information schema is changed`) | |
+    | `SELECT * FROM t;` (returns `ERROR 8028 (HY000): public column a has changed`) | |
 
 ## Observability
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

fix error message of 8028 in metadata lock from "Error 8028: Information schema is changed" to "ERROR 8028 (HY000): public column a has changed"

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v8.2 (TiDB 8.2 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.6 (TiDB 7.6 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
