### PR TITLE
Update EBNF for password options

### DIFF
--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -166,8 +166,10 @@ SELECT USER, HOST, USER_ATTRIBUTES FROM MYSQL.USER WHERE USER='newuser7';
 
 The following `CREATE USER` options are not yet supported by TiDB, and will be parsed but ignored:
 
-* TiDB does not support `WITH MAX_QUERIES_PER_HOUR`, `WITH MAX_UPDATES_PER_HOUR`, and `WITH MAX_USER_CONNECTIONS` options.
-* TiDB does not support `PASSWORD REQUIRE CURRENT DEFAULT`.
+* `PASSWORD REQUIRE CURRENT DEFAULT`
+* `WITH MAX_QUERIES_PER_HOUR`
+* `WITH MAX_UPDATES_PER_HOUR`
+* `WITH MAX_USER_CONNECTIONS`
 
 The following `CREATE USER` options are also not supported by TiDB, and are *not* accepted by the parser:
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -169,10 +169,10 @@ The following `CREATE USER` options are not yet supported by TiDB, and will be p
 * TiDB does not support `WITH MAX_QUERIES_PER_HOUR`, `WITH MAX_UPDATES_PER_HOUR`, and `WITH MAX_USER_CONNECTIONS` options.
 * TiDB does not support `PASSWORD REQUIRE CURRENT DEFAULT`.
 
-In addition to that these options are also not supported by TiDB, and are *not* accepted by the parser:
+The following `CREATE USER` options are also not supported by TiDB, and are *not* accepted by the parser:
 
-* TiDB does not support the `DEFAULT ROLE` option.
-* TiDB does not support `PASSWORD REQUIRE CURRENT OPTIONAL`.
+* `DEFAULT ROLE`
+* `PASSWORD REQUIRE CURRENT OPTIONAL`
 
 ## See also
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -21,8 +21,8 @@ UserSpecList ::=
     UserSpec ( ',' UserSpec )*
 
 RequireClauseOpt ::=
-    ( 'REQUIRE' 'NONE' | 'REQUIRE' 'SSL' | 'REQUIRE' 'X509' | 'REQUIRE' RequireList )?  
-    
+    ( 'REQUIRE' 'NONE' | 'REQUIRE' 'SSL' | 'REQUIRE' 'X509' | 'REQUIRE' RequireList )?
+
 RequireList ::=
     ( "ISSUER" stringLit | "SUBJECT" stringLit | "CIPHER" stringLit | "SAN" stringLit | "TOKEN_ISSUER" stringLit )*
 
@@ -36,7 +36,12 @@ StringName ::=
     stringLit
 |   Identifier
 
-PasswordOption ::= ( 'PASSWORD' 'EXPIRE' ( 'DEFAULT' | 'NEVER' | 'INTERVAL' N 'DAY' )? | 'PASSWORD' 'HISTORY' ( 'DEFAULT' | N ) | 'PASSWORD' 'REUSE' 'INTERVAL' ( 'DEFAULT' | N 'DAY' ) | 'FAILED_LOGIN_ATTEMPTS' N | 'PASSWORD_LOCK_TIME' ( N | 'UNBOUNDED' ) )*
+PasswordOption ::= ( 'PASSWORD' 'EXPIRE' ( 'DEFAULT' | 'NEVER' | 'INTERVAL' N 'DAY' )?
+| 'PASSWORD' 'HISTORY' ( 'DEFAULT' | N )
+| 'PASSWORD' 'REUSE' 'INTERVAL' ( 'DEFAULT' | N 'DAY' )
+| 'PASSWORD' 'REQUIRE' 'CURRENT' 'DEFAULT'
+| 'FAILED_LOGIN_ATTEMPTS' N
+| 'PASSWORD_LOCK_TIME' ( N | 'UNBOUNDED' ) )*
 
 LockOption ::= ( 'ACCOUNT' 'LOCK' | 'ACCOUNT' 'UNLOCK' )?
 
@@ -162,7 +167,12 @@ SELECT USER, HOST, USER_ATTRIBUTES FROM MYSQL.USER WHERE USER='newuser7';
 The following `CREATE USER` options are not yet supported by TiDB, and will be parsed but ignored:
 
 * TiDB does not support `WITH MAX_QUERIES_PER_HOUR`, `WITH MAX_UPDATES_PER_HOUR`, and `WITH MAX_USER_CONNECTIONS` options.
+* TiDB does not support `PASSWORD REQUIRE CURRENT DEFAULT`.
+
+In addition to that these options are also not supported by TiDB, and are *not* accepted by the parser:
+
 * TiDB does not support the `DEFAULT ROLE` option.
+* TiDB does not support `PASSWORD REQUIRE CURRENT OPTIONAL`.
 
 ## See also
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -171,7 +171,7 @@ The following `CREATE USER` options are not yet supported by TiDB, and will be p
 * `WITH MAX_UPDATES_PER_HOUR`
 * `WITH MAX_USER_CONNECTIONS`
 
-The following `CREATE USER` options are also not supported by TiDB, and are *not* accepted by the parser:
+The following `CREATE USER` options are not supported by TiDB either, and are *not* accepted by the parser:
 
 * `DEFAULT ROLE`
 * `PASSWORD REQUIRE CURRENT OPTIONAL`


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

For reviewers: Preview ebnf on https://kennytm.github.io/website-docs/dist/

### What is changed, added or deleted? (Required)

The `PASSWORD REQUIRE CURRENT DEFAULT` syntax is accepted to be able to parse the output of `SHOW CREATE USER`  from MySQL.  Especially as this is added by default by MySQL even if not specified when creating the user.

In MySQL `PASSWORD REQUIRE CURRENT` and `PASSWORD REQUIRE CURRENT OPTIONAL` are also accepted, but TiDB doesn't and the parser won't accept this.

As there is no `password_require_current` system variable in TiDB and no other options are accepted this syntax is meaningless / ignored.

See also: https://dev.mysql.com/doc/refman/8.4/en/password-management.html#password-reverification-policy

Note that the docs suggested that `CREATE USER 'foo3'@'%' IDENTIFIED BY 'abc' DEFAULT ROLE 'myrole'` should be accepted by TiDB with the role being ignored, but that doesn't seem to be the case.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

https://github.com/pingcap/tidb/pull/53306

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
