### PR TITLE
fix: correct CHAR and BINARY maximum length from 256 to 255

### DIFF
--- a/tidb-limitations.md
+++ b/tidb-limitations.md
@@ -71,8 +71,8 @@ You can adjust the size limit via the [`txn-entry-size-limit`](/tidb-configurati
 
 | Type       | Upper limit   |
 |:----------|:----------|
-| CHAR       | 256 characters      |
-| BINARY     | 256 characters      |
+| CHAR       | 255 characters      |
+| BINARY     | 255 characters      |
 | VARBINARY  | 65535 characters    |
 | VARCHAR    | 16383 characters    |
 | TEXT       | Defaults to 6 MiB and can be adjusted to 120 MiB                |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

fix: correct CHAR and BINARY maximum length from 256 to 255

```bash
mysql> create table t(c char(256));
ERROR 1074 (42000): Column length too big for column 'c' (max = 255); use BLOB or TEXT instead
mysql> create table t(b binary(256));
ERROR 1074 (42000): Column length too big for column 'b' (max = 255); use BLOB or TEXT instead
```
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.4 (TiDB 8.4 versions)
- [x] v8.3 (TiDB 8.3 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/19493
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
