### PR TITLE
v6.5: add aliases for stale benchmark docs

### DIFF
--- a/benchmark/benchmark-sysbench-v6.2.0-vs-v6.1.0.md
+++ b/benchmark/benchmark-sysbench-v6.2.0-vs-v6.1.0.md
@@ -1,5 +1,6 @@
 ---
 title: TiDB Sysbench Performance Test Report -- v6.2.0 vs. v6.1.0
+aliases: ['/tidb/dev/benchmark-sysbench-v6.2.0-vs-v6.1.0/','/tidb/stable/benchmark-sysbench-v6.2.0-vs-v6.1.0/']
 ---
 
 # TiDB Sysbench Performance Test Report -- v6.2.0 vs. v6.1.0

--- a/benchmark/v6.2-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v6.2-performance-benchmarking-with-tpcc.md
@@ -1,5 +1,6 @@
 ---
 title: TiDB TPC-C Performance Test Report -- v6.2.0 vs. v6.1.0
+aliases: ['/tidb/dev/v6.2-performance-benchmarking-with-tpcc/','/tidb/stable/v6.2-performance-benchmarking-with-tpcc/']
 ---
 
 # TiDB TPC-C Performance Test Report -- v6.2.0 vs. v6.1.0

--- a/benchmark/v6.2-performance-benchmarking-with-tpch.md
+++ b/benchmark/v6.2-performance-benchmarking-with-tpch.md
@@ -1,5 +1,6 @@
 ---
 title: Performance Comparison between TiFlash and Greenplum/Spark
+aliases: ['/tidb/dev/v6.2-performance-benchmarking-with-tpch/','/tidb/stable/v6.2-performance-benchmarking-with-tpch/']
 ---
 
 # Performance Comparison between TiFlash and Greenplum/Spark


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR adds aliases for the following stale benchmark docs removed in https://github.com/pingcap/docs/pull/20462.

- ./benchmark/benchmark-sysbench-v6.2.0-vs-v6.1.0.md
- ./benchmark/v6.2-performance-benchmarking-with-tpcc.md
- ./benchmark/v6.2-performance-benchmarking-with-tpch.md

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/website-docs/issues/599

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
