### PR TITLE
chore: remove v5.3/v8.2 from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,14 +28,12 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 - [ ] v8.5 (TiDB 8.5 versions)
 - [ ] v8.4 (TiDB 8.4 versions)
 - [ ] v8.3 (TiDB 8.3 versions)
-- [ ] v8.2 (TiDB 8.2 versions)
 - [ ] v8.1 (TiDB 8.1 versions)
 - [ ] v7.5 (TiDB 7.5 versions)
 - [ ] v7.1 (TiDB 7.1 versions)
 - [ ] v6.5 (TiDB 6.5 versions)
 - [ ] v6.1 (TiDB 6.1 versions)
 - [ ] v5.4 (TiDB 5.4 versions)
-- [ ] v5.3 (TiDB 5.3 versions)
 
 ### What is the related PR or file link(s)?
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, we maintain the following versions of TiDB documentation in different
 | [`release-8.5`](https://github.com/pingcap/docs/tree/release-8.5) | 8.5 LTS (Long-Term Support) |
 | [`release-8.4`](https://github.com/pingcap/docs/tree/release-8.4) | 8.4 Development Milestone Release |
 | [`release-8.3`](https://github.com/pingcap/docs/tree/release-8.3) | 8.3 Development Milestone Release |
-| [`release-8.2`](https://github.com/pingcap/docs/tree/release-8.2) | 8.2 Development Milestone Release |
+| [`release-8.2`](https://github.com/pingcap/docs/tree/release-8.2) | 8.2 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-8.1`](https://github.com/pingcap/docs/tree/release-8.1) | 8.1 LTS (Long-Term Support) |
 | [`release-8.0`](https://github.com/pingcap/docs/tree/release-8.0) | 8.0 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-7.6`](https://github.com/pingcap/docs/tree/release-7.6) | 7.6 Development Milestone Release (Archived documentation, no longer updated) |
@@ -49,7 +49,7 @@ Currently, we maintain the following versions of TiDB documentation in different
 | [`release-6.1`](https://github.com/pingcap/docs/tree/release-6.1) | 6.1 LTS (Long-Term Support) version |
 | [`release-6.0`](https://github.com/pingcap/docs/tree/release-6.0) | 6.0 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-5.4`](https://github.com/pingcap/docs/tree/release-5.4) | 5.4 stable version |
-| [`release-5.3`](https://github.com/pingcap/docs/tree/release-5.3) | 5.3 stable version |
+| [`release-5.3`](https://github.com/pingcap/docs/tree/release-5.3) | 5.3 stable version (Archived documentation, no longer updated) |
 | [`release-5.2`](https://github.com/pingcap/docs/tree/release-5.2) | 5.2 stable version (Archived documentation, no longer updated) |
 | [`release-5.1`](https://github.com/pingcap/docs/tree/release-5.1) | 5.1 stable version (Archived documentation, no longer updated) |
 | [`release-5.0`](https://github.com/pingcap/docs/tree/release-5.0) | 5.0 stable version (Archived documentation, no longer updated) |

--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,1 @@
+This is a test file.

--- a/temp.md
+++ b/temp.md
@@ -1,1 +1,0 @@
-This is a test file.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove v5.3/v8.2 from the PR template because v5.3/v8.2 docs have been archived at [docs-archive.pingcap.com/zh/tidb](https://docs-archive.pingcap.com/zh/tidb) and will no longer receive new updates.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/19414
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
