### PR TITLE
Use decimal data type for the TRUNCATE argument to address the `Truncated incorrect INTEGER value: '' warning`

### DIFF
--- a/predicate-push-down.md
+++ b/predicate-push-down.md
@@ -74,18 +74,18 @@ In addition, This SQL statement has an inner join executed, and the `ON` conditi
 ### Case 4: predicates that are not supported by storage layers cannot be pushed down
 
 ```sql
-create table t(id int primary key, a varchar(10) not null);
-desc select * from t where truncate(a, " ") = '1';
-+-------------------------+----------+-----------+---------------+---------------------------------------------------+
-| id                      | estRows  | task      | access object | operator info                                     |
-+-------------------------+----------+-----------+---------------+---------------------------------------------------+
-| Selection_5             | 8000.00  | root      |               | eq(truncate(cast(test.t.a, double BINARY), 0), 1) |
-| └─TableReader_7         | 10000.00 | root      |               | data:TableFullScan_6                              |
-|   └─TableFullScan_6     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo                    |
-+-------------------------+----------+-----------+---------------+---------------------------------------------------+
+create table t(id int primary key, a decimal(10, 2) not null);
+desc select * from t where truncate(a, 0) = 1;
++-------------------------+----------+-----------+---------------+--------------------------------+
+| id                      | estRows  | task      | access object | operator info                  |
++-------------------------+----------+-----------+---------------+--------------------------------+
+| Selection_5             | 8000.00  | root      |               | eq(truncate(test.t.a, 0), 1)   |
+| └─TableReader_7         | 10000.00 | root      |               | data:TableFullScan_6           |
+|   └─TableFullScan_6     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo |
++-------------------------+----------+-----------+---------------+--------------------------------+
 ```
 
-In this query, there is a predicate `truncate(a, " ") = '1'`.
+In this query, there is a predicate `truncate(a, 0) = 1`.
 
 From the `explain` results, you can see that the predicate is not pushed down to TiKV for calculation. This is because the TiKV coprocessor does not support the built-in function `truncate`.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This pull request replaces the data type for the truncate argument from varchar to decimal because the current example raises the `Truncated incorrect INTEGER value: '' ` warning.

* Current example that raises the `Truncated incorrect INTEGER value: '' ` warning.

```sql
mysql> use test;
Database changed
mysql> create table t(id int primary key, a varchar(10) not null);
Query OK, 0 rows affected (0.07 sec)

mysql> desc select * from t where truncate(a, " ") = '1';
+-------------------------+----------+-----------+---------------+---------------------------------------------------+
| id                      | estRows  | task      | access object | operator info                                     |
+-------------------------+----------+-----------+---------------+---------------------------------------------------+
| Selection_5             | 8000.00  | root      |               | eq(truncate(cast(test.t.a, double BINARY), 0), 1) |
| └─TableReader_7         | 10000.00 | root      |               | data:TableFullScan_6                              |
|   └─TableFullScan_6     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo                    |
+-------------------------+----------+-----------+---------------+---------------------------------------------------+
3 rows in set, 2 warnings (0.00 sec)

mysql> show warnings;
+---------+------+------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                      |
+---------+------+------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1292 | Truncated incorrect INTEGER value: ''                                                                                        |
| Warning | 1105 | Scalar function 'truncate'(signature: TruncateReal, return type: double) is not supported to push down to storage layer now. |
+---------+------+------------------------------------------------------------------------------------------------------------------------------+
2 rows in set (0.00 sec)

mysql>
mysql> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v8.1.0
Edition: Community
Git Commit Hash: 945d07c5d5c7a1ae212f6013adfb187f2de24b23
Git Branch: HEAD
UTC Build Time: 2024-05-21 03:52:40
GoVersion: go1.21.10
Race Enabled: false
Check Table Before Drop: false
Store: tikv
1 row in set (0.00 sec)

mysql>
```

* Updated example that does not raise the `Truncated incorrect INTEGER value: '' ` warning.
```sql
mysql> drop table t;
Query OK, 0 rows affected (0.19 sec)

mysql> create table t(id int primary key, a decimal(10, 2) not null);
Query OK, 0 rows affected (0.07 sec)

mysql> desc select * from t where truncate(a, 0) = 1;
+-------------------------+----------+-----------+---------------+--------------------------------+
| id                      | estRows  | task      | access object | operator info                  |
+-------------------------+----------+-----------+---------------+--------------------------------+
| Selection_5             | 8000.00  | root      |               | eq(truncate(test.t.a, 0), 1)   |
| └─TableReader_7         | 10000.00 | root      |               | data:TableFullScan_6           |
|   └─TableFullScan_6     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo |
+-------------------------+----------+-----------+---------------+--------------------------------+
3 rows in set, 1 warning (0.00 sec)

mysql> show warnings;
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                               |
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1105 | Scalar function 'truncate'(signature: TruncateDecimal, return type: decimal(8,0)) is not supported to push down to storage layer now. |
+---------+------+---------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql>
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): The current change has been made via #13682

This document says "Truncate to specified number of decimal places".
https://docs.pingcap.com/tidb/stable/numeric-functions-and-operators
> TRUNCATE()	Truncate to specified number of decimal places

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
