### PR TITLE
tiup: remove the manual links for returning to the previous page

### DIFF
--- a/tiup/tiup-command-clean.md
+++ b/tiup/tiup-command-clean.md
@@ -28,5 +28,3 @@ The value of `[name]` is the `Name` field output by the [`status` command](/tiup
 ```
 Clean instance of `%s`, directory: %s
 ```
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-clean.md
+++ b/tiup/tiup-command-clean.md
@@ -29,3 +29,4 @@ The value of `[name]` is the `Name` field output by the [`status` command](/tiup
 Clean instance of `%s`, directory: %s
 ```
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-clean.md
+++ b/tiup/tiup-command-clean.md
@@ -29,4 +29,3 @@ The value of `[name]` is the `Name` field output by the [`status` command](/tiup
 Clean instance of `%s`, directory: %s
 ```
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-completion.md
+++ b/tiup/tiup-command-completion.md
@@ -42,5 +42,3 @@ source $HOME/.bash_profile
 ```shell
 tiup completion zsh > "${fpath[1]}/_tiup"
 ```
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-completion.md
+++ b/tiup/tiup-command-completion.md
@@ -43,4 +43,3 @@ source $HOME/.bash_profile
 tiup completion zsh > "${fpath[1]}/_tiup"
 ```
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-completion.md
+++ b/tiup/tiup-command-completion.md
@@ -43,3 +43,4 @@ source $HOME/.bash_profile
 tiup completion zsh > "${fpath[1]}/_tiup"
 ```
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-env.md
+++ b/tiup/tiup-command-env.md
@@ -25,5 +25,3 @@ None
 - If `[name1...N]` is specified, the "{value}" list is output in order.
 
 In the above output, if `value` is empty, it means that the value of the environment variable is not set. In this case, TiUP uses the default value.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-env.md
+++ b/tiup/tiup-command-env.md
@@ -26,3 +26,4 @@ None
 
 In the above output, if `value` is empty, it means that the value of the environment variable is not set. In this case, TiUP uses the default value.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-env.md
+++ b/tiup/tiup-command-env.md
@@ -26,4 +26,3 @@ None
 
 In the above output, if `value` is empty, it means that the value of the environment variable is not set. In this case, TiUP uses the default value.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-help.md
+++ b/tiup/tiup-command-help.md
@@ -22,5 +22,3 @@ None
 ## Output
 
 The help information of `[command]` or TiUP.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-help.md
+++ b/tiup/tiup-command-help.md
@@ -23,3 +23,4 @@ None
 
 The help information of `[command]` or TiUP.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-help.md
+++ b/tiup/tiup-command-help.md
@@ -23,4 +23,3 @@ None
 
 The help information of `[command]` or TiUP.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-install.md
+++ b/tiup/tiup-command-install.md
@@ -24,5 +24,3 @@ None
 - Normally outputs the download information of the component.
 - If the component does not exist, the `The component "%s" not found` error is reported.
 - If the version does not exist, the `version %s not supported by component %s` error is reported.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-install.md
+++ b/tiup/tiup-command-install.md
@@ -25,3 +25,4 @@ None
 - If the component does not exist, the `The component "%s" not found` error is reported.
 - If the version does not exist, the `version %s not supported by component %s` error is reported.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-install.md
+++ b/tiup/tiup-command-install.md
@@ -25,4 +25,3 @@ None
 - If the component does not exist, the `The component "%s" not found` error is reported.
 - If the version does not exist, the `version %s not supported by component %s` error is reported.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-list.md
+++ b/tiup/tiup-command-list.md
@@ -43,5 +43,3 @@ tiup list [component] [flags]
 - If `[component]` is set:
     - If the specified component exists: TiUP outputs a version information list of the specified component, consisting of `Version` (version number), `Installed` (installation status), `Release` (release date), and `Platforms` (supported platforms).
     - If the specified component does not exist: TiUP reports the error `failed to fetch component: unknown component`.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-list.md
+++ b/tiup/tiup-command-list.md
@@ -44,4 +44,3 @@ tiup list [component] [flags]
     - If the specified component exists: TiUP outputs a version information list of the specified component, consisting of `Version` (version number), `Installed` (installation status), `Release` (release date), and `Platforms` (supported platforms).
     - If the specified component does not exist: TiUP reports the error `failed to fetch component: unknown component`.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-list.md
+++ b/tiup/tiup-command-list.md
@@ -44,3 +44,4 @@ tiup list [component] [flags]
     - If the specified component exists: TiUP outputs a version information list of the specified component, consisting of `Version` (version number), `Installed` (installation status), `Release` (release date), and `Platforms` (supported platforms).
     - If the specified component does not exist: TiUP reports the error `failed to fetch component: unknown component`.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-mirror-clone.md
+++ b/tiup/tiup-command-mirror-clone.md
@@ -47,5 +47,3 @@ tiup mirror clone <target-dir> [global version] [flags]
 - Specifies the version list of the component to be cloned. Fill component names in `{component}`. You can run [`tiup list --all`](/tiup/tiup-command-list.md) to view available component names.
 - Data type: Strings
 - Default: Null
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-clone.md
+++ b/tiup/tiup-command-mirror-clone.md
@@ -48,3 +48,4 @@ tiup mirror clone <target-dir> [global version] [flags]
 - Data type: Strings
 - Default: Null
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-clone.md
+++ b/tiup/tiup-command-mirror-clone.md
@@ -48,4 +48,3 @@ tiup mirror clone <target-dir> [global version] [flags]
 - Data type: Strings
 - Default: Null
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-genkey.md
+++ b/tiup/tiup-command-mirror-genkey.md
@@ -52,5 +52,3 @@ tiup mirror genkey [flags]
 - If `-p/--public` is specified:
     - If the private key specified in `-n/--name` does not exist: TiUP reports the error `Error: open ${TIUP_HOME}/keys/{name}.json: no such file or directory`.
     - If the private key specified in `-n/--name` exists: TiUP outputs the content of the corresponding public key.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-genkey.md
+++ b/tiup/tiup-command-mirror-genkey.md
@@ -53,3 +53,4 @@ tiup mirror genkey [flags]
     - If the private key specified in `-n/--name` does not exist: TiUP reports the error `Error: open ${TIUP_HOME}/keys/{name}.json: no such file or directory`.
     - If the private key specified in `-n/--name` exists: TiUP outputs the content of the corresponding public key.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-genkey.md
+++ b/tiup/tiup-command-mirror-genkey.md
@@ -53,4 +53,3 @@ tiup mirror genkey [flags]
     - If the private key specified in `-n/--name` does not exist: TiUP reports the error `Error: open ${TIUP_HOME}/keys/{name}.json: no such file or directory`.
     - If the private key specified in `-n/--name` exists: TiUP outputs the content of the corresponding public key.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-grant.md
+++ b/tiup/tiup-command-mirror-grant.md
@@ -41,5 +41,3 @@ tiup mirror grant <id> [flags]
 - If the command is executed successfully, there is no output.
 - If the component owner's ID is duplicated, TiUP reports the error `Error: owner %s exists`.
 - If the key is used by another component owner, TiUP reports the error `Error: key %s exists`.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-grant.md
+++ b/tiup/tiup-command-mirror-grant.md
@@ -42,3 +42,4 @@ tiup mirror grant <id> [flags]
 - If the component owner's ID is duplicated, TiUP reports the error `Error: owner %s exists`.
 - If the key is used by another component owner, TiUP reports the error `Error: key %s exists`.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-grant.md
+++ b/tiup/tiup-command-mirror-grant.md
@@ -42,4 +42,3 @@ tiup mirror grant <id> [flags]
 - If the component owner's ID is duplicated, TiUP reports the error `Error: owner %s exists`.
 - If the key is used by another component owner, TiUP reports the error `Error: key %s exists`.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-init.md
+++ b/tiup/tiup-command-mirror-init.md
@@ -43,5 +43,3 @@ tiup mirror init <path> [flags]
 - If the command is executed successfully, there is no output.
 - If the specified `<path>` is not empty, TiUP reports the error `Error: the target path '%s' is not an empty directory`.
 - If the specified `<path>` is not a directory, TiUP reports the error `Error: fdopendir: not a directory`.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-init.md
+++ b/tiup/tiup-command-mirror-init.md
@@ -44,4 +44,3 @@ tiup mirror init <path> [flags]
 - If the specified `<path>` is not empty, TiUP reports the error `Error: the target path '%s' is not an empty directory`.
 - If the specified `<path>` is not a directory, TiUP reports the error `Error: fdopendir: not a directory`.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-init.md
+++ b/tiup/tiup-command-mirror-init.md
@@ -44,3 +44,4 @@ tiup mirror init <path> [flags]
 - If the specified `<path>` is not empty, TiUP reports the error `Error: the target path '%s' is not an empty directory`.
 - If the specified `<path>` is not a directory, TiUP reports the error `Error: fdopendir: not a directory`.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-merge.md
+++ b/tiup/tiup-command-mirror-merge.md
@@ -29,5 +29,3 @@ None
 
 - If the command is executed successfully, there is no output.
 - If the current mirror does not have a component owner of the target mirror, or if `${TIUP_HOME}/keys` does not have the owner's private key, TiUP reports the `Error: missing owner keys for owner %s on component %s` error.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-merge.md
+++ b/tiup/tiup-command-mirror-merge.md
@@ -30,4 +30,3 @@ None
 - If the command is executed successfully, there is no output.
 - If the current mirror does not have a component owner of the target mirror, or if `${TIUP_HOME}/keys` does not have the owner's private key, TiUP reports the `Error: missing owner keys for owner %s on component %s` error.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-merge.md
+++ b/tiup/tiup-command-mirror-merge.md
@@ -30,3 +30,4 @@ None
 - If the command is executed successfully, there is no output.
 - If the current mirror does not have a component owner of the target mirror, or if `${TIUP_HOME}/keys` does not have the owner's private key, TiUP reports the `Error: missing owner keys for owner %s on component %s` error.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-modify.md
+++ b/tiup/tiup-command-mirror-modify.md
@@ -61,5 +61,3 @@ Marks a specified component or version as unavailable.
 - If the component owner is not authorized to modify the target component:
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-modify.md
+++ b/tiup/tiup-command-mirror-modify.md
@@ -62,4 +62,3 @@ Marks a specified component or version as unavailable.
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-modify.md
+++ b/tiup/tiup-command-mirror-modify.md
@@ -62,3 +62,4 @@ Marks a specified component or version as unavailable.
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-publish.md
+++ b/tiup/tiup-command-mirror-publish.md
@@ -82,5 +82,3 @@ The meaning of each parameter is as follows:
 - If the component owner is not authorized to modify the target component:
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-publish.md
+++ b/tiup/tiup-command-mirror-publish.md
@@ -83,4 +83,3 @@ The meaning of each parameter is as follows:
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-publish.md
+++ b/tiup/tiup-command-mirror-publish.md
@@ -83,3 +83,4 @@ The meaning of each parameter is as follows:
     - If the mirror is a remote mirror, TiUP reports the error `Error: The server refused, make sure you have access to this component`.
     - If the mirror is a local mirror, TiUP reports the error `Error: the signature is not correct`.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-rotate.md
+++ b/tiup/tiup-command-mirror-rotate.md
@@ -59,5 +59,3 @@ For how mirror administrators sign files, refer to the [`sign` command](/tiup/ti
 ## Outputs
 
 The current signature status of each mirror administrator.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-rotate.md
+++ b/tiup/tiup-command-mirror-rotate.md
@@ -60,4 +60,3 @@ For how mirror administrators sign files, refer to the [`sign` command](/tiup/ti
 
 The current signature status of each mirror administrator.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-rotate.md
+++ b/tiup/tiup-command-mirror-rotate.md
@@ -60,3 +60,4 @@ For how mirror administrators sign files, refer to the [`sign` command](/tiup/ti
 
 The current signature status of each mirror administrator.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-set.md
+++ b/tiup/tiup-command-mirror-set.md
@@ -46,5 +46,3 @@ In the steps above, if the mirror is attacked before the `wget` command, you can
 ## Output
 
 None
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-set.md
+++ b/tiup/tiup-command-mirror-set.md
@@ -47,3 +47,4 @@ In the steps above, if the mirror is attacked before the `wget` command, you can
 
 None
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-set.md
+++ b/tiup/tiup-command-mirror-set.md
@@ -47,4 +47,3 @@ In the steps above, if the mirror is attacked before the `wget` command, you can
 
 None
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-sign.md
+++ b/tiup/tiup-command-mirror-sign.md
@@ -46,5 +46,3 @@ If it is a network address, this address must provide the following features:
 - If the command is executed successfully, there is no output.
 - If the file has been signed by the specified key, TiUP reports the error `Error: this manifest file has already been signed by specified key`.
 - If the file is not a valid manifest, TiUP reports the error `Error: unmarshal manifest: %s`.
-
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-sign.md
+++ b/tiup/tiup-command-mirror-sign.md
@@ -47,4 +47,3 @@ If it is a network address, this address must provide the following features:
 - If the file has been signed by the specified key, TiUP reports the error `Error: this manifest file has already been signed by specified key`.
 - If the file is not a valid manifest, TiUP reports the error `Error: unmarshal manifest: %s`.
 
-[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror-sign.md
+++ b/tiup/tiup-command-mirror-sign.md
@@ -47,3 +47,4 @@ If it is a network address, this address must provide the following features:
 - If the file has been signed by the specified key, TiUP reports the error `Error: this manifest file has already been signed by specified key`.
 - If the file is not a valid manifest, TiUP reports the error `Error: unmarshal manifest: %s`.
 
+[<< Back to the previous page - TiUP Mirror command list](/tiup/tiup-command-mirror.md#command-list)

--- a/tiup/tiup-command-mirror.md
+++ b/tiup/tiup-command-mirror.md
@@ -36,5 +36,3 @@ None
 - [rotate](/tiup/tiup-command-mirror-rotate.md): updates the root certificate in the current mirror
 - [clone](/tiup/tiup-command-mirror-clone.md): clones a new mirror from an existing one
 - [merge](/tiup/tiup-command-mirror-merge.md): merges mirrors
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-mirror.md
+++ b/tiup/tiup-command-mirror.md
@@ -37,4 +37,3 @@ None
 - [clone](/tiup/tiup-command-mirror-clone.md): clones a new mirror from an existing one
 - [merge](/tiup/tiup-command-mirror-merge.md): merges mirrors
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-mirror.md
+++ b/tiup/tiup-command-mirror.md
@@ -37,3 +37,4 @@ None
 - [clone](/tiup/tiup-command-mirror-clone.md): clones a new mirror from an existing one
 - [merge](/tiup/tiup-command-mirror-merge.md): merges mirrors
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-status.md
+++ b/tiup/tiup-command-status.md
@@ -52,5 +52,3 @@ A component can run in one of the following statuses:
 > `Pending Offline` in TiUP, `Offline` returned by PD API, and `Leaving` in TiDB Dashboard indicate the same status.
 
 Component status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-status.md
+++ b/tiup/tiup-command-status.md
@@ -53,4 +53,3 @@ A component can run in one of the following statuses:
 
 Component status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-status.md
+++ b/tiup/tiup-command-status.md
@@ -53,3 +53,4 @@ A component can run in one of the following statuses:
 
 Component status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-telemetry.md
+++ b/tiup/tiup-command-telemetry.md
@@ -49,5 +49,3 @@ The `tiup telemetry enable` command is used to enable the telemetry.
 ### disable
 
 The `tiup telemetry disable` command is used to disable the telemetry.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-telemetry.md
+++ b/tiup/tiup-command-telemetry.md
@@ -50,4 +50,3 @@ The `tiup telemetry enable` command is used to enable the telemetry.
 
 The `tiup telemetry disable` command is used to disable the telemetry.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-telemetry.md
+++ b/tiup/tiup-command-telemetry.md
@@ -50,3 +50,4 @@ The `tiup telemetry enable` command is used to enable the telemetry.
 
 The `tiup telemetry disable` command is used to disable the telemetry.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-uninstall.md
+++ b/tiup/tiup-command-uninstall.md
@@ -35,5 +35,3 @@ tiup uninstall <component1>:<version> [component2...N] [flags]
 
 - If the command exits without any error, `Uninstalled component "%s" successfully!` is output.
 - If neither `<version>` nor `--all` is specified, the `Use "tiup uninstall tidbx --all" if you want to remove all versions.` error is reported.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-uninstall.md
+++ b/tiup/tiup-command-uninstall.md
@@ -36,4 +36,3 @@ tiup uninstall <component1>:<version> [component2...N] [flags]
 - If the command exits without any error, `Uninstalled component "%s" successfully!` is output.
 - If neither `<version>` nor `--all` is specified, the `Use "tiup uninstall tidbx --all" if you want to remove all versions.` error is reported.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-uninstall.md
+++ b/tiup/tiup-command-uninstall.md
@@ -36,3 +36,4 @@ tiup uninstall <component1>:<version> [component2...N] [flags]
 - If the command exits without any error, `Uninstalled component "%s" successfully!` is output.
 - If neither `<version>` nor `--all` is specified, the `Use "tiup uninstall tidbx --all" if you want to remove all versions.` error is reported.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-update.md
+++ b/tiup/tiup-command-update.md
@@ -49,5 +49,3 @@ The update operation does not delete the old version. You can still specify usin
 
 - If the update is successful, `Updated successfully!` is output.
 - If target version does not exist, the `Error: version %s not supported by component %s` error is reported.
-
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-update.md
+++ b/tiup/tiup-command-update.md
@@ -50,4 +50,3 @@ The update operation does not delete the old version. You can still specify usin
 - If the update is successful, `Updated successfully!` is output.
 - If target version does not exist, the `Error: version %s not supported by component %s` error is reported.
 
-[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-command-update.md
+++ b/tiup/tiup-command-update.md
@@ -50,3 +50,4 @@ The update operation does not delete the old version. You can still specify usin
 - If the update is successful, `Updated successfully!` is output.
 - If target version does not exist, the `Error: version %s not supported by component %s` error is reported.
 
+[<< Back to the previous page - TiUP Reference command list](/tiup/tiup-reference.md#command-list)

--- a/tiup/tiup-component-cluster-audit-cleanup.md
+++ b/tiup/tiup-component-cluster-audit-cleanup.md
@@ -34,5 +34,3 @@ tiup cluster audit cleanup [flags]
 ```shell
 clean audit log successfully
 ```
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-audit-cleanup.md
+++ b/tiup/tiup-component-cluster-audit-cleanup.md
@@ -35,4 +35,3 @@ tiup cluster audit cleanup [flags]
 clean audit log successfully
 ```
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-audit-cleanup.md
+++ b/tiup/tiup-component-cluster-audit-cleanup.md
@@ -35,3 +35,4 @@ tiup cluster audit cleanup [flags]
 clean audit log successfully
 ```
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-audit.md
+++ b/tiup/tiup-component-cluster-audit.md
@@ -31,5 +31,3 @@ tiup cluster audit [audit-id] [flags]
     - ID: the `audit-id` corresponding to the record
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-audit.md
+++ b/tiup/tiup-component-cluster-audit.md
@@ -32,3 +32,4 @@ tiup cluster audit [audit-id] [flags]
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-audit.md
+++ b/tiup/tiup-component-cluster-audit.md
@@ -32,4 +32,3 @@ tiup cluster audit [audit-id] [flags]
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-check.md
+++ b/tiup/tiup-component-cluster-check.md
@@ -252,5 +252,3 @@ A table containing the following fields:
 - `Check`: the check item
 - `Result`: the check result (Pass, Warn, or Fail)
 - `Message`: the result description
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-check.md
+++ b/tiup/tiup-component-cluster-check.md
@@ -253,4 +253,3 @@ A table containing the following fields:
 - `Result`: the check result (Pass, Warn, or Fail)
 - `Message`: the result description
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-check.md
+++ b/tiup/tiup-component-cluster-check.md
@@ -253,3 +253,4 @@ A table containing the following fields:
 - `Result`: the check result (Pass, Warn, or Fail)
 - `Message`: the result description
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-clean.md
+++ b/tiup/tiup-component-cluster-clean.md
@@ -64,8 +64,6 @@ tiup cluster clean <cluster-name> [flags]
 
 The execution logs of tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-clean.md
+++ b/tiup/tiup-component-cluster-clean.md
@@ -64,6 +64,7 @@ tiup cluster clean <cluster-name> [flags]
 
 The execution logs of tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-clean.md
+++ b/tiup/tiup-component-cluster-clean.md
@@ -64,7 +64,6 @@ tiup cluster clean <cluster-name> [flags]
 
 The execution logs of tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-deploy.md
+++ b/tiup/tiup-component-cluster-deploy.md
@@ -67,8 +67,6 @@ tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]
 
 The deployment log.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [Deploy a TiDB Cluster Using TiUP](/production-deployment-using-tiup.md)

--- a/tiup/tiup-component-cluster-deploy.md
+++ b/tiup/tiup-component-cluster-deploy.md
@@ -67,6 +67,7 @@ tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]
 
 The deployment log.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-deploy.md
+++ b/tiup/tiup-component-cluster-deploy.md
@@ -67,7 +67,6 @@ tiup cluster deploy <cluster-name> <version> <topology.yaml> [flags]
 
 The deployment log.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-destroy.md
+++ b/tiup/tiup-component-cluster-destroy.md
@@ -49,8 +49,6 @@ tiup cluster destroy <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-destroy.md
+++ b/tiup/tiup-component-cluster-destroy.md
@@ -49,7 +49,6 @@ tiup cluster destroy <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-destroy.md
+++ b/tiup/tiup-component-cluster-destroy.md
@@ -49,6 +49,7 @@ tiup cluster destroy <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-disable.md
+++ b/tiup/tiup-component-cluster-disable.md
@@ -46,5 +46,3 @@ tiup cluster disable <cluster-name> [flags]
 ## Output
 
 The execution log of the tiup-cluster.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-disable.md
+++ b/tiup/tiup-component-cluster-disable.md
@@ -47,3 +47,4 @@ tiup cluster disable <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-disable.md
+++ b/tiup/tiup-component-cluster-disable.md
@@ -47,4 +47,3 @@ tiup cluster disable <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-display.md
+++ b/tiup/tiup-component-cluster-display.md
@@ -101,8 +101,6 @@ A node service can run in one of the following statuses:
 
 Node service status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-display.md
+++ b/tiup/tiup-component-cluster-display.md
@@ -101,6 +101,7 @@ A node service can run in one of the following statuses:
 
 Node service status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-display.md
+++ b/tiup/tiup-component-cluster-display.md
@@ -101,7 +101,6 @@ A node service can run in one of the following statuses:
 
 Node service status derives from the PD scheduling information. For more details, see [Information collection](/tidb-scheduling.md#information-collection).
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-edit-config.md
+++ b/tiup/tiup-component-cluster-edit-config.md
@@ -33,8 +33,6 @@ tiup cluster edit-config <cluster-name> [flags]
 - If the command is successfully executed, there is no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error will be reported, reminding you to edit the file again. For the fields that cannot be modified, see the [topology file](/tiup/tiup-cluster-topology-reference.md).
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-edit-config.md
+++ b/tiup/tiup-component-cluster-edit-config.md
@@ -33,6 +33,7 @@ tiup cluster edit-config <cluster-name> [flags]
 - If the command is successfully executed, there is no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error will be reported, reminding you to edit the file again. For the fields that cannot be modified, see the [topology file](/tiup/tiup-cluster-topology-reference.md).
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-edit-config.md
+++ b/tiup/tiup-component-cluster-edit-config.md
@@ -33,7 +33,6 @@ tiup cluster edit-config <cluster-name> [flags]
 - If the command is successfully executed, there is no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error will be reported, reminding you to edit the file again. For the fields that cannot be modified, see the [topology file](/tiup/tiup-cluster-topology-reference.md).
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-enable.md
+++ b/tiup/tiup-component-cluster-enable.md
@@ -50,5 +50,3 @@ tiup cluster enable <cluster-name> [flags]
 ## Output
 
 The execution log of the tiup-cluster.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-enable.md
+++ b/tiup/tiup-component-cluster-enable.md
@@ -51,3 +51,4 @@ tiup cluster enable <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-enable.md
+++ b/tiup/tiup-component-cluster-enable.md
@@ -51,4 +51,3 @@ tiup cluster enable <cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-help.md
+++ b/tiup/tiup-component-cluster-help.md
@@ -24,5 +24,3 @@ tiup cluster help [command] [flags]
 ## Output
 
 The help information of the `[command]` or tiup-cluster.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-help.md
+++ b/tiup/tiup-component-cluster-help.md
@@ -25,4 +25,3 @@ tiup cluster help [command] [flags]
 
 The help information of the `[command]` or tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-help.md
+++ b/tiup/tiup-component-cluster-help.md
@@ -25,3 +25,4 @@ tiup cluster help [command] [flags]
 
 The help information of the `[command]` or tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -67,5 +67,3 @@ tiup cluster import [flags]
 ## Output
 
 Shows the logs of the import process.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -68,3 +68,4 @@ tiup cluster import [flags]
 
 Shows the logs of the import process.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -68,4 +68,3 @@ tiup cluster import [flags]
 
 Shows the logs of the import process.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-list.md
+++ b/tiup/tiup-component-cluster-list.md
@@ -35,8 +35,6 @@ Outputs the table with the following fields:
 - Path: the path of the cluster deployment data on the control machine
 - PrivateKey: the path of the private key that is used to connect the cluster
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-list.md
+++ b/tiup/tiup-component-cluster-list.md
@@ -35,6 +35,7 @@ Outputs the table with the following fields:
 - Path: the path of the cluster deployment data on the control machine
 - PrivateKey: the path of the private key that is used to connect the cluster
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-list.md
+++ b/tiup/tiup-component-cluster-list.md
@@ -35,7 +35,6 @@ Outputs the table with the following fields:
 - Path: the path of the cluster deployment data on the control machine
 - PrivateKey: the path of the private key that is used to connect the cluster
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-meta-backup.md
+++ b/tiup/tiup-component-cluster-meta-backup.md
@@ -30,5 +30,3 @@ Specifies the target directory to store the TiUP meta backup file.
 ## Output
 
 The execution logs of tiup-cluster.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-meta-backup.md
+++ b/tiup/tiup-component-cluster-meta-backup.md
@@ -31,4 +31,3 @@ Specifies the target directory to store the TiUP meta backup file.
 
 The execution logs of tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-meta-backup.md
+++ b/tiup/tiup-component-cluster-meta-backup.md
@@ -31,3 +31,4 @@ Specifies the target directory to store the TiUP meta backup file.
 
 The execution logs of tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-meta-restore.md
+++ b/tiup/tiup-component-cluster-meta-restore.md
@@ -31,5 +31,3 @@ tiup cluster meta restore <cluster-name> <backup-file> [flags]
 ## Output
 
 The execution logs of tiup-cluster.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-meta-restore.md
+++ b/tiup/tiup-component-cluster-meta-restore.md
@@ -32,4 +32,3 @@ tiup cluster meta restore <cluster-name> <backup-file> [flags]
 
 The execution logs of tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-meta-restore.md
+++ b/tiup/tiup-component-cluster-meta-restore.md
@@ -32,3 +32,4 @@ tiup cluster meta restore <cluster-name> <backup-file> [flags]
 
 The execution logs of tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-patch.md
+++ b/tiup/tiup-component-cluster-patch.md
@@ -120,8 +120,6 @@ After you have completed the preceding steps, you can use `/tmp/${component}-hot
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-patch.md
+++ b/tiup/tiup-component-cluster-patch.md
@@ -120,6 +120,7 @@ After you have completed the preceding steps, you can use `/tmp/${component}-hot
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-patch.md
+++ b/tiup/tiup-component-cluster-patch.md
@@ -120,7 +120,6 @@ After you have completed the preceding steps, you can use `/tmp/${component}-hot
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-prune.md
+++ b/tiup/tiup-component-cluster-prune.md
@@ -24,5 +24,3 @@ tiup cluster prune <cluster-name> [flags]
 ## Output
 
 The log of the cleanup process.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-prune.md
+++ b/tiup/tiup-component-cluster-prune.md
@@ -25,4 +25,3 @@ tiup cluster prune <cluster-name> [flags]
 
 The log of the cleanup process.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-prune.md
+++ b/tiup/tiup-component-cluster-prune.md
@@ -25,3 +25,4 @@ tiup cluster prune <cluster-name> [flags]
 
 The log of the cleanup process.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-reload.md
+++ b/tiup/tiup-component-cluster-reload.md
@@ -103,8 +103,6 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-reload.md
+++ b/tiup/tiup-component-cluster-reload.md
@@ -103,6 +103,7 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-reload.md
+++ b/tiup/tiup-component-cluster-reload.md
@@ -103,7 +103,6 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-rename.md
+++ b/tiup/tiup-component-cluster-rename.md
@@ -35,8 +35,6 @@ tiup cluster rename <old-cluster-name> <new-cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-rename.md
+++ b/tiup/tiup-component-cluster-rename.md
@@ -35,7 +35,6 @@ tiup cluster rename <old-cluster-name> <new-cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-rename.md
+++ b/tiup/tiup-component-cluster-rename.md
@@ -35,6 +35,7 @@ tiup cluster rename <old-cluster-name> <new-cluster-name> [flags]
 
 The execution log of the tiup-cluster.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-replay.md
+++ b/tiup/tiup-component-cluster-replay.md
@@ -24,5 +24,3 @@ Prints the help information.
 ## Output
 
 The output of the command corresponding to `<audit-id>`.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-replay.md
+++ b/tiup/tiup-component-cluster-replay.md
@@ -25,3 +25,4 @@ Prints the help information.
 
 The output of the command corresponding to `<audit-id>`.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-replay.md
+++ b/tiup/tiup-component-cluster-replay.md
@@ -25,4 +25,3 @@ Prints the help information.
 
 The output of the command corresponding to `<audit-id>`.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-restart.md
+++ b/tiup/tiup-component-cluster-restart.md
@@ -50,5 +50,3 @@ tiup cluster restart <cluster-name> [flags]
 ## Outputs
 
 The log of the service restart process.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-restart.md
+++ b/tiup/tiup-component-cluster-restart.md
@@ -51,4 +51,3 @@ tiup cluster restart <cluster-name> [flags]
 
 The log of the service restart process.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-restart.md
+++ b/tiup/tiup-component-cluster-restart.md
@@ -51,3 +51,4 @@ tiup cluster restart <cluster-name> [flags]
 
 The log of the service restart process.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-scale-in.md
+++ b/tiup/tiup-component-cluster-scale-in.md
@@ -71,5 +71,3 @@ tiup cluster scale-in <cluster-name> [flags]
 ## Output
 
 Shows the logs of the scaling-in process.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-scale-in.md
+++ b/tiup/tiup-component-cluster-scale-in.md
@@ -72,4 +72,3 @@ tiup cluster scale-in <cluster-name> [flags]
 
 Shows the logs of the scaling-in process.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-scale-in.md
+++ b/tiup/tiup-component-cluster-scale-in.md
@@ -72,3 +72,4 @@ tiup cluster scale-in <cluster-name> [flags]
 
 Shows the logs of the scaling-in process.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-scale-out.md
+++ b/tiup/tiup-component-cluster-scale-out.md
@@ -63,8 +63,6 @@ tiup cluster scale-out <cluster-name> <topology.yaml> [flags]
 
 The log of scaling out.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [Scale a TiDB Cluster Using TiUP](/scale-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-scale-out.md
+++ b/tiup/tiup-component-cluster-scale-out.md
@@ -63,7 +63,6 @@ tiup cluster scale-out <cluster-name> <topology.yaml> [flags]
 
 The log of scaling out.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-scale-out.md
+++ b/tiup/tiup-component-cluster-scale-out.md
@@ -63,6 +63,7 @@ tiup cluster scale-out <cluster-name> <topology.yaml> [flags]
 
 The log of scaling out.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-start.md
+++ b/tiup/tiup-component-cluster-start.md
@@ -56,8 +56,6 @@ Starts the cluster in a safe way. It is recommended to use this option when the 
 
 The log of starting the service.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-start.md
+++ b/tiup/tiup-component-cluster-start.md
@@ -56,6 +56,7 @@ Starts the cluster in a safe way. It is recommended to use this option when the 
 
 The log of starting the service.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-start.md
+++ b/tiup/tiup-component-cluster-start.md
@@ -56,7 +56,6 @@ Starts the cluster in a safe way. It is recommended to use this option when the 
 
 The log of starting the service.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-stop.md
+++ b/tiup/tiup-component-cluster-stop.md
@@ -51,8 +51,6 @@ tiup cluster stop <cluster-name> [flags]
 
 The log of stopping the service.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [TiUP Common Operations](/maintain-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-stop.md
+++ b/tiup/tiup-component-cluster-stop.md
@@ -51,6 +51,7 @@ tiup cluster stop <cluster-name> [flags]
 
 The log of stopping the service.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-stop.md
+++ b/tiup/tiup-component-cluster-stop.md
@@ -51,7 +51,6 @@ tiup cluster stop <cluster-name> [flags]
 
 The log of stopping the service.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-template.md
+++ b/tiup/tiup-component-cluster-template.md
@@ -47,5 +47,3 @@ Prints the help information.
 ## Output
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
-
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-template.md
+++ b/tiup/tiup-component-cluster-template.md
@@ -48,3 +48,4 @@ Prints the help information.
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-template.md
+++ b/tiup/tiup-component-cluster-template.md
@@ -48,4 +48,3 @@ Prints the help information.
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -146,8 +146,6 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 The log of the upgrading progress.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
-
 ## See also
 
 - [Upgrade TiDB Using TiUP](/upgrade-tidb-using-tiup.md)

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -146,6 +146,7 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 The log of the upgrading progress.
 
+[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -146,7 +146,6 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 The log of the upgrading progress.
 
-[<< Back to the previous page - TiUP Cluster command list](/tiup/tiup-component-cluster.md#command-list)
 
 ## See also
 

--- a/tiup/tiup-component-cluster.md
+++ b/tiup/tiup-component-cluster.md
@@ -86,5 +86,3 @@ tiup cluster [command] [flags]
 - [meta backup](/tiup/tiup-component-cluster-meta-backup.md): backs up the TiUP meta file required for the operation and maintenance of a specified cluster
 - [meta restore](/tiup/tiup-component-cluster-meta-restore.md): restores the TiUP meta file of a specified cluster
 - [help](/tiup/tiup-component-cluster-help.md): prints the help information
-
-[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)

--- a/tiup/tiup-component-cluster.md
+++ b/tiup/tiup-component-cluster.md
@@ -87,3 +87,4 @@ tiup cluster [command] [flags]
 - [meta restore](/tiup/tiup-component-cluster-meta-restore.md): restores the TiUP meta file of a specified cluster
 - [help](/tiup/tiup-component-cluster-help.md): prints the help information
 
+[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)

--- a/tiup/tiup-component-cluster.md
+++ b/tiup/tiup-component-cluster.md
@@ -87,4 +87,3 @@ tiup cluster [command] [flags]
 - [meta restore](/tiup/tiup-component-cluster-meta-restore.md): restores the TiUP meta file of a specified cluster
 - [help](/tiup/tiup-component-cluster-help.md): prints the help information
 
-[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)

--- a/tiup/tiup-component-dm-audit.md
+++ b/tiup/tiup-component-dm-audit.md
@@ -31,5 +31,3 @@ tiup dm audit [audit-id] [flags]
     - ID: the `audit-id` corresponding to this record
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-audit.md
+++ b/tiup/tiup-component-dm-audit.md
@@ -32,3 +32,4 @@ tiup dm audit [audit-id] [flags]
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-audit.md
+++ b/tiup/tiup-component-dm-audit.md
@@ -32,4 +32,3 @@ tiup dm audit [audit-id] [flags]
     - Time: the execution time of the command corresponding to the record
     - Command: the command corresponding to the record
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-deploy.md
+++ b/tiup/tiup-component-dm-deploy.md
@@ -46,5 +46,3 @@ tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]
 ## Output
 
 The deployment log.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-deploy.md
+++ b/tiup/tiup-component-dm-deploy.md
@@ -47,4 +47,3 @@ tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]
 
 The deployment log.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-deploy.md
+++ b/tiup/tiup-component-dm-deploy.md
@@ -47,3 +47,4 @@ tiup dm deploy <cluster-name> <version> <topology.yaml> [flags]
 
 The deployment log.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-destroy.md
+++ b/tiup/tiup-component-dm-destroy.md
@@ -30,5 +30,3 @@ tiup dm destroy <cluster-name> [flags]
 ## Output
 
 The execution log of the tiup-dm.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-destroy.md
+++ b/tiup/tiup-component-dm-destroy.md
@@ -31,4 +31,3 @@ tiup dm destroy <cluster-name> [flags]
 
 The execution log of the tiup-dm.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-destroy.md
+++ b/tiup/tiup-component-dm-destroy.md
@@ -31,3 +31,4 @@ tiup dm destroy <cluster-name> [flags]
 
 The execution log of the tiup-dm.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-disable.md
+++ b/tiup/tiup-component-dm-disable.md
@@ -44,5 +44,3 @@ Prints the help information.
 ## Output
 
 The execution log of the tiup-dm.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-disable.md
+++ b/tiup/tiup-component-dm-disable.md
@@ -45,4 +45,3 @@ Prints the help information.
 
 The execution log of the tiup-dm.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-disable.md
+++ b/tiup/tiup-component-dm-disable.md
@@ -45,3 +45,4 @@ Prints the help information.
 
 The execution log of the tiup-dm.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-display.md
+++ b/tiup/tiup-component-dm-display.md
@@ -57,5 +57,3 @@ tiup dm display <cluster-name> [flags]
     - `Status`: the current status of the services on the node.
     - `Data Dir`: the data directory of the service. `-` means that there is no data directory.
     - `Deploy Dir`: the deployment directory of the service.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-display.md
+++ b/tiup/tiup-component-dm-display.md
@@ -58,4 +58,3 @@ tiup dm display <cluster-name> [flags]
     - `Data Dir`: the data directory of the service. `-` means that there is no data directory.
     - `Deploy Dir`: the deployment directory of the service.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-display.md
+++ b/tiup/tiup-component-dm-display.md
@@ -58,3 +58,4 @@ tiup dm display <cluster-name> [flags]
     - `Data Dir`: the data directory of the service. `-` means that there is no data directory.
     - `Deploy Dir`: the deployment directory of the service.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-edit-config.md
+++ b/tiup/tiup-component-dm-edit-config.md
@@ -32,5 +32,3 @@ tiup dm edit-config <cluster-name> [flags]
 
 - Normally, no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error is reported, reminding you to edit the file again. For the fields that cannot be modified, see [the topology file](/tiup/tiup-dm-topology-reference.md).
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-edit-config.md
+++ b/tiup/tiup-component-dm-edit-config.md
@@ -33,3 +33,4 @@ tiup dm edit-config <cluster-name> [flags]
 - Normally, no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error is reported, reminding you to edit the file again. For the fields that cannot be modified, see [the topology file](/tiup/tiup-dm-topology-reference.md).
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-edit-config.md
+++ b/tiup/tiup-component-dm-edit-config.md
@@ -33,4 +33,3 @@ tiup dm edit-config <cluster-name> [flags]
 - Normally, no output.
 - If you have mistakenly modified the fields that cannot be modified, when you save the file, an error is reported, reminding you to edit the file again. For the fields that cannot be modified, see [the topology file](/tiup/tiup-dm-topology-reference.md).
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-enable.md
+++ b/tiup/tiup-component-dm-enable.md
@@ -44,5 +44,3 @@ Prints the help information.
 ## Output
 
 the execution log of tiup-dm.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-enable.md
+++ b/tiup/tiup-component-dm-enable.md
@@ -45,3 +45,4 @@ Prints the help information.
 
 the execution log of tiup-dm.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-enable.md
+++ b/tiup/tiup-component-dm-enable.md
@@ -45,4 +45,3 @@ Prints the help information.
 
 the execution log of tiup-dm.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-help.md
+++ b/tiup/tiup-component-dm-help.md
@@ -24,5 +24,3 @@ tiup dm help [command] [flags]
 ## Output
 
 The help information of `[command]` or `tiup-dm`.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-help.md
+++ b/tiup/tiup-component-dm-help.md
@@ -25,4 +25,3 @@ tiup dm help [command] [flags]
 
 The help information of `[command]` or `tiup-dm`.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-help.md
+++ b/tiup/tiup-component-dm-help.md
@@ -25,3 +25,4 @@ tiup dm help [command] [flags]
 
 The help information of `[command]` or `tiup-dm`.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-import.md
+++ b/tiup/tiup-component-dm-import.md
@@ -65,5 +65,3 @@ tiup dm import [flags]
 ## Outputs
 
 The log of the importing process.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-import.md
+++ b/tiup/tiup-component-dm-import.md
@@ -66,4 +66,3 @@ tiup dm import [flags]
 
 The log of the importing process.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-import.md
+++ b/tiup/tiup-component-dm-import.md
@@ -66,3 +66,4 @@ tiup dm import [flags]
 
 The log of the importing process.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-list.md
+++ b/tiup/tiup-component-dm-list.md
@@ -34,5 +34,3 @@ A table consisting of the following fields:
 - `Version`: the cluster version.
 - `Path`: the path of the cluster deployment data on the control machine.
 - `PrivateKey`: the path of the private key to the cluster.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-list.md
+++ b/tiup/tiup-component-dm-list.md
@@ -35,3 +35,4 @@ A table consisting of the following fields:
 - `Path`: the path of the cluster deployment data on the control machine.
 - `PrivateKey`: the path of the private key to the cluster.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-list.md
+++ b/tiup/tiup-component-dm-list.md
@@ -35,4 +35,3 @@ A table consisting of the following fields:
 - `Path`: the path of the cluster deployment data on the control machine.
 - `PrivateKey`: the path of the private key to the cluster.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-patch.md
+++ b/tiup/tiup-component-dm-patch.md
@@ -200,5 +200,3 @@ Go Version: go version go1.16.4 linux/amd64
     172.16.100.21:9090  prometheus           172.16.100.21  9090       linux/x86_64  Up         /home/tidb/dm/data/prometheus-9090    /home/tidb/dm/deploy/prometheus-9090
     Total nodes: 5
     ```
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-patch.md
+++ b/tiup/tiup-component-dm-patch.md
@@ -201,3 +201,4 @@ Go Version: go version go1.16.4 linux/amd64
     Total nodes: 5
     ```
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-patch.md
+++ b/tiup/tiup-component-dm-patch.md
@@ -201,4 +201,3 @@ Go Version: go version go1.16.4 linux/amd64
     Total nodes: 5
     ```
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-prune.md
+++ b/tiup/tiup-component-dm-prune.md
@@ -24,5 +24,3 @@ tiup dm prune <cluster-name> [flags]
 ## Output
 
 The log of the cleanup process.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-prune.md
+++ b/tiup/tiup-component-dm-prune.md
@@ -25,4 +25,3 @@ tiup dm prune <cluster-name> [flags]
 
 The log of the cleanup process.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-prune.md
+++ b/tiup/tiup-component-dm-prune.md
@@ -25,3 +25,4 @@ tiup dm prune <cluster-name> [flags]
 
 The log of the cleanup process.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-reload.md
+++ b/tiup/tiup-component-dm-reload.md
@@ -60,5 +60,3 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 ## Output
 
 The execution log of the tiup-dm.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-reload.md
+++ b/tiup/tiup-component-dm-reload.md
@@ -61,3 +61,4 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 
 The execution log of the tiup-dm.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-reload.md
+++ b/tiup/tiup-component-dm-reload.md
@@ -61,4 +61,3 @@ After you specify the `--skip-restart` option, it only refreshes the configurati
 
 The execution log of the tiup-dm.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-replay.md
+++ b/tiup/tiup-component-dm-replay.md
@@ -24,5 +24,3 @@ Prints the help information.
 ## Output
 
 The output of the command corresponding to `<audit-id>`.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-replay.md
+++ b/tiup/tiup-component-dm-replay.md
@@ -25,4 +25,3 @@ Prints the help information.
 
 The output of the command corresponding to `<audit-id>`.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-replay.md
+++ b/tiup/tiup-component-dm-replay.md
@@ -25,3 +25,4 @@ Prints the help information.
 
 The output of the command corresponding to `<audit-id>`.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-restart.md
+++ b/tiup/tiup-component-dm-restart.md
@@ -50,5 +50,3 @@ tiup dm restart <cluster-name> [flags]
 ## Outputs
 
 The log of the service restart process.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-restart.md
+++ b/tiup/tiup-component-dm-restart.md
@@ -51,4 +51,3 @@ tiup dm restart <cluster-name> [flags]
 
 The log of the service restart process.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-restart.md
+++ b/tiup/tiup-component-dm-restart.md
@@ -51,3 +51,4 @@ tiup dm restart <cluster-name> [flags]
 
 The log of the service restart process.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-in.md
+++ b/tiup/tiup-component-dm-scale-in.md
@@ -38,5 +38,3 @@ tiup dm scale-in <cluster-name> [flags]
 ## Output
 
 The log of scaling in.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-in.md
+++ b/tiup/tiup-component-dm-scale-in.md
@@ -39,4 +39,3 @@ tiup dm scale-in <cluster-name> [flags]
 
 The log of scaling in.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-in.md
+++ b/tiup/tiup-component-dm-scale-in.md
@@ -39,3 +39,4 @@ tiup dm scale-in <cluster-name> [flags]
 
 The log of scaling in.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-out.md
+++ b/tiup/tiup-component-dm-scale-out.md
@@ -46,5 +46,3 @@ tiup dm scale-out <cluster-name> <topology.yaml> [flags]
 ## Output
 
 The log of scaling out.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-out.md
+++ b/tiup/tiup-component-dm-scale-out.md
@@ -47,3 +47,4 @@ tiup dm scale-out <cluster-name> <topology.yaml> [flags]
 
 The log of scaling out.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-scale-out.md
+++ b/tiup/tiup-component-dm-scale-out.md
@@ -47,4 +47,3 @@ tiup dm scale-out <cluster-name> <topology.yaml> [flags]
 
 The log of scaling out.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-start.md
+++ b/tiup/tiup-component-dm-start.md
@@ -46,5 +46,3 @@ tiup dm start <cluster-name> [flags]
 ## Output
 
 The log of starting the service.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-start.md
+++ b/tiup/tiup-component-dm-start.md
@@ -47,3 +47,4 @@ tiup dm start <cluster-name> [flags]
 
 The log of starting the service.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-start.md
+++ b/tiup/tiup-component-dm-start.md
@@ -47,4 +47,3 @@ tiup dm start <cluster-name> [flags]
 
 The log of starting the service.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-stop.md
+++ b/tiup/tiup-component-dm-stop.md
@@ -50,5 +50,3 @@ tiup dm stop <cluster-name> [flags]
 ## Output
 
 The log of stopping the service.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-stop.md
+++ b/tiup/tiup-component-dm-stop.md
@@ -51,4 +51,3 @@ tiup dm stop <cluster-name> [flags]
 
 The log of stopping the service.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-stop.md
+++ b/tiup/tiup-component-dm-stop.md
@@ -51,3 +51,4 @@ tiup dm stop <cluster-name> [flags]
 
 The log of stopping the service.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-template.md
+++ b/tiup/tiup-component-dm-template.md
@@ -35,5 +35,3 @@ Prints the help information.
 ## Output
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-template.md
+++ b/tiup/tiup-component-dm-template.md
@@ -36,3 +36,4 @@ Prints the help information.
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-template.md
+++ b/tiup/tiup-component-dm-template.md
@@ -36,4 +36,3 @@ Prints the help information.
 
 Outputs the topology template according to the specified options, which can be redirected to the topology file for deployment.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-upgrade.md
+++ b/tiup/tiup-component-dm-upgrade.md
@@ -31,5 +31,3 @@ tiup dm upgrade <cluster-name> <version> [flags]
 ## Output
 
 Log of the service upgrade process.
-
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-upgrade.md
+++ b/tiup/tiup-component-dm-upgrade.md
@@ -32,4 +32,3 @@ tiup dm upgrade <cluster-name> <version> [flags]
 
 Log of the service upgrade process.
 
-[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm-upgrade.md
+++ b/tiup/tiup-component-dm-upgrade.md
@@ -32,3 +32,4 @@ tiup dm upgrade <cluster-name> <version> [flags]
 
 Log of the service upgrade process.
 
+[<< Back to the previous page - TiUP DM command list](/tiup/tiup-component-dm.md#command-list)

--- a/tiup/tiup-component-dm.md
+++ b/tiup/tiup-component-dm.md
@@ -82,5 +82,3 @@ tiup dm [command] [flags]
 - [enable](/tiup/tiup-component-dm-enable.md): Enables the auto-enabling of the cluster service after a machine is restarted.
 - [disable](/tiup/tiup-component-dm-disable.md): Disables the auto-enabling of the cluster service after a machine is restarted.
 - [help](/tiup/tiup-component-dm-help.md): Prints help information.
-
-[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)

--- a/tiup/tiup-component-dm.md
+++ b/tiup/tiup-component-dm.md
@@ -83,4 +83,3 @@ tiup dm [command] [flags]
 - [disable](/tiup/tiup-component-dm-disable.md): Disables the auto-enabling of the cluster service after a machine is restarted.
 - [help](/tiup/tiup-component-dm-help.md): Prints help information.
 
-[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)

--- a/tiup/tiup-component-dm.md
+++ b/tiup/tiup-component-dm.md
@@ -83,3 +83,4 @@ tiup dm [command] [flags]
 - [disable](/tiup/tiup-component-dm-disable.md): Disables the auto-enabling of the cluster service after a machine is restarted.
 - [help](/tiup/tiup-component-dm-help.md): Prints help information.
 
+[<< Back to the previous page - TiUP Reference component list](/tiup/tiup-reference.md#component-list)


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

As in the title, this PR removes the "Back to the previous page" links in TiUP docs, as these links were added in the context that TiUP command docs were not included in TiDB TOC file. As all these TiUP command docs are now presented in TiDB TOC files, these manual links are not needed. 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
