### PR TITLE
docs: replace deprecated PingCAP domains

### DIFF
--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
     #upload_to_aws(local_file, remote_name)
     upload_to_qiniu(local_file, remote_name)
 
-    print("https://download.pingcap.org/{}".format(remote_name))
+    print("https://download.pingcap.com/{}".format(remote_name))


### PR DESCRIPTION
## Summary
- replace deprecated `download.pingcap.org` references with `download.pingcap.com`
- replace deprecated `charts.pingcap.org` references with `charts.pingcap.com`
- keep existing paths and protocols unchanged

## Validation
- `git diff --check`
- verified no remaining `download.pingcap.org` / `charts.pingcap.org` references in the patched branch