### PR TITLE
Update description of `tidb_replica_read` variable values for follower read

### DIFF
--- a/follower-read.md
+++ b/follower-read.md
@@ -32,17 +32,17 @@ Default: leader
 
 This variable is used to set the expected data read mode.
 
-- When the value of `tidb_replica_read` is set to `leader` or an empty string, TiDB maintains its default behavior and sends all read operations to the leader replica to perform.
-- When the value of `tidb_replica_read` is set to `follower`, TiDB selects a follower replica of the Region to perform all read operations.
-- When the value of `tidb_replica_read` is set to `leader-and-follower`, TiDB can select any replicas to perform read operations. In this mode, read requests are load balanced between the leader and follower.
-- When the value of `tidb_replica_read` is set to `prefer-leader`, TiDB prefers to select the leader replica to perform read operations. If the leader replica is obviously slow in processing read operations (such as caused by disk or network performance jitter), TiDB will select other available follower replicas to perform read operations.
-- When the value of `tidb_replica_read` is set to `closest-replicas`, TiDB prefers to select a replica in the same availability zone to perform read operations, which can be a leader or a follower. If there is no replica in the same availability zone, TiDB reads from the leader replica.
+- When the value of `tidb_replica_read` is set to `leader` or an empty string, TiDB maintains its default behavior and sends all read operations to the leader replica if the estimated waiting duration in the leader replica's kv store does not exceed [`tidb_load_based_replica_read_threshold`](/system-variables.md#tidb_load_based_replica_read_threshold-new-in-v700).
+- When the value of `tidb_replica_read` is set to `follower`, TiDB selects a follower or learner replica of the Region to perform all read operations.
+- When the value of `tidb_replica_read` is set to `leader-and-follower`, TiDB can select any replicas to perform read operations. In this mode, read requests are load balanced between the leader, follower and learner replicas.
+- When the value of `tidb_replica_read` is set to `prefer-leader`, TiDB prefers to select the leader replica to perform read operations. If the leader replica is obviously slow in processing read operations (such as caused by disk or network performance jitter), TiDB will select other available follower or learner replicas to perform read operations.
+- When the value of `tidb_replica_read` is set to `closest-replicas`, TiDB prefers to select a replica in the same availability zone to perform read operations, which can be a leader, follower or learner. If there is no replica in the same availability zone, TiDB reads from the leader replica.
 - When the value of `tidb_replica_read` is set to `closest-adaptive`:
 
     - If the estimated result of a read request is greater than or equal to the value of [`tidb_adaptive_closest_read_threshold`](/system-variables.md#tidb_adaptive_closest_read_threshold-new-in-v630), TiDB prefers to select a replica in the same availability zone for read operations. To avoid unbalanced distribution of read traffic across availability zones, TiDB dynamically detects the distribution of availability zones for all online TiDB and TiKV nodes. In each availability zone, the number of TiDB nodes whose `closest-adaptive` configuration takes effect is limited, which is always the same as the number of TiDB nodes in the availability zone with the fewest TiDB nodes, and the other TiDB nodes automatically read from the leader replica. For example, if TiDB nodes are distributed across 3 availability zones (A, B, and C), where A and B each contains 3 TiDB nodes and C contains only 2 TiDB nodes, the number of TiDB nodes whose `closest-adaptive` configuration takes effect in each availability zone is 2, and the other TiDB node in each of the A and B availability zones automatically selects the leader replica for read operations.
     - If the estimated result of a read request is less than the value of [`tidb_adaptive_closest_read_threshold`](/system-variables.md#tidb_adaptive_closest_read_threshold-new-in-v630), TiDB can only select the leader replica for read operations.
 
-- When the value of `tidb_replica_read` is set to `learner`, TiDB reads data from the learner replica. If there is no learner replica in the Region, TiDB returns an error.
+- When the value of `tidb_replica_read` is set to `learner`, TiDB reads data from the learner replica. If there is no learner replica in the Region, TiDB will read either the from leader or follower replicas randomly.
 
 <CustomContent platform="tidb">
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
- After reviewing the source code for client-go and TiDB, I noticed that some descriptions in the [follower read doc](https://docs.pingcap.com/tidb/stable/follower-read) do not fully align with the source code behavior and my test results.
1. Behavior of tidb_replica_read set to leader
    - According to [client-go](https://github.com/tikv/client-go/blob/master/internal/locate/replica_selector.go#L135), when `tidb_replica_read` is set to `leader`, if the leader replica's kv store is busy, which is partially determined by the [`tidb_load_based_replica_read_threshold`](https://docs.pingcap.com/tidb/stable/system-variables#tidb_load_based_replica_read_threshold-new-in-v700), then the client-go will select the others replica to read, which can be follower or learner replicas. 
    - I have updated the doc to reflect this behavior and clarify the relationship between `tidb_load_based_replica_read_threshold` and `tidb_replica_read` when set to `leader`.
2. Reading from Learner Replicas
    - Since reading from learner replicas is supported in the current version, I found it necessary to distinguish between reading from follower and learner replicas.
    -  There are generally no restrictions on reading from learner replicas when `tidb_replica_read` is set to `follower`, `leader-and-follower`, `prefer-leader`, or `closest-replicas`. However, the current documentation only mentions follower reads in these contexts.
    - More details on how replicas are chosen based on scores can be found in the [client-go calculateScore](https://github.com/tikv/client-go/blob/master/internal/locate/replica_selector.go#L386).
3. Behavior when tidb_replica_read is set to learner
    - [The doc](https://docs.pingcap.com/tidb/stable/follower-read#usage) currently states that :
        > When the value of `tidb_replica_read` is set to learner, TiDB reads data from the learner replica. If there is no learner replica in the Region, TiDB returns an error.

    - However, in my test results (under `v8.1.0`), when there are no learner replica and `tidb_replica_read` is set to `learner`, mysql client still can read data from tidb.This occurs because client-go will randomly choose the leader or follower replica to read. 
- Please let me know If I have misunderstood any concepts, Thanks !
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
