### PR TITLE
Hibernate: recommend `MySQLDialect` over `TiDBDialect`

### DIFF
--- a/develop/dev-guide-sample-application-java-hibernate.md
+++ b/develop/dev-guide-sample-application-java-hibernate.md
@@ -284,7 +284,7 @@ After this variable is enabled, TiDB accepts requests that specify `SERIALIZABLE
 
 ### `CHECK` constraints
 
-Hibernate's [`@Check`](https://docs.hibernate.org/orm/6.5/javadocs/org/hibernate/annotations/Check.html) annotation generates DDL `CHECK` constraints. [MySQL 8.0.16+](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html) enforces these constraints by default, but TiDB does not enforce them unless explicitly enabled.
+Hibernate's [`@Check`](https://docs.hibernate.org/orm/6.5/javadocs/org/hibernate/annotations/Check.html) annotation generates DDL `CHECK` constraints. [MySQL 8.0.16 and later verions](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html) enforces these constraints by default, but TiDB does not enforce them unless explicitly enabled.
 
 To enable `CHECK` constraint enforcement in TiDB, set the following system variable:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Closes pingcap/docs#21618

This PR updates the Hibernate documentation to recommend `MySQLDialect` over `TiDBDialect`.

**Background:** Starting with Hibernate 7.x, `TiDBDialect` was moved from hibernate-core to hibernate-community-dialects ([HHH-19361](https://hibernate.atlassian.net/browse/HHH-19361)). Since PingCAP has no current maintenance plan for the community dialect, and TiDB is highly MySQL-compatible, using `MySQLDialect` is the recommended approach for long-term compatibility.

**Changes:**
- Update dialect recommendation from `org.hibernate.dialect.TiDBDialect` to `org.hibernate.dialect.MySQLDialect`
- Add reference to `org.hibernate.community.dialect.TiDBDialect` in Hibernate community dialects for users who need it
- Add guidance for reporting compatibility issues if users encounter any

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - [HHH-19361: Move TiDBDialect to community dialects](https://hibernate.atlassian.net/browse/HHH-19361)
  - [Hibernate community dialects](https://github.com/hibernate/hibernate-orm/tree/main/hibernate-community-dialects)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
