### PR TITLE
cloud/dm: add LOCK TABLES to source privilege prerequisites

### DIFF
--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -438,7 +438,7 @@ For production workloads, it is recommended to have a dedicated user for data du
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
-| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances where FTWRL is available. |
+| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted. In this case, DM falls back to `LOCK TABLES` to ensure consistency during full data export. Not required for self-managed MySQL instances where FTWRL is available. |
 
 For example, you can use the following `GRANT` statement in your source MySQL instance to grant corresponding privileges:
 
@@ -446,7 +446,7 @@ For example, you can use the following `GRANT` statement in your source MySQL in
 -- For self-managed MySQL:
 GRANT SELECT, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
 
--- For managed MySQL (Amazon RDS, Aurora, etc.), also grant LOCK TABLES:
+-- For managed MySQL services (such as Amazon RDS and Aurora), also grant the LOCK TABLES privilege:
 GRANT SELECT, RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
 ```
 

--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -438,7 +438,7 @@ For production workloads, it is recommended to have a dedicated user for data du
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
-| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances. |
+| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances where FTWRL is available. |
 
 For example, you can use the following `GRANT` statement in your source MySQL instance to grant corresponding privileges:
 

--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -438,7 +438,7 @@ For production workloads, it is recommended to have a dedicated user for data du
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
-| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances where FTWRL is available. |
+| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances where FTWRL is available. |
 
 For example, you can use the following `GRANT` statement in your source MySQL instance to grant corresponding privileges:
 

--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -436,13 +436,17 @@ For production workloads, it is recommended to have a dedicated user for data du
 |:----------|:------|:--------|
 | `SELECT` | Tables | Allows reading data from all tables |
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
-| `LOCK TABLES` | Tables | Required for table-level locking during full data export |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
+| `LOCK TABLES` | Tables | Required when the source is a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted. In this case, DM falls back to `LOCK TABLES` for consistency during full data export. Not required for self-managed MySQL instances. |
 
 For example, you can use the following `GRANT` statement in your source MySQL instance to grant corresponding privileges:
 
 ```sql
+-- For self-managed MySQL:
+GRANT SELECT, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
+
+-- For managed MySQL (Amazon RDS, Aurora, etc.), also grant LOCK TABLES:
 GRANT SELECT, RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
 ```
 

--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -436,7 +436,7 @@ For production workloads, it is recommended to have a dedicated user for data du
 |:----------|:------|:--------|
 | `SELECT` | Tables | Allows reading data from all tables |
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
-| `LOCK TABLES` | Tables | Required for consistent full data export (`consistency=flush`) |
+| `LOCK TABLES` | Tables | Required for table-level locking during full data export |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
 

--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -436,13 +436,14 @@ For production workloads, it is recommended to have a dedicated user for data du
 |:----------|:------|:--------|
 | `SELECT` | Tables | Allows reading data from all tables |
 | `RELOAD` | Global | Ensures consistent snapshots during full dump |
+| `LOCK TABLES` | Tables | Required for consistent full data export (`consistency=flush`) |
 | `REPLICATION SLAVE` | Global | Enables binlog streaming for incremental data migration |
 | `REPLICATION CLIENT` | Global | Provides access to binlog position and server status |
 
 For example, you can use the following `GRANT` statement in your source MySQL instance to grant corresponding privileges:
 
 ```sql
-GRANT SELECT, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
+GRANT SELECT, RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dm_source_user'@'%';
 ```
 
 #### Grant required privileges in the target TiDB Cloud cluster

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,11 +96,13 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
+The full data export fails because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted by the cloud provider. In this scenario, DM uses the default `consistency=auto` mode, which falls back to `LOCK TABLES` to ensure data consistency during full export. This operation requires the `LOCK TABLES` privilege.
 
-> **Note:** This error can also occur on self-managed MySQL instances if FTWRL is unavailable for other reasons (for example, missing `RELOAD` privilege).
+> **Note:** 
+>
+> This error can also occur on self-managed MySQL instances if FTWRL is unavailable for other reasons, such as a missing `RELOAD` privilege.
 
-To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
+To resolve this issue, grant the `LOCK TABLES` privilege to the migration user on the source MySQL database:
 
 ```sql
 GRANT LOCK TABLES ON *.* TO 'dm_source_user'@'%';

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -94,6 +94,18 @@ Failed to create a schema in the downstream TiDB cluster. This error means that 
 
 To resolve this issue, you can create a schema in the TiDB cluster based on a [supported collation](/character-set-and-collation.md#character-sets-and-collations-supported-by-tidb), and then resume the task by clicking **Restart**.
 
+### Error message: "LOCK TABLES ... Access denied"
+
+The full data export failed because the source database user does not have the `LOCK TABLES` privilege. Cloud DM uses `consistency=flush` for full data migration, which requires this privilege to ensure a consistent snapshot.
+
+To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
+
+```sql
+GRANT LOCK TABLES ON *.* TO 'dm_source_user'@'%';
+```
+
+Then resume the task by clicking **Restart**.
+
 ## Alerts
 
 You can subscribe to TiDB Cloud alert emails to be informed in time when an alert occurs.

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,7 +96,7 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-This error indicates that the user for your source database lacks the `LOCK TABLES` privilege. Data Migration uses `consistency=flush` for full data migration, which requires this privilege to ensure a consistent snapshot.
+The full data export failed because the source database user does not have the `LOCK TABLES` privilege. During full data migration, DM might fall back to locking individual tables when the global flush lock is unavailable, which requires this privilege.
 
 To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,7 +96,7 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-The full data export failed because the source database user does not have the `LOCK TABLES` privilege. Cloud DM uses `consistency=flush` for full data migration, which requires this privilege to ensure a consistent snapshot.
+This error indicates that the user for your source database lacks the `LOCK TABLES` privilege. Data Migration uses `consistency=flush` for full data migration, which requires this privilege to ensure a consistent snapshot.
 
 To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,7 +96,7 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
+The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
 
 > **Note:** This error can also occur on self-managed MySQL instances if FTWRL is unavailable for other reasons (for example, missing `RELOAD` privilege).
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,9 +96,9 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is restricted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
+The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
 
-> **Note:** This error does not occur on self-managed MySQL instances where FTWRL is available.
+> **Note:** This error can also occur on self-managed MySQL instances if FTWRL is unavailable for other reasons (for example, missing `RELOAD` privilege).
 
 To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -96,7 +96,9 @@ To resolve this issue, you can create a schema in the TiDB cluster based on a [s
 
 ### Error message: "LOCK TABLES ... Access denied"
 
-The full data export failed because the source database user does not have the `LOCK TABLES` privilege. During full data migration, DM might fall back to locking individual tables when the global flush lock is unavailable, which requires this privilege.
+The full data export failed because the source database user does not have the `LOCK TABLES` privilege. This error typically occurs when migrating from a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is restricted by the cloud provider. In this case, DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency during full export, which requires this privilege.
+
+> **Note:** This error does not occur on self-managed MySQL instances where FTWRL is available.
 
 To resolve this issue, grant the missing privilege to the migration user in the source MySQL database:
 


### PR DESCRIPTION
## Summary

- Add `LOCK TABLES` to the source privilege table and GRANT statement in the Cloud DM migration guide
- Add troubleshooting entry for the `LOCK TABLES ... Access denied` error during full migration

## Why

Cloud DM sets `consistency=auto` for the dump phase (both `dataflow-service` and `serverless-service` set `Consistency: "auto"` in `OnTaskCreating()`). For MySQL sources, `auto` resolves to `flush` at runtime (`FLUSH TABLES WITH READ LOCK`), which only requires `RELOAD`.

However, if FTWRL fails or times out (e.g., long-running queries on the source), dumpling **automatically falls back to `consistency=lock`**, which executes `LOCK TABLES` SQL and requires the `LOCK TABLES` privilege. Without it, the dump fails with:

```
[code=32001:class=dump-unit] RawCause: sql: LOCK TABLES ... Error 1044 (42000): Access denied
```

The DM pre-checker does not catch this because it only validates privileges for the initial `auto`/`flush` path, not the `lock` fallback (see `resolveAutoConsistency()` in `dumpling/export/dump.go` and the fallback added in [tidb#36576](https://github.com/pingcap/tidb/pull/36576)).

Granting `LOCK TABLES` is defensive but correct — it ensures the dump succeeds regardless of which consistency path dumpling takes at runtime.

Other TiDB Cloud docs (Dumpling migration, OSS DM precheck) already include `LOCK TABLES` — this PR aligns the Cloud DM page.

## Test plan

- [ ] Verify privilege table renders correctly in preview
- [ ] Verify GRANT statement includes LOCK TABLES
- [ ] Verify troubleshooting entry appears under Migration errors