### PR TITLE
ticdc: clarify event filter matcher behavior for DB-level DDLs

### DIFF
--- a/ticdc/ticdc-filter.md
+++ b/ticdc/ticdc-filter.md
@@ -55,6 +55,22 @@ ignore-update-new-value-expr = "gender = 'male' and age > 18" # Ignore update DM
 Description of configuration parameters:
 
 - `matcher`: the database and table that this event filter rule applies to. The syntax is the same as [table filter](/table-filter.md).
+
+    > **Note:**
+    >
+    > `matcher` matches the database name, so you need to pay extra attention when configuring it. For example, when the `event-filters` configuration is as follows:
+    >
+    > ```toml
+    > [filter]
+    > [[filter.event-filters]]
+    > matcher = ["test.t1"]
+    > ignore-sql = ["^drop"]
+    > ```
+    >
+    > `ignore-sql = ["^drop"]` not only filters out `DROP TABLE test.t1` but also filters out `DROP DATABASE test`, because `matcher` contains the database name `test`.
+    >
+    > If you only want to filter out the specified table instead of the entire database, modify the `ignore-sql` value to `["drop table"]`.
+
 - `ignore-event`: the event type to be ignored. This parameter accepts an array of strings. You can configure multiple event types. Currently, the following event types are supported:
 
     | Event           | Type | Alias | Description         |


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

This PR adds a note to the TiCDC event filter documentation to clarify how the `matcher` parameter works with database-level DDLs.

When a `matcher` is configured (e.g., `matcher = ["test.t1"]`), it matches against the database name (`test`) as well. This can cause a broad rule like `ignore-sql = ["^drop"]` to unexpectedly filter `DROP DATABASE test` in addition to `DROP TABLE test.t1`.

This change adds an explicit note explaining this behavior and recommends using a more precise filter, such as `ignore-sql = ["drop table"]`, if the goal is to only ignore DDLs for the specific table.

This clarification helps prevent users from unintentionally filtering important database-level DDLs when they only mean to filter table-level events. It improves the predictability and safety of the event filter feature.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/20815
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
