### PR TITLE
planner: fix the default value of 46177 to OFF for versions earlier than 8.5

### DIFF
--- a/optimizer-fix-controls.md
+++ b/optimizer-fix-controls.md
@@ -54,6 +54,6 @@ SET SESSION tidb_opt_fix_control = '44262:ON,44389:ON';
 
 ### [`46177`](https://github.com/pingcap/tidb/issues/46177) <span class="version-mark">New in v6.5.6</span>
 
-- Default value: `ON`
+- Default value: `OFF`
 - Possible values: `ON`, `OFF`
 - This variable controls whether the optimizer explores enforced plans during query optimization after finding an unenforced plan.


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

Before v8.5.0, the default value of 46177 is OFF
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [x] v8.4 (TiDB 8.4 versions)
- [x] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/19301
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
