### PR TITLE
docs: document column-level privileges (v8.5)

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -627,7 +627,7 @@
   - Privileges
     - [Security Compatibility with MySQL](/security-compatibility-with-mysql.md)
     - [Privilege Management](/privilege-management.md)
-    - [Column Privilege Management](/column-privilege-management.md)
+    - [Column-Level Privilege Management](/column-privilege-management.md)
     - [User Account Management](/user-account-management.md)
     - [TiDB Password Management](/password-management.md)
     - [Role-Based Access Control](/role-based-access-control.md)

--- a/TOC.md
+++ b/TOC.md
@@ -627,6 +627,7 @@
   - Privileges
     - [Security Compatibility with MySQL](/security-compatibility-with-mysql.md)
     - [Privilege Management](/privilege-management.md)
+    - [Column Privilege Management](/column-privilege-management.md)
     - [User Account Management](/user-account-management.md)
     - [TiDB Password Management](/password-management.md)
     - [Role-Based Access Control](/role-based-access-control.md)

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -1,0 +1,169 @@
+```markdown
+title: Column-Level Privilege Management
+summary: TiDB supports a MySQL-compatible column-level privilege management mechanism, allowing you to grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, thus achieving finer-grained access control.
+---
+
+# Column-Level Privilege Management
+
+Starting from version v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. With column-level privileges, you can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table, achieving finer-grained data access control.
+
+> **Note:**
+>
+> Although MySQL syntax allows column-level specification like `REFERENCES(col_name)`, `REFERENCES` itself is a database/table-level privilege used for foreign key-related permission checks. Therefore, column-level `REFERENCES` does not actually take effect in MySQL. TiDB's behavior is consistent with MySQL.
+
+## Syntax
+
+Granting and revoking column-level privileges are similar to table-level privileges, with the following differences:
+
+- The column name list is placed after the **privilege type**, not after the **table name**.
+- Multiple column names are separated by commas (`,`).
+
+```sql
+GRANT priv_type(col_name [, col_name] ...) [, priv_type(col_name [, col_name] ...)] ...
+    ON db_name.tbl_name
+    TO 'user'@'host';
+
+REVOKE priv_type(col_name [, col_name] ...) [, priv_type(col_name [, col_name] ...)] ...
+    ON db_name.tbl_name
+    FROM 'user'@'host';
+```
+
+Where:
+
+* `priv_type` supports `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES`.
+* The `ON` clause requires specifying the specific table, for example, `test.tbl`.
+* A single `GRANT` or `REVOKE` statement can include multiple privilege items, and each privilege item can specify its own list of column names.
+
+For example, the following statement grants `SELECT` privileges on `col1` and `col2` and `UPDATE` privilege on `col3` to the user:
+
+```sql
+GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'user'@'host';
+```
+
+## Granting Column-Level Privileges
+
+The following example grants the `SELECT` privilege on `col1` and `col2` of table `test.tbl` to user `newuser`, and grants the `UPDATE` privilege on `col3` to the same user:
+
+```sql
+CREATE DATABASE IF NOT EXISTS test;
+USE test;
+
+DROP TABLE IF EXISTS tbl;
+CREATE TABLE tbl (col1 INT, col2 INT, col3 INT);
+
+DROP USER IF EXISTS 'newuser'@'%';
+CREATE USER 'newuser'@'%';
+
+GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'newuser'@'%';
+SHOW GRANTS FOR 'newuser'@'%';
+```
+
+```
++---------------------------------------------------------------------+
+| Grants for newuser@%                                                |
++---------------------------------------------------------------------+
+| GRANT USAGE ON *.* TO 'newuser'@'%'                                 |
+| GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'newuser'@'%' |
++---------------------------------------------------------------------+
+```
+
+In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying [`INFORMATION_SCHEMA.COLUMN_PRIVILEGES`](/information-schema/information-schema-columns.md).
+
+## Revoking Column-Level Privileges
+
+The following example revokes the `SELECT` privilege on column `col2` from user `newuser`:
+
+```sql
+REVOKE SELECT(col2) ON test.tbl FROM 'newuser'@'%';
+SHOW GRANTS FOR 'newuser'@'%';
+```
+
+```
++---------------------------------------------------------------+
+| Grants for newuser@%                                          |
++---------------------------------------------------------------+
+| GRANT USAGE ON *.* TO 'newuser'@'%'                           |
+| GRANT SELECT(col1), UPDATE(col3) ON test.tbl TO 'newuser'@'%' |
++---------------------------------------------------------------+
+```
+
+## Column-Level Privilege Access Control Example
+
+After granting or revoking column-level privileges, TiDB performs privilege checks on columns referenced in SQL statements. For example:
+
+* `SELECT` statements: `SELECT` column privileges affect columns referenced in the `SELECT` list as well as `WHERE`, `ORDER BY`, and other clauses.
+* `UPDATE` statements: Columns being updated in the `SET` clause require `UPDATE` column privileges. Columns read in expressions or conditions usually also require `SELECT` column privileges.
+* `INSERT` statements: Columns being written to require `INSERT` column privileges. `INSERT INTO t VALUES (...)` is equivalent to writing to all columns.
+
+In the following example, user `newuser` can only query `col1` and update `col3`:
+
+```sql
+-- Execute as newuser
+SELECT col1 FROM tbl;
+SELECT * FROM tbl; -- Error (missing SELECT column privilege for col2, col3)
+
+UPDATE tbl SET col3 = 1;
+UPDATE tbl SET col1 = 2; -- Error (missing UPDATE column privilege for col1)
+
+UPDATE tbl SET col3 = col1;
+UPDATE tbl SET col3 = col3 + 1; -- Error (missing SELECT column privilege for col3)
+UPDATE tbl SET col3 = col1 WHERE col1 > 0;
+```
+
+## Compatibility Differences with MySQL
+
+TiDB's column-level privileges are generally compatible with MySQL. However, there are differences in the following scenarios:
+| Scenario                                             | TiDB                                                                                                                                                                   | MySQL                                                                                                                                                                            |
+| :--------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Revoking column-level privileges not granted to a user | `REVOKE` executes successfully.                                                                                                                                        | `REVOKE` throws an error.                                                                                                                                                        |
+| Execution order of column pruning and `SELECT` privilege check | `SELECT` column privileges are checked first, then column pruning is performed. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` requires `SELECT` column privileges for both `t.a` and `t.b`. | Column pruning is performed first, then `SELECT` column privileges are checked. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` only requires `SELECT` column privilege for `t.a`. |
+
+### Column Pruning and Privilege Checks in View Scenarios
+
+When performing `SELECT` privilege checks on views, MySQL first prunes columns in the view's internal query and then checks the column privileges of the internal tables, making the checks relatively lenient in some scenarios. TiDB does not perform column pruning before privilege checks, so additional column privileges might be required.
+
+```sql
+-- Prepare the environment by logging in as root
+DROP USER IF EXISTS 'u'@'%';
+CREATE USER 'u'@'%';
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (a INT, b INT, c INT, d INT);
+
+DROP VIEW IF EXISTS v;
+CREATE SQL SECURITY INVOKER VIEW v AS SELECT a, b FROM t WHERE c = 0 ORDER BY d;
+
+GRANT SELECT ON v TO 'u'@'%';
+
+-- Log in as u
+SELECT a FROM v;
+-- MySQL: Error, missing access privileges for t.a, t.c, t.d
+-- TiDB: Error, missing access privileges for t.a, t.b, t.c, t.d
+
+-- Log in as root
+GRANT SELECT(a, c, d) ON t TO 'u'@'%';
+
+-- Log in as u
+SELECT a FROM v;
+-- MySQL: Success (internal query is pruned to `SELECT a FROM t WHERE c = 0 ORDER BY d`)
+-- TiDB: Error, missing access privileges for t.b
+
+SELECT * FROM v;
+-- MySQL: Error, missing access privileges for t.b
+-- TiDB: Error, missing access privileges for t.b
+
+-- Log in as root
+GRANT SELECT(b) ON t TO 'u'@'%';
+
+-- Log in as u
+SELECT * FROM v;
+-- MySQL: Success
+-- TiDB: Success
+```
+
+## See Also
+
+* [Privilege Management](/privilege-management.md)
+* [`GRANT <privileges>`](/sql-statements/sql-statement-grant-privileges.md)
+* [`REVOKE <privileges>`](/sql-statements/sql-statement-revoke-privileges.md)
+```

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -1,21 +1,21 @@
 ---
 title: Column-Level Privilege Management
-summary: TiDB supports a MySQL-compatible column-level privilege management mechanism, enabling you to grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, thus achieving finer-grained access control.
+summary: TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, achieving finer-grained access control.
 ---
 
 # Column-Level Privilege Management
 
-Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. With column-level privileges, you can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table, achieving finer-grained data access control.
+Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. With column-level privileges, you can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns in a specified table, achieving finer-grained data access control.
 
 > **Note:**
 >
-> Although MySQL syntax allows column-level specification like `REFERENCES(col_name)`, `REFERENCES` itself is a database/table-level privilege used for foreign key-related permission checks. Therefore, column-level `REFERENCES` does not actually take effect in MySQL. TiDB's behavior is consistent with MySQL.
+> Although MySQL syntax allows column-level syntax such as `REFERENCES(col_name)`, `REFERENCES` itself is a database-level or table-level privilege used for foreign key-related privilege checks. Therefore, column-level `REFERENCES` does not produce any actual column-level privilege effect in MySQL. TiDB's behavior is consistent with MySQL.
 
 ## Syntax
 
-Granting and revoking column-level privileges are similar to table-level privileges, with the following differences:
+The syntax for granting and revoking column-level privileges is similar to that for table-level privileges, with the following differences:
 
-- The column name list is placed after the **privilege type**, not after the **table name**.
+- Write the column name list after the **privilege type**, not after the **table name**.
 - Multiple column names are separated by commas (`,`).
 
 ```sql
@@ -31,7 +31,7 @@ REVOKE priv_type(col_name [, col_name] ...) [, priv_type(col_name [, col_name] .
 Where:
 
 * `priv_type` supports `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES`.
-* The `ON` clause requires specifying the specific table, for example, `test.tbl`.
+* The `ON` clause must specify a table, for example, `test.tbl`.
 * A single `GRANT` or `REVOKE` statement can include multiple privilege items, and each privilege item can specify its own list of column names.
 
 For example, the following statement grants `SELECT` privileges on `col1` and `col2` and `UPDATE` privilege on `col3` to the user:
@@ -40,9 +40,9 @@ For example, the following statement grants `SELECT` privileges on `col1` and `c
 GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'user'@'host';
 ```
 
-## Grant column-level privileges
+## Grant column-level privilege example
 
-The following example grants the `SELECT` privilege on `col1` and `col2` of table `test.tbl` to user `newuser`, and grants the `UPDATE` privilege on `col3` to the same user:
+The following example grants user `newuser` the `SELECT` privilege on `col1` and `col2` in table `test.tbl`, and grants the same user the `UPDATE` privilege on `col3`:
 
 ```sql
 CREATE DATABASE IF NOT EXISTS test;
@@ -69,7 +69,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 
 In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying `INFORMATION_SCHEMA.COLUMN_PRIVILEGES`.
 
-## Revoke column-level privileges
+## Revoke column-level privilege example
 
 The following example revokes the `SELECT` privilege on column `col2` from user `newuser`:
 
@@ -93,7 +93,7 @@ After granting or revoking column-level privileges, TiDB performs privilege chec
 
 * `SELECT` statements: `SELECT` column privileges affect columns referenced in the `SELECT` list as well as `WHERE`, `ORDER BY`, and other clauses.
 * `UPDATE` statements: columns being updated in the `SET` clause require `UPDATE` column privileges. Columns read in expressions or conditions usually also require `SELECT` column privileges.
-* `INSERT` statements: columns being written to require `INSERT` column privileges. `INSERT INTO t VALUES (...)` is equivalent to writing to all columns.
+* `INSERT` statements: columns being written to require `INSERT` column privileges. `INSERT INTO t VALUES (...)` is equivalent to writing values to all columns in table definition order.
 
 In the following example, user `newuser` can only query `col1` and update `col3`:
 
@@ -116,8 +116,8 @@ TiDB's column-level privileges are generally compatible with MySQL. However, the
 
 | Scenario                                             | TiDB                                                                                                                                                                   | MySQL                                                                                                                                                                            |
 | :--------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Revoking column-level privileges not granted to a user | `REVOKE` executes successfully.                                                                                                                                        | `REVOKE` throws an error.                                                                                                                                                        |
-| Execution order of column pruning and `SELECT` privilege check | `SELECT` column privileges are checked first, then column pruning is performed. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` requires `SELECT` column privileges for both `t.a` and `t.b`. | Column pruning is performed first, then `SELECT` column privileges are checked. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` only requires `SELECT` column privilege for `t.a`. |
+| Revoking column-level privileges not granted to a user | `REVOKE` executes successfully. | When `IF EXISTS` is not used, `REVOKE` returns an error. |
+| Execution order of column pruning and `SELECT` privilege check | `SELECT` column privileges are checked before column pruning. For example, executing `SELECT a FROM (SELECT a, b FROM t) s` requires `SELECT` column privileges on both `t.a` and `t.b`. | Column pruning is performed before `SELECT` column privileges are checked. For example, executing `SELECT a FROM (SELECT a, b FROM t) s` only requires the `SELECT` column privilege on `t.a`. |
 
 ### Column pruning and privilege checks in view scenarios
 

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -1,4 +1,4 @@
-```markdown
+``
 title: Column-Level Privilege Management
 summary: TiDB supports a MySQL-compatible column-level privilege management mechanism, allowing you to grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, thus achieving finer-grained access control.
 ---
@@ -40,7 +40,7 @@ For example, the following statement grants `SELECT` privileges on `col1` and `c
 GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'user'@'host';
 ```
 
-## Granting Column-Level Privileges
+## Grant column-level privileges
 
 The following example grants the `SELECT` privilege on `col1` and `col2` of table `test.tbl` to user `newuser`, and grants the `UPDATE` privilege on `col3` to the same user:
 
@@ -69,7 +69,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 
 In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying [`INFORMATION_SCHEMA.COLUMN_PRIVILEGES`](/information-schema/information-schema-columns.md).
 
-## Revoking Column-Level Privileges
+## Revoke column-level privileges
 
 The following example revokes the `SELECT` privilege on column `col2` from user `newuser`:
 
@@ -87,7 +87,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 +---------------------------------------------------------------+
 ```
 
-## Column-Level Privilege Access Control Example
+## Column-level privilege access control example
 
 After granting or revoking column-level privileges, TiDB performs privilege checks on columns referenced in SQL statements. For example:
 
@@ -110,7 +110,7 @@ UPDATE tbl SET col3 = col3 + 1; -- Error (missing SELECT column privilege for co
 UPDATE tbl SET col3 = col1 WHERE col1 > 0;
 ```
 
-## Compatibility Differences with MySQL
+## Compatibility differences with MySQL
 
 TiDB's column-level privileges are generally compatible with MySQL. However, there are differences in the following scenarios:
 | Scenario                                             | TiDB                                                                                                                                                                   | MySQL                                                                                                                                                                            |
@@ -118,7 +118,7 @@ TiDB's column-level privileges are generally compatible with MySQL. However, the
 | Revoking column-level privileges not granted to a user | `REVOKE` executes successfully.                                                                                                                                        | `REVOKE` throws an error.                                                                                                                                                        |
 | Execution order of column pruning and `SELECT` privilege check | `SELECT` column privileges are checked first, then column pruning is performed. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` requires `SELECT` column privileges for both `t.a` and `t.b`. | Column pruning is performed first, then `SELECT` column privileges are checked. For example: executing `SELECT a FROM (SELECT a, b FROM t) s` only requires `SELECT` column privilege for `t.a`. |
 
-### Column Pruning and Privilege Checks in View Scenarios
+### Column pruning and privilege checks in view scenarios
 
 When performing `SELECT` privilege checks on views, MySQL first prunes columns in the view's internal query and then checks the column privileges of the internal tables, making the checks relatively lenient in some scenarios. TiDB does not perform column pruning before privilege checks, so additional column privileges might be required.
 
@@ -161,7 +161,7 @@ SELECT * FROM v;
 -- TiDB: Success
 ```
 
-## See Also
+## See also
 
 * [Privilege Management](/privilege-management.md)
 * [`GRANT <privileges>`](/sql-statements/sql-statement-grant-privileges.md)

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -1,11 +1,11 @@
-``
+---
 title: Column-Level Privilege Management
-summary: TiDB supports a MySQL-compatible column-level privilege management mechanism, allowing you to grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, thus achieving finer-grained access control.
+summary: TiDB supports a MySQL-compatible column-level privilege management mechanism, enabling you to grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table using `GRANT` or `REVOKE`, thus achieving finer-grained access control.
 ---
 
 # Column-Level Privilege Management
 
-Starting from version v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. With column-level privileges, you can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table, achieving finer-grained data access control.
+Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. With column-level privileges, you can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns of a table, achieving finer-grained data access control.
 
 > **Note:**
 >
@@ -92,8 +92,8 @@ SHOW GRANTS FOR 'newuser'@'%';
 After granting or revoking column-level privileges, TiDB performs privilege checks on columns referenced in SQL statements. For example:
 
 * `SELECT` statements: `SELECT` column privileges affect columns referenced in the `SELECT` list as well as `WHERE`, `ORDER BY`, and other clauses.
-* `UPDATE` statements: Columns being updated in the `SET` clause require `UPDATE` column privileges. Columns read in expressions or conditions usually also require `SELECT` column privileges.
-* `INSERT` statements: Columns being written to require `INSERT` column privileges. `INSERT INTO t VALUES (...)` is equivalent to writing to all columns.
+* `UPDATE` statements: columns being updated in the `SET` clause require `UPDATE` column privileges. Columns read in expressions or conditions usually also require `SELECT` column privileges.
+* `INSERT` statements: columns being written to require `INSERT` column privileges. `INSERT INTO t VALUES (...)` is equivalent to writing to all columns.
 
 In the following example, user `newuser` can only query `col1` and update `col3`:
 
@@ -113,6 +113,7 @@ UPDATE tbl SET col3 = col1 WHERE col1 > 0;
 ## Compatibility differences with MySQL
 
 TiDB's column-level privileges are generally compatible with MySQL. However, there are differences in the following scenarios:
+
 | Scenario                                             | TiDB                                                                                                                                                                   | MySQL                                                                                                                                                                            |
 | :--------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Revoking column-level privileges not granted to a user | `REVOKE` executes successfully.                                                                                                                                        | `REVOKE` throws an error.                                                                                                                                                        |
@@ -120,7 +121,10 @@ TiDB's column-level privileges are generally compatible with MySQL. However, the
 
 ### Column pruning and privilege checks in view scenarios
 
-When performing `SELECT` privilege checks on views, MySQL first prunes columns in the view's internal query and then checks the column privileges of the internal tables, making the checks relatively lenient in some scenarios. TiDB does not perform column pruning before privilege checks, so additional column privileges might be required.
+When performing `SELECT` privilege checks on views, MySQL and TiDB differ as follows:
+
+- MySQL first prunes columns in the view's internal query and then checks the column privileges of the internal tables, making the checks relatively lenient in some scenarios. 
+- TiDB does not perform column pruning before privilege checks, so additional column privileges might be required.
 
 ```sql
 -- Prepare the environment by logging in as root

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -170,4 +170,3 @@ SELECT * FROM v;
 * [Privilege Management](/privilege-management.md)
 * [`GRANT <privileges>`](/sql-statements/sql-statement-grant-privileges.md)
 * [`REVOKE <privileges>`](/sql-statements/sql-statement-revoke-privileges.md)
-```

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -40,7 +40,7 @@ For example, the following statement grants `SELECT` privileges on `col1` and `c
 GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'user'@'host';
 ```
 
-## Example: Granting column-level privileges
+## Example: Grant column-level privileges
 
 The following example grants user `newuser` the `SELECT` privilege on `col1` and `col2` in table `test.tbl`, and grants the same user the `UPDATE` privilege on `col3`:
 

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -67,7 +67,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 +---------------------------------------------------------------------+
 ```
 
-In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying [`INFORMATION_SCHEMA.COLUMN_PRIVILEGES`](/information-schema/information-schema-columns.md).
+In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying `INFORMATION_SCHEMA.COLUMN_PRIVILEGES`.
 
 ## Revoke column-level privileges
 

--- a/column-privilege-management.md
+++ b/column-privilege-management.md
@@ -40,7 +40,7 @@ For example, the following statement grants `SELECT` privileges on `col1` and `c
 GRANT SELECT(col1, col2), UPDATE(col3) ON test.tbl TO 'user'@'host';
 ```
 
-## Grant column-level privilege example
+## Example: Granting column-level privileges
 
 The following example grants user `newuser` the `SELECT` privilege on `col1` and `col2` in table `test.tbl`, and grants the same user the `UPDATE` privilege on `col3`:
 
@@ -69,7 +69,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 
 In addition to using `SHOW GRANTS`, you can also view column-level privilege information by querying `INFORMATION_SCHEMA.COLUMN_PRIVILEGES`.
 
-## Revoke column-level privilege example
+## Example: Revoke column-level privileges
 
 The following example revokes the `SELECT` privilege on column `col2` from user `newuser`:
 
@@ -87,7 +87,7 @@ SHOW GRANTS FOR 'newuser'@'%';
 +---------------------------------------------------------------+
 ```
 
-## Column-level privilege access control example
+## Example: Column-level privilege access control
 
 After granting or revoking column-level privileges, TiDB performs privilege checks on columns referenced in SQL statements. For example:
 

--- a/information-schema/information-schema.md
+++ b/information-schema/information-schema.md
@@ -20,7 +20,7 @@ Many `INFORMATION_SCHEMA` tables have a corresponding `SHOW` statement. The bene
 | [`COLLATIONS`](/information-schema/information-schema-collations.md)                    | Provides a list of collations that the server supports. |
 | [`COLLATION_CHARACTER_SET_APPLICABILITY`](/information-schema/information-schema-collation-character-set-applicability.md) | Explains which collations apply to which character sets. |
 | [`COLUMNS`](/information-schema/information-schema-columns.md)                          | Provides a list of columns for all tables. |
-| `COLUMN_PRIVILEGES`                                                                     | Not implemented by TiDB. Returns zero rows. |
+| `COLUMN_PRIVILEGES`                                                                     | Summarizes the information about column privileges visible to the current user. |
 | `COLUMN_STATISTICS`                                                                     | Not implemented by TiDB. Returns zero rows. |
 | [`ENGINES`](/information-schema/information-schema-engines.md)                          | Provides a list of supported storage engines. |
 | `EVENTS`                                                                                | Not implemented by TiDB. Returns zero rows. |
@@ -38,14 +38,14 @@ Many `INFORMATION_SCHEMA` tables have a corresponding `SHOW` statement. The bene
 | `REFERENTIAL_CONSTRAINTS`                                                               | Provides information on `FOREIGN KEY` constraints. |
 | `ROUTINES`                                                                              | Not implemented by TiDB. Returns zero rows. |
 | [`SCHEMATA`](/information-schema/information-schema-schemata.md)                        | Provides similar information to `SHOW DATABASES`. |
-| `SCHEMA_PRIVILEGES`                                                                     | Not implemented by TiDB. Returns zero rows. |
+| `SCHEMA_PRIVILEGES`                                                                     | Summarizes the database privileges visible to the current user. |
 | `SESSION_STATUS`                                                                        | Not implemented by TiDB. Returns zero rows. |
 | [`SESSION_VARIABLES`](/information-schema/information-schema-session-variables.md)      | Provides similar functionality to the command `SHOW SESSION VARIABLES` |
 | [`STATISTICS`](/information-schema/information-schema-statistics.md)                    | Provides information on table indexes. |
 | [`TABLES`](/information-schema/information-schema-tables.md)                            | Provides a list of tables that the current user has visibility of. Similar to `SHOW TABLES`. |
 | `TABLESPACES`                                                                           | Not implemented by TiDB. Returns zero rows. |
 | [`TABLE_CONSTRAINTS`](/information-schema/information-schema-table-constraints.md)      | Provides information on primary keys, unique indexes and foreign keys. |
-| `TABLE_PRIVILEGES`                                                                      | Not implemented by TiDB. Returns zero rows. |
+| `TABLE_PRIVILEGES`                                                                      | Summarizes the table privileges visible to the current user. |
 | `TRIGGERS`                                                                              | Not implemented by TiDB. Returns zero rows. |
 | [`USER_ATTRIBUTES`](/information-schema/information-schema-user-attributes.md) | Summarizes information about user comments and user attributes. |
 | [`USER_PRIVILEGES`](/information-schema/information-schema-user-privileges.md)          | Summarizes the privileges associated with the current user. |

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -51,11 +51,10 @@ You can try out TiDB features on [TiDB Playground](https://play.tidbcloud.com/?u
     > Currently, only {{{ .starter }}} and {{{ .essential }}} clusters in certain AWS regions support [`FULLTEXT` syntax and indexes](https://docs.pingcap.com/tidbcloud/vector-search-full-text-search-sql). TiDB Self-Managed and TiDB Cloud Dedicated support parsing the `FULLTEXT` syntax but do not support using the `FULLTEXT` indexes.
 
 + `SPATIAL` (also known as `GIS`/`GEOMETRY`) functions, data types and indexes [#6347](https://github.com/pingcap/tidb/issues/6347)
-+ Character sets other than `ascii`, `latin1`, `binary`, `utf8`, `utf8mb4`, and `gbk`.
++ Character sets other than `ascii`, `latin1`, `binary`, `utf8`, `utf8mb4`, `gbk`, and `gb18030`.
 + Optimizer trace
 + XML Functions
 + X-Protocol [#1109](https://github.com/pingcap/tidb/issues/1109)
-+ Column-level privileges [#9766](https://github.com/pingcap/tidb/issues/9766)
 + `XA` syntax (TiDB uses a two-phase commit internally, but this is not exposed via an SQL interface)
 + `CREATE TABLE tblName AS SELECT stmt` syntax [#4754](https://github.com/pingcap/tidb/issues/4754)
 + `CHECK TABLE` syntax [#4673](https://github.com/pingcap/tidb/issues/4673)

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -51,7 +51,7 @@ You can try out TiDB features on [TiDB Playground](https://play.tidbcloud.com/?u
     > Currently, only {{{ .starter }}} and {{{ .essential }}} clusters in certain AWS regions support [`FULLTEXT` syntax and indexes](https://docs.pingcap.com/tidbcloud/vector-search-full-text-search-sql). TiDB Self-Managed and TiDB Cloud Dedicated support parsing the `FULLTEXT` syntax but do not support using the `FULLTEXT` indexes.
 
 + `SPATIAL` (also known as `GIS`/`GEOMETRY`) functions, data types and indexes [#6347](https://github.com/pingcap/tidb/issues/6347)
-+ Character sets other than `ascii`, `latin1`, `binary`, `utf8`, `utf8mb4`, `gbk`, and `gb18030`.
++ Character sets other than `ascii`, `latin1`, `binary`, `utf8`, `utf8mb4`, and `gbk`.
 + Optimizer trace
 + XML Functions
 + X-Protocol [#1109](https://github.com/pingcap/tidb/issues/1109)

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -29,6 +29,7 @@ Use the following statement to grant the `xxx` user all privileges on all databa
 ```sql
 GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
 ```
+From v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges for specific columns at the table level. For more information, see [Column Privilege Management](/column-privilege-management.md).
 
 By default, [`GRANT`](/sql-statements/sql-statement-grant-privileges.md) statements will return an error if the user specified does not exist. This behavior depends on if the [SQL mode](/system-variables.md#sql_mode) `NO_AUTO_CREATE_USER` is specified:
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -29,7 +29,7 @@ Use the following statement to grant the `xxx` user all privileges on all databa
 ```sql
 GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
 ```
-From v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges for specific columns at the table level. For more information, see [Column Privilege Management](/column-privilege-management.md).
+Starting from v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges for specific columns at the table level. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 
 By default, [`GRANT`](/sql-statements/sql-statement-grant-privileges.md) statements will return an error if the user specified does not exist. This behavior depends on if the [SQL mode](/system-variables.md#sql_mode) `NO_AUTO_CREATE_USER` is specified:
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -508,7 +508,7 @@ The following [`mysql` system tables](/mysql-schema/mysql-schema.md) are special
 - `mysql.user` (user account, global privilege)
 - `mysql.db` (database-level privilege)
 - `mysql.tables_priv` (table-level privilege)
-- `mysql.columns_priv` (column-level privilege; not currently supported)
+- `mysql.columns_priv` (column-level privilege; supported starting from v8.5.6)
 
 These tables contain the effective range and privilege information of the data. For example, in the `mysql.user` table:
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -30,7 +30,7 @@ Use the following statement to grant the `xxx` user all privileges on all databa
 GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
 ```
 
-Starting from v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges for specific columns at the table level. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
+Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns in a specified table. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 
 By default, [`GRANT`](/sql-statements/sql-statement-grant-privileges.md) statements will return an error if the user specified does not exist. This behavior depends on if the [SQL mode](/system-variables.md#sql_mode) `NO_AUTO_CREATE_USER` is specified:
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -29,6 +29,7 @@ Use the following statement to grant the `xxx` user all privileges on all databa
 ```sql
 GRANT ALL PRIVILEGES ON *.* TO 'xxx'@'%';
 ```
+
 Starting from v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges for specific columns at the table level. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 
 By default, [`GRANT`](/sql-statements/sql-statement-grant-privileges.md) statements will return an error if the user specified does not exist. This behavior depends on if the [SQL mode](/system-variables.md#sql_mode) `NO_AUTO_CREATE_USER` is specified:

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -82,7 +82,7 @@ mysql> SHOW GRANTS FOR 'newuser';
 ## MySQL compatibility
 
 * Similar to MySQL, the `USAGE` privilege denotes the ability to log into a TiDB server.
-* Column level privileges are not currently supported.
+* Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns at the table level. For more information, see [Column-level privilege management](/column-privilege-management.md).
 * Similar to MySQL, when the `NO_AUTO_CREATE_USER` sql mode is not present, the `GRANT` statement will automatically create a new user with an empty password when a user does not exist. Removing this sql-mode (it is enabled by default) presents a security risk.
 * In TiDB, after the `GRANT <privileges>` statement is executed successfully, the execution result takes effect immediately on the current connection. Whereas [in MySQL, for some privileges, the execution results take effect only on subsequent connections](https://dev.mysql.com/doc/refman/8.0/en/privilege-changes.html). See [TiDB #39356](https://github.com/pingcap/tidb/issues/39356) for details.
 

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -82,7 +82,7 @@ mysql> SHOW GRANTS FOR 'newuser';
 ## MySQL compatibility
 
 * Similar to MySQL, the `USAGE` privilege denotes the ability to log into a TiDB server.
-* Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns at the table level. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
+* Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns in a specified table. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 * Similar to MySQL, when the `NO_AUTO_CREATE_USER` sql mode is not present, the `GRANT` statement will automatically create a new user with an empty password when a user does not exist. Removing this sql-mode (it is enabled by default) presents a security risk.
 * In TiDB, after the `GRANT <privileges>` statement is executed successfully, the execution result takes effect immediately on the current connection. Whereas [in MySQL, for some privileges, the execution results take effect only on subsequent connections](https://dev.mysql.com/doc/refman/8.0/en/privilege-changes.html). See [TiDB #39356](https://github.com/pingcap/tidb/issues/39356) for details.
 

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -82,7 +82,7 @@ mysql> SHOW GRANTS FOR 'newuser';
 ## MySQL compatibility
 
 * Similar to MySQL, the `USAGE` privilege denotes the ability to log into a TiDB server.
-* Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns at the table level. For more information, see [Column-level privilege management](/column-privilege-management.md).
+* Starting from v8.5.6, TiDB supports a MySQL-compatible column-level privilege management mechanism. You can grant or revoke `SELECT`, `INSERT`, `UPDATE`, and `REFERENCES` privileges on specific columns at the table level. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 * Similar to MySQL, when the `NO_AUTO_CREATE_USER` sql mode is not present, the `GRANT` statement will automatically create a new user with an empty password when a user does not exist. Removing this sql-mode (it is enabled by default) presents a security risk.
 * In TiDB, after the `GRANT <privileges>` statement is executed successfully, the execution result takes effect immediately on the current connection. Whereas [in MySQL, for some privileges, the execution results take effect only on subsequent connections](https://dev.mysql.com/doc/refman/8.0/en/privilege-changes.html). See [TiDB #39356](https://github.com/pingcap/tidb/issues/39356) for details.
 

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -6,6 +6,7 @@ summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
 # `REVOKE <privileges>`
 
 This statement removes privileges from an existing user. Executing this statement requires the `GRANT OPTION` privilege and all privileges you revoke.
+
 Starting from v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can specify a list of column names in `REVOKE`, for example `REVOKE SELECT(col2) ON test.tbl FROM 'user'@'host';`. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 
 ## Synopsis

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -6,6 +6,7 @@ summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
 # `REVOKE <privileges>`
 
 This statement removes privileges from an existing user. Executing this statement requires the `GRANT OPTION` privilege and all privileges you revoke.
+Starting from TiDB v8.5.6 and subsequent 8.5.x versions, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can specify a list of column names in `REVOKE`, for example `REVOKE SELECT(col2) ON test.tbl FROM 'user'@'host';`. For more information, see [Column Privilege Management](/column-privilege-management.md).
 
 ## Synopsis
 

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -6,7 +6,7 @@ summary: An overview of the usage of REVOKE <privileges> for the TiDB database.
 # `REVOKE <privileges>`
 
 This statement removes privileges from an existing user. Executing this statement requires the `GRANT OPTION` privilege and all privileges you revoke.
-Starting from TiDB v8.5.6 and subsequent 8.5.x versions, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can specify a list of column names in `REVOKE`, for example `REVOKE SELECT(col2) ON test.tbl FROM 'user'@'host';`. For more information, see [Column Privilege Management](/column-privilege-management.md).
+Starting from v8.5.6, TiDB supports the MySQL-compatible column-level privilege management mechanism. You can specify a list of column names in `REVOKE`, for example `REVOKE SELECT(col2) ON test.tbl FROM 'user'@'host';`. For more information, see [Column-Level Privilege Management](/column-privilege-management.md).
 
 ## Synopsis
 

--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,1 @@
+This is a test file.

--- a/temp.md
+++ b/temp.md
@@ -1,1 +1,0 @@
-This is a test file.


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

- Add a Chinese user doc for TiDB column-level privileges (`column-privilege-management.md`).
- Update `TOC.md` and `privilege-management.md` to link the new doc.
- Update `GRANT <privileges>` / `REVOKE <privileges>` docs and `mysql-compatibility.md` to reflect column-level privilege support in TiDB v8.5.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from:https://github.com/pingcap/docs-cn/pull/21437
- Other reference link(s):
  - pingcap/tidb branch: `release-8.5-20250606-v8.5.2` (column privilege implementation; commits after `4f65dffdd6480fc1c36c61fe7cd655f163bc9d41`).

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

