### PR TITLE
tiflash: Add warnings about LOCATION LABELS on ALTER TABLE ... SET TIFLASH REPLICA

### DIFF
--- a/tiflash/create-tiflash-replicas.md
+++ b/tiflash/create-tiflash-replicas.md
@@ -233,47 +233,49 @@ When configuring replicas, if you need to distribute TiFlash replicas to multipl
 
     Note that the `flash.proxy.labels` configuration in earlier versions cannot handle special characters in the available zone name correctly. It is recommended to use the `server.labels` in `learner_config` to configure the name of an available zone.
 
-2. After starting a cluster, specify the labels when creating replicas.
+2. After starting a cluster, specify the number of TiFlash replicas that meet high availability requirements when creating replicas. The syntax is as follows:
 
     ```sql
-    ALTER TABLE table_name SET TIFLASH REPLICA count LOCATION LABELS location_labels;
+    ALTER TABLE table_name SET TIFLASH REPLICA count;
     ```
 
     For example:
 
     ```sql
-    ALTER TABLE t SET TIFLASH REPLICA 2 LOCATION LABELS "zone";
+    ALTER TABLE t SET TIFLASH REPLICA 2;
     ```
 
-3. PD schedules the replicas based on the labels. In this example, PD respectively schedules two replicas of the table `t` to two available zones. You can use pd-ctl to view the scheduling.
+3. PD schedules the replicas of table `t` to different availability zones based on the `server.labels` in the TiFlash node's `learner_config` and the table's replica count `count`, ensuring availability. For details, see [Schedule Replicas by Topology Labels](/schedule-replicas-by-topology-labels.md). You can use the following SQL statement to verify the distribution of a table's Regions across TiFlash nodes:
 
-    ```shell
-    > tiup ctl:v<CLUSTER_VERSION> pd -u http://<PD_ADDRESS>:2379 store
-
-        ...
-        "address": "172.16.5.82:23913",
-        "labels": [
-          { "key": "engine", "value": "tiflash"},
-          { "key": "zone", "value": "z1" }
-        ],
-        "region_count": 4,
-
-        ...
-        "address": "172.16.5.81:23913",
-        "labels": [
-          { "key": "engine", "value": "tiflash"},
-          { "key": "zone", "value": "z1" }
-        ],
-        "region_count": 5,
-        ...
-
-        "address": "172.16.5.85:23913",
-        "labels": [
-          { "key": "engine", "value": "tiflash"},
-          { "key": "zone", "value": "z2" }
-        ],
-        "region_count": 9,
-        ...
+    ```SQL
+    -- Non-partitioned table
+    SELECT table_id, p.store_id, address, COUNT(p.region_id) 
+    FROM
+      information_schema.tikv_region_status r,
+      information_schema.tikv_region_peers p,
+      information_schema.tikv_store_status s
+    WHERE
+      r.db_name = 'test' 
+      AND r.table_name = 'table_to_check'
+      AND r.region_id = p.region_id 
+      AND p.store_id = s.store_id
+      AND JSON_EXTRACT(s.label, '$[0].value') = 'tiflash'
+    GROUP BY table_id, p.store_id, address;
+    -- Partitioned table
+    SELECT table_id, r.partition_name, p.store_id, address, COUNT(p.region_id)
+    FROM
+      information_schema.tikv_region_status r,
+      information_schema.tikv_region_peers p,
+      information_schema.tikv_store_status s
+    WHERE 
+      r.db_name = 'test' 
+      AND r.table_name = 'table_to_check' 
+      AND r.partition_name LIKE 'p202312%'
+      AND r.region_id = p.region_id 
+      AND p.store_id = s.store_id
+      AND JSON_EXTRACT(s.label, '$[0].value') = 'tiflash'
+    GROUP BY table_id, r.partition_name, p.store_id, address
+    ORDER BY table_id, r.partition_name, p.store_id;
     ```
 
 <CustomContent platform="tidb">
@@ -283,3 +285,7 @@ For more information about scheduling replicas by using labels, see [Schedule Re
 TiFlash supports configuring the replica selection strategy for different zones. For more information, see [`tiflash_replica_read`](/system-variables.md#tiflash_replica_read-new-in-v730).
 
 </CustomContent>
+
+> **Note:**
+>
+> In the syntax `ALTER TABLE table_name SET TIFLASH REPLICA count LOCATION LABELS location_labels;`, if `location_labels` contains multiple labels, it cannot be correctly parsed and used to set Placement Rules. Therefore, it is not recommended to use `LOCATION LABELS` to configure TiFlash replicas.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

According to the discussion with @JmPotato , the current implementation of `LOCATION LABELS` is not correct and may acts does not meet the user want. Fixing the behavior requires manpower, and there is currently no plan or demand from users. So just add warnings about it.

For example, if the user set `LOCATION LABELS` with the similar string as placement-rule-in-SQL does: https://docs.pingcap.com/zh/tidb/stable/placement-rules-in-sql/#%E6%8C%87%E5%AE%9A%E7%94%9F%E5%AD%98%E5%81%8F%E5%A5%BD

```
alter table t set tiflash replica 2 LOCATION LABELS "[region, zone, host]"
```

then the generated placement-rule in PD is

```JSON
  {
    "group_id": "tiflash",
    ...
    "start_key": "748000000000055fff795f720000000000fa",
    "end_key": "748000000000055fff7a00000000000000f8",
    "role": "learner",
    "count": 2,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": ["tiflash"]
      }
    ],
    "location_labels": [
      "[region, zone, host]"
    ],
  }
```

but not

```JSON
  {
    "group_id": "tiflash",
    ...
    "start_key": "748000000000055fff795f720000000000fa",
    "end_key": "748000000000055fff7a00000000000000f8",
    "role": "learner",
    "count": 2,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": ["tiflash"]
      }
    ],
    "location_labels": [
      "region",
      "zone",
      "host"
    ],
  }
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
