### PR TITLE
dm: add LOCK TABLES privilege note for managed MySQL sources (8.5)

### DIFF
--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -72,7 +72,7 @@ For the full data migration mode (`task-mode: full`), in addition to the [common
 
     > **Note:**
     >
-    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
+    > When `consistency=auto` (the default), DM first attempts `FLUSH TABLES WITH READ LOCK` and falls back to `LOCK TABLES` if FTWRL is unavailable. This fallback commonly occurs on managed MySQL services (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where FTWRL is not permitted. In this case, the `LOCK TABLES` privilege is required at runtime, but the precheck does not currently validate it. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for the full privilege list.
 
 * (Mandatory) Consistency of upstream MySQL multi-instance sharding tables
 

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -53,7 +53,7 @@ The upstream database (MySQL/MariaDB) user must have the following privileges:
 
 > **Note:**
 >
-> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
+> If migrating from a managed MySQL service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL) where `FLUSH TABLES WITH READ LOCK` is not permitted, the user also needs the `LOCK TABLES` privilege. DM's default `consistency=auto` mode falls back to `LOCK TABLES` for data consistency when FTWRL is unavailable.
 
 If you need to migrate the data from `db1` to TiDB, execute the following `GRANT` statement:
 

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -90,7 +90,7 @@ You can use Docker to quickly deploy a test MySQL 8.0 instance.
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 4. Create sample data:
 
@@ -149,7 +149,7 @@ On macOS, you can quickly install and start MySQL 8.0 locally using [Homebrew](h
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
-    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
+    > **Note:** If your MySQL source is a managed service (such as Amazon RDS, Aurora, ApsaraDB RDS for MySQL, Azure Database for MySQL, or Google Cloud SQL), also grant `LOCK TABLES`. See [DM-worker privileges](/dm/dm-worker-intro.md#upstream-database-user-privileges) for details.
 
 6. Create sample data:
 


### PR DESCRIPTION
Cherry-pick of #22605 to release-8.5.

Adds conditional `LOCK TABLES` privilege documentation for managed MySQL sources (RDS, Aurora) to dm-precheck, dm-worker-intro, and quick-start-with-dm.

See #22605 for full context.

### Which TiDB version(s) do your changes apply to?

- [x] v8.5 (LTS)

cc @gmhdbjd @qiancai