### PR TITLE
tiup-playground: add default login credentials for TiDB Dashboard and Grafana

### DIFF
--- a/tiup/tiup-playground.md
+++ b/tiup/tiup-playground.md
@@ -92,7 +92,7 @@ For a cluster started in this way, the data files are retained after the cluster
 
 ## Access TiDB Dashboard and Grafana
 
-When you start a TiDB cluster using TiUP playground, you can access the TiDB Dashboard and Grafana by the following websites:
+When you start a TiDB cluster using TiUP playground, you can access [TiDB Dashboard](/dashboard/dashboard-intro.md) and Grafana at the following addresses in your browser:
 
 - TiDB Dashboard: `http://127.0.0.1:2379/dashboard`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Add a new section "Access TiDB Dashboard and Grafana" in `tiup/tiup-playground.md`
- Document default login credentials for TiDB Dashboard (username: `root`, password: empty)
- Document default login credentials for Grafana (username: `admin`, password: `admin`)
- Add a note about using updated root password if changed

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (English version)
- Other reference link(s):
  - Closes #21768

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch