### PR TITLE
add aliases for Binlog docs

### DIFF
--- a/sql-statements/sql-statement-change-drainer.md
+++ b/sql-statements/sql-statement-change-drainer.md
@@ -1,7 +1,7 @@
 ---
 title: CHANGE DRAINER
 summary: An overview of the usage of CHANGE DRAINER for the TiDB database.
-aliases: ['/tidb/dev/sql-statement-change-drainer/','/docs/dev/sql-statements/sql-statement-change-drainer/']
+aliases: ['/tidb/dev/sql-statement-change-drainer/','/tidb/stable/sql-statement-change-drainer/','/docs/dev/sql-statements/sql-statement-change-drainer/']
 ---
 
 # CHANGE DRAINER

--- a/sql-statements/sql-statement-change-pump.md
+++ b/sql-statements/sql-statement-change-pump.md
@@ -1,7 +1,7 @@
 ---
 title: CHANGE PUMP
 summary: An overview of the usage of CHANGE PUMP for the TiDB database.
-aliases: ['/tidb/dev/sql-statement-change-pump/','/docs/dev/sql-statements/sql-statement-change-pump/']
+aliases: ['/tidb/dev/sql-statement-change-pump/','/tidb/stable/sql-statement-change-pump/','/docs/dev/sql-statements/sql-statement-change-pump/']
 ---
 
 # CHANGE PUMP

--- a/sql-statements/sql-statement-show-drainer-status.md
+++ b/sql-statements/sql-statement-show-drainer-status.md
@@ -1,7 +1,7 @@
 ---
 title: SHOW DRAINER STATUS
 summary: An overview of the usage of SHOW DRAINER STATUS for the TiDB database.
-aliases: ['/tidb/dev/sql-statement-show-drainer-status/','/docs/dev/sql-statements/sql-statement-show-drainer-status/']
+aliases: ['/tidb/dev/sql-statement-show-drainer-status/','/tidb/stable/sql-statement-show-drainer-status/','/docs/dev/sql-statements/sql-statement-show-drainer-status/']
 ---
 
 # SHOW DRAINER STATUS

--- a/sql-statements/sql-statement-show-pump-status.md
+++ b/sql-statements/sql-statement-show-pump-status.md
@@ -1,7 +1,7 @@
 ---
 title: SHOW PUMP STATUS
 summary: An overview of the usage of SHOW PUMP STATUS for the TiDB database.
-aliases: ['/tidb/dev/sql-statement-show-pump-status/','/docs/dev/sql-statements/sql-statement-show-pump-status/']
+aliases: ['/tidb/dev/sql-statement-show-pump-status/','/tidb/stable/sql-statement-show-pump-status/','/docs/dev/sql-statements/sql-statement-show-pump-status/']
 ---
 
 # SHOW PUMP STATUS

--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,1 @@
+This is a test file.

--- a/temp.md
+++ b/temp.md
@@ -1,1 +1,0 @@
-This is a test file.

--- a/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
+++ b/tidb-binlog/bidirectional-replication-between-tidb-clusters.md
@@ -1,7 +1,7 @@
 ---
 title: Bidirectional Replication Between TiDB Clusters
 summary: Learn how to perform the bidirectional replication between TiDB clusters.
-aliases: ['/tidb/dev/bidirectional-replication-between-tidb-clusters/','/docs/dev/tidb-binlog/bidirectional-replication-between-tidb-clusters/','/docs/dev/reference/tidb-binlog/bidirectional-replication/']
+aliases: ['/tidb/dev/bidirectional-replication-between-tidb-clusters/','/tidb/stable/bidirectional-replication-between-tidb-clusters/','/docs/dev/tidb-binlog/bidirectional-replication-between-tidb-clusters/','/docs/dev/reference/tidb-binlog/bidirectional-replication/']
 ---
 
 # Bidirectional Replication between TiDB Clusters

--- a/tidb-binlog/binlog-consumer-client.md
+++ b/tidb-binlog/binlog-consumer-client.md
@@ -1,7 +1,7 @@
 ---
 title: Binlog Consumer Client User Guide
 summary: Use Binlog Consumer Client to consume TiDB secondary binlog data from Kafka and output the data in a specific format.
-aliases: ['/tidb/dev/binlog-consumer-client/','/tidb/dev/binlog-slave-client','/docs/dev/tidb-binlog/binlog-slave-client/','/docs/dev/reference/tidb-binlog/binlog-slave-client/','/docs/dev/reference/tools/tidb-binlog/binlog-slave-client/']
+aliases: ['/tidb/dev/binlog-consumer-client/','/tidb/stable/binlog-consumer-client/','/tidb/dev/binlog-slave-client','/docs/dev/tidb-binlog/binlog-slave-client/','/docs/dev/reference/tidb-binlog/binlog-slave-client/','/docs/dev/reference/tools/tidb-binlog/binlog-slave-client/']
 ---
 
 # Binlog Consumer Client User Guide

--- a/tidb-binlog/binlog-control.md
+++ b/tidb-binlog/binlog-control.md
@@ -1,7 +1,7 @@
 ---
 title: binlogctl
 summary: Learns how to use `binlogctl`.
-aliases: ['/tidb/dev/binlog-control/','/docs/dev/tidb-binlog/binlog-control/']
+aliases: ['/tidb/dev/binlog-control/','/tidb/stable/binlog-control/','/docs/dev/tidb-binlog/binlog-control/']
 ---
 
 # binlogctl

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Cluster Deployment
 summary: Learn how to deploy TiDB Binlog cluster.
-aliases: ['/tidb/dev/deploy-tidb-binlog/','/docs/dev/tidb-binlog/deploy-tidb-binlog/','/docs/dev/reference/tidb-binlog/deploy/','/docs/dev/how-to/deploy/tidb-binlog/']
+aliases: ['/tidb/dev/deploy-tidb-binlog/','/tidb/stable/deploy-tidb-binlog/','/docs/dev/tidb-binlog/deploy-tidb-binlog/','/docs/dev/reference/tidb-binlog/deploy/','/docs/dev/how-to/deploy/tidb-binlog/']
 ---
 
 # TiDB Binlog Cluster Deployment

--- a/tidb-binlog/get-started-with-tidb-binlog.md
+++ b/tidb-binlog/get-started-with-tidb-binlog.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Tutorial
 summary: Learn to deploy TiDB Binlog with a simple TiDB cluster.
-aliases: ['/tidb/dev/get-started-with-tidb-binlog/','/docs/dev/get-started-with-tidb-binlog/','/docs/dev/how-to/get-started/tidb-binlog/']
+aliases: ['/tidb/dev/get-started-with-tidb-binlog/','/tidb/stable/get-started-with-tidb-binlog/','/docs/dev/get-started-with-tidb-binlog/','/docs/dev/how-to/get-started/tidb-binlog/']
 ---
 
 # TiDB Binlog Tutorial

--- a/tidb-binlog/handle-tidb-binlog-errors.md
+++ b/tidb-binlog/handle-tidb-binlog-errors.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Error Handling
 summary: Learn how to handle TiDB Binlog errors.
-aliases: ['/tidb/dev/handle-tidb-binlog-errors/','/docs/dev/tidb-binlog/handle-tidb-binlog-errors/','/docs/dev/reference/tidb-binlog/troubleshoot/error-handling/']
+aliases: ['/tidb/dev/handle-tidb-binlog-errors/','/tidb/stable/handle-tidb-binlog-errors/','/docs/dev/tidb-binlog/handle-tidb-binlog-errors/','/docs/dev/reference/tidb-binlog/troubleshoot/error-handling/']
 ---
 
 # TiDB Binlog Error Handling

--- a/tidb-binlog/maintain-tidb-binlog-cluster.md
+++ b/tidb-binlog/maintain-tidb-binlog-cluster.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Cluster Operations
 summary: Learn how to operate the cluster version of TiDB Binlog.
-aliases: ['/tidb/dev/maintain-tidb-binlog-cluster/','/docs/dev/tidb-binlog/maintain-tidb-binlog-cluster/','/docs/dev/reference/tidb-binlog/maintain/','/docs/dev/how-to/maintain/tidb-binlog/','/docs/dev/reference/tools/tidb-binlog/maintain/']
+aliases: ['/tidb/dev/maintain-tidb-binlog-cluster/','/tidb/stable/maintain-tidb-binlog-cluster/','/docs/dev/tidb-binlog/maintain-tidb-binlog-cluster/','/docs/dev/reference/tidb-binlog/maintain/','/docs/dev/how-to/maintain/tidb-binlog/','/docs/dev/reference/tools/tidb-binlog/maintain/']
 ---
 
 # TiDB Binlog Cluster Operations

--- a/tidb-binlog/monitor-tidb-binlog-cluster.md
+++ b/tidb-binlog/monitor-tidb-binlog-cluster.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Monitoring
 summary: Learn how to monitor the cluster version of TiDB Binlog.
-aliases: ['/tidb/dev/monitor-tidb-binlog-cluster/','/docs/dev/tidb-binlog/monitor-tidb-binlog-cluster/','/docs/dev/reference/tidb-binlog/monitor/','/docs/dev/how-to/monitor/tidb-binlog/']
+aliases: ['/tidb/dev/monitor-tidb-binlog-cluster/','/tidb/stable/monitor-tidb-binlog-cluster/','/docs/dev/tidb-binlog/monitor-tidb-binlog-cluster/','/docs/dev/reference/tidb-binlog/monitor/','/docs/dev/how-to/monitor/tidb-binlog/']
 ---
 
 # TiDB Binlog Monitoring

--- a/tidb-binlog/tidb-binlog-configuration-file.md
+++ b/tidb-binlog/tidb-binlog-configuration-file.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Configuration File
 summary: Learn the configuration items of TiDB Binlog.
-aliases: ['/tidb/dev/tidb-binlog-configuration-file/','/docs/dev/tidb-binlog/tidb-binlog-configuration-file/','/docs/dev/reference/tidb-binlog/config/']
+aliases: ['/tidb/dev/tidb-binlog-configuration-file/','/tidb/stable/tidb-binlog-configuration-file/','/docs/dev/tidb-binlog/tidb-binlog-configuration-file/','/docs/dev/reference/tidb-binlog/config/']
 ---
 
 # TiDB Binlog Configuration File

--- a/tidb-binlog/tidb-binlog-faq.md
+++ b/tidb-binlog/tidb-binlog-faq.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog FAQs
 summary: Learn about the frequently asked questions (FAQs) and answers about TiDB Binlog.
-aliases: ['/tidb/dev/tidb-binlog-faq/','/docs/dev/tidb-binlog/tidb-binlog-faq/','/docs/dev/reference/tidb-binlog/faq/','/docs/dev/reference/tools/tidb-binlog/faq/']
+aliases: ['/tidb/dev/tidb-binlog-faq/','/tidb/stable/tidb-binlog-faq/','/docs/dev/tidb-binlog/tidb-binlog-faq/','/docs/dev/reference/tidb-binlog/faq/','/docs/dev/reference/tools/tidb-binlog/faq/']
 ---
 
 # TiDB Binlog FAQs

--- a/tidb-binlog/tidb-binlog-glossary.md
+++ b/tidb-binlog/tidb-binlog-glossary.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Glossary
 summary: Learn the terms used in TiDB Binlog.
-aliases: ['/tidb/dev/tidb-binlog-glossary/','/docs/dev/tidb-binlog/tidb-binlog-glossary/','/docs/dev/reference/tidb-binlog/glossary/']
+aliases: ['/tidb/dev/tidb-binlog-glossary/','/tidb/stable/tidb-binlog-glossary/','/docs/dev/tidb-binlog/tidb-binlog-glossary/','/docs/dev/reference/tidb-binlog/glossary/']
 ---
 
 # TiDB Binlog Glossary

--- a/tidb-binlog/tidb-binlog-overview.md
+++ b/tidb-binlog/tidb-binlog-overview.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Overview
 summary: Learn overview of the cluster version of TiDB Binlog.
-aliases: ['/tidb/dev/tidb-binlog-overview/','/docs/dev/tidb-binlog/tidb-binlog-overview/','/docs/dev/reference/tidb-binlog/overview/','/docs/dev/reference/tidb-binlog-overview/','/docs/dev/reference/tools/tidb-binlog/overview/']
+aliases: ['/tidb/dev/tidb-binlog-overview/','/tidb/stable/tidb-binlog-overview/','/docs/dev/tidb-binlog/tidb-binlog-overview/','/docs/dev/reference/tidb-binlog/overview/','/docs/dev/reference/tidb-binlog-overview/','/docs/dev/reference/tools/tidb-binlog/overview/']
 ---
 
 # TiDB Binlog Cluster Overview

--- a/tidb-binlog/tidb-binlog-relay-log.md
+++ b/tidb-binlog/tidb-binlog-relay-log.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Relay Log
 summary: Learn how to use relay log to maintain data consistency in extreme cases.
-aliases: ['/tidb/dev/tidb-binlog-relay-log/','/docs/dev/tidb-binlog/tidb-binlog-relay-log/','/docs/dev/reference/tidb-binlog/relay-log/']
+aliases: ['/tidb/dev/tidb-binlog-relay-log/','/tidb/stable/tidb-binlog-relay-log/','/docs/dev/tidb-binlog/tidb-binlog-relay-log/','/docs/dev/reference/tidb-binlog/relay-log/']
 ---
 
 # TiDB Binlog Relay Log

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -1,7 +1,7 @@
 ---
 title: Reparo User Guide
 summary: Learn to use Reparo.
-aliases: ['/tidb/dev/tidb-binlog-reparo/','/docs/dev/tidb-binlog/tidb-binlog-reparo/','/docs/dev/reference/tidb-binlog/reparo/']
+aliases: ['/tidb/dev/tidb-binlog-reparo/','/tidb/stable/tidb-binlog-reparo/','/docs/dev/tidb-binlog/tidb-binlog-reparo/','/docs/dev/reference/tidb-binlog/reparo/']
 ---
 
 # Reparo User Guide

--- a/tidb-binlog/troubleshoot-tidb-binlog.md
+++ b/tidb-binlog/troubleshoot-tidb-binlog.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Binlog Troubleshooting
 summary: Learn the troubleshooting process of TiDB Binlog.
-aliases: ['/tidb/dev/troubleshoot-tidb-binlog/','/docs/dev/tidb-binlog/troubleshoot-tidb-binlog/','/docs/dev/reference/tidb-binlog/troubleshoot/binlog/','/docs/dev/how-to/troubleshoot/tidb-binlog/']
+aliases: ['/tidb/dev/troubleshoot-tidb-binlog/','/tidb/stable/troubleshoot-tidb-binlog/','/docs/dev/tidb-binlog/troubleshoot-tidb-binlog/','/docs/dev/reference/tidb-binlog/troubleshoot/binlog/','/docs/dev/how-to/troubleshoot/tidb-binlog/']
 ---
 
 # TiDB Binlog Troubleshooting

--- a/tidb-binlog/upgrade-tidb-binlog.md
+++ b/tidb-binlog/upgrade-tidb-binlog.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade TiDB Binlog
 summary: Learn how to upgrade TiDB Binlog to the latest cluster version.
-aliases: ['/tidb/dev/upgrade-tidb-binlog/','/docs/dev/tidb-binlog/upgrade-tidb-binlog/','/docs/dev/reference/tidb-binlog/upgrade/','/docs/dev/how-to/upgrade/tidb-binlog/']
+aliases: ['/tidb/dev/upgrade-tidb-binlog/','/tidb/stable/upgrade-tidb-binlog/','/docs/dev/tidb-binlog/upgrade-tidb-binlog/','/docs/dev/reference/tidb-binlog/upgrade/','/docs/dev/how-to/upgrade/tidb-binlog/']
 ---
 
 # Upgrade TiDB Binlog


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB ends the support of Binlog starting from v8.4.0. This PR adds aliases for Binlog docs for stable doc links.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [x] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/19191
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
