### PR TITLE
dm: add LOCK TABLES privilege note for managed MySQL sources

### DIFF
--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -73,7 +73,7 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
     > **Note:**
     >
-    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
+    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
 
 * (Mandatory) Consistency of upstream MySQL multi-instance sharding tables
 

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -73,7 +73,7 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
     > **Note:**
     >
-    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
+    > When `consistency=auto` (the default), DM first tries `FLUSH TABLES WITH READ LOCK` (FTWRL). If FTWRL is unavailable, DM falls back to `LOCK TABLES`. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, and Google Cloud SQL), where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently verify this privilege. For the full list of privileges, see [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges).
 
 * (Mandatory) Consistency of upstream MySQL multi-instance sharding tables
 

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -69,7 +69,7 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
     - SELECT permission on INFORMATION_SCHEMA and dump tables
     - RELOAD permission if `consistency=flush`
-    - LOCK TABLES permission on the dump tables if `consistency=flush/lock`
+    - LOCK TABLES permission on the dump tables if `consistency=lock`, or if `consistency=auto` and the source is a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted
 
 * (Mandatory) Consistency of upstream MySQL multi-instance sharding tables
 

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -67,9 +67,9 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
 * (Mandatory) dump permission of the upstream database
 
-    - SELECT permission on INFORMATION_SCHEMA and dump tables
-    - RELOAD permission if `consistency=flush`
-    - LOCK TABLES permission on the dump tables if `consistency=lock`
+    - `SELECT` permission on `INFORMATION_SCHEMA` and dump tables
+    - `RELOAD` permission if `consistency=flush`
+    - `LOCK TABLES` permission on the dump tables if `consistency=lock`
 
     > **Note:**
     >

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -69,7 +69,11 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
     - SELECT permission on INFORMATION_SCHEMA and dump tables
     - RELOAD permission if `consistency=flush`
-    - LOCK TABLES permission on the dump tables if `consistency=lock`, or if `consistency=auto` and the source is a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted
+    - LOCK TABLES permission on the dump tables if `consistency=lock`
+
+    > **Note:**
+    >
+    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
 
 * (Mandatory) Consistency of upstream MySQL multi-instance sharding tables
 

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -52,11 +52,16 @@ The upstream database (MySQL/MariaDB) user must have the following privileges:
 | `REPLICATION SLAVE` | Global |
 | `REPLICATION CLIENT` | Global |
 
+> **Note:** If migrating from a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
+
 If you need to migrate the data from `db1` to TiDB, execute the following `GRANT` statement:
 
 ```sql
 GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_wildcard_of_host';
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
+
+-- For managed MySQL (Amazon RDS, Aurora, etc.), also grant:
+-- GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
 If you also need to migrate the data from other databases into TiDB, make sure the same privileges are granted to the user of the respective databases.

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -52,16 +52,21 @@ The upstream database (MySQL/MariaDB) user must have the following privileges:
 | `REPLICATION SLAVE` | Global |
 | `REPLICATION CLIENT` | Global |
 
-> **Note:** If migrating from a managed MySQL service (such as Amazon RDS or Aurora) where `FLUSH TABLES WITH READ LOCK` is restricted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
+> **Note:**
+>
+> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
 
 If you need to migrate the data from `db1` to TiDB, execute the following `GRANT` statement:
 
 ```sql
 GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_wildcard_of_host';
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
+```
 
--- For managed MySQL (Amazon RDS, Aurora, etc.), also grant:
--- GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';
+For managed MySQL services where FTWRL is not permitted, also grant `LOCK TABLES`:
+
+```sql
+GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
 If you also need to migrate the data from other databases into TiDB, make sure the same privileges are granted to the user of the respective databases.

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -54,7 +54,7 @@ The upstream database (MySQL/MariaDB) user must have the following privileges:
 
 > **Note:**
 >
-> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
+> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
 
 If you need to migrate the data from `db1` to TiDB, execute the following `GRANT` statement:
 

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -63,7 +63,7 @@ GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_w
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
-For managed MySQL services where FTWRL is not permitted, also grant the `LOCK TABLES` privilege:
+For managed MySQL services where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted, also grant the `LOCK TABLES` privilege:
 
 ```sql
 GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -54,7 +54,7 @@ The upstream database (MySQL/MariaDB) user must have the following privileges:
 
 > **Note:**
 >
-> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
+> If you migrate from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` (FTWRL) is not permitted, also grant the `LOCK TABLES` privilege. With the default `consistency=auto` setting, DM falls back to `LOCK TABLES` when FTWRL is unavailable.
 
 If you need to migrate the data from `db1` to TiDB, execute the following `GRANT` statement:
 
@@ -63,7 +63,7 @@ GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_w
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
-For managed MySQL services where FTWRL is not permitted, also grant `LOCK TABLES`:
+For managed MySQL services where FTWRL is not permitted, also grant the `LOCK TABLES` privilege:
 
 ```sql
 GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -91,6 +91,8 @@ You can use Docker to quickly deploy a test MySQL 8.0 instance.
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS or Aurora), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+
 4. Create sample data:
 
     ```sql
@@ -147,6 +149,8 @@ On macOS, you can quickly install and start MySQL 8.0 locally using [Homebrew](h
 
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
+
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS or Aurora), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 6. Create sample data:
 

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -91,7 +91,7 @@ You can use Docker to quickly deploy a test MySQL 8.0 instance.
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 4. Create sample data:
 
@@ -150,7 +150,7 @@ On macOS, you can quickly install and start MySQL 8.0 locally using [Homebrew](h
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 6. Create sample data:
 

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -91,7 +91,7 @@ You can use Docker to quickly deploy a test MySQL 8.0 instance.
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS or Aurora), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 4. Create sample data:
 
@@ -150,7 +150,7 @@ On macOS, you can quickly install and start MySQL 8.0 locally using [Homebrew](h
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS or Aurora), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 6. Create sample data:
 

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -91,7 +91,9 @@ You can use Docker to quickly deploy a test MySQL 8.0 instance.
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:**
+    >
+    > If your MySQL source is a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant the `LOCK TABLES` privilege. For more information, see [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges).
 
 4. Create sample data:
 
@@ -150,7 +152,9 @@ On macOS, you can quickly install and start MySQL 8.0 locally using [Homebrew](h
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:**
+    >
+    > If your MySQL source is a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant the `LOCK TABLES` privilege. For more information, see [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges).
 
 6. Create sample data:
 


### PR DESCRIPTION
### What is changed, added or deleted?

Added conditional `LOCK TABLES` privilege documentation for managed MySQL sources (Amazon RDS, Aurora, Google Cloud SQL) across three DM docs pages.

**Background:** DM defaults to `consistency=auto`. On managed MySQL where `FLUSH TABLES WITH READ LOCK` is restricted by the cloud provider, DM falls back to `LOCK TABLES`. This privilege is not needed on self-managed MySQL instances. Confirmed with @gmhdbjd (Minghao Guo): the FTWRL → LOCK TABLES fallback in `auto` mode is by design.

**Changes:**
- `dm/dm-precheck.md`: Clarified that `LOCK TABLES` is needed for `auto` fallback on managed MySQL, not just `flush/lock`
- `dm/dm-worker-intro.md`: Added `LOCK TABLES` to privilege table with managed-MySQL scope note; added conditional GRANT example
- `dm/quick-start-with-dm.md`: Added note pointing to dm-worker-intro for managed MySQL sources (×2 instances)

**Evidence:** [Lab-06: LOCK TABLES privilege testing](https://github.com/alastori/tidb-sandbox/tree/main/labs/dm/lab-06-lock-tables-privilege) (9 scenarios, vanilla MySQL vs RDS)

**Related:**
- Cloud DM docs: https://github.com/pingcap/docs/pull/22598
- Pre-check improvement: https://tidb.atlassian.net/browse/DM-12687

### Which TiDB version(s) do your changes apply to?

- [x] master (dev)
- [x] v8.5 (LTS)

cc @gmhdbjd @qiancai @OliverS929