### PR TITLE
cloud: revise Dedicated import docs for the new wizard UX

### DIFF
--- a/tidb-cloud/dedicated-external-storage.md
+++ b/tidb-cloud/dedicated-external-storage.md
@@ -163,7 +163,7 @@ To allow TiDB Cloud to access the source data in your GCS bucket, you need to co
 
     3. Click **Import data from Cloud Storage**.
 
-    4. On the **Import Data from Cloud Storage** page, set **Storage Provider** to **Google Cloud Storage**, and then copy the Google Cloud Service Account ID displayed under **Credentials** for later use.
+    4. On the **Import Data from Cloud Storage** page, set **Storage Provider** to **Google Cloud Storage**, and then copy the Google Cloud Service Account ID for later use.
 
 2. In the Google Cloud console, create an IAM role for your GCS bucket.
 

--- a/tidb-cloud/dedicated-external-storage.md
+++ b/tidb-cloud/dedicated-external-storage.md
@@ -31,11 +31,11 @@ Configure the bucket access for TiDB Cloud and get the Role ARN as follows:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-    3. Select **Import data from Cloud Storage**, and then click **Amazon S3**.
+    3. Click **Import data from Cloud Storage**.
 
-    4. On the **Import Data from Amazon S3** page, click the link under **Role ARN**. The **Add New Role ARN** dialog is displayed.
+    4. On the **Import Data from Cloud Storage** page, set **Storage Provider** to **Amazon S3**, make sure **AWS Role ARN** is selected under **Credentials**, and then click **Click here to create new one with AWS CloudFormation** under the **Role ARN** field. The **Add New Role ARN** dialog is displayed.
 
-    5. Expand **Create Role ARN manually** to get the TiDB Cloud Account ID and TiDB Cloud External ID. Take a note of these IDs for later use.
+    5. Expand **Having trouble? Create Role ARN manually** to get the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for this cluster. Take a note of these IDs for later use.
 
 2. In the AWS Management Console, create a managed policy for your Amazon S3 bucket.
 
@@ -161,9 +161,9 @@ To allow TiDB Cloud to access the source data in your GCS bucket, you need to co
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-    3. Select **Import data from Cloud Storage**, and then click **Google Cloud Storage**.
+    3. Click **Import data from Cloud Storage**.
 
-    4. Click **Show Google Cloud Server Account ID**, and then copy the Service Account ID for later use.
+    4. On the **Import Data from Cloud Storage** page, set **Storage Provider** to **Google Cloud Storage**, and then copy the Google Cloud Service Account ID displayed under **Credentials** for later use.
 
 2. In the Google Cloud console, create an IAM role for your GCS bucket.
 

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -31,7 +31,7 @@ This document describes how to import CSV files from Amazon Simple Storage Servi
     > - You only need to compress the data files, not the database or table schema files.
     > - To achieve better performance, it is recommended to limit the size of each compressed file to 100 MiB.
     > - The Snappy compressed file must be in the [official Snappy format](https://github.com/google/snappy). Other variants of Snappy compression are not supported.
-    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules in some cases (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and use the **Mapping Settings** in [Step 4](#step-4-import-csv-files-to-tidb-cloud) to import your source data to a single target table.
+    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and unselect **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** step of [Step 4](#step-4-import-csv-files-to-tidb-cloud) to manually map your source files to a single target table.
 
 ## Step 2. Create the target table schemas
 
@@ -105,35 +105,46 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Amazon S3** page, provide the following information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **CSV**.
-    - **Edit CSV Configuration**: if necessary, configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
-    - **Folder URI**: enter the source folder URI in the `s3://[bucket_name]/[data_source_folder]/` format. The path must end with a `/`. For example, `s3://mybucket/myfolder/`.
-    - **Bucket Access**: you can use either an AWS IAM role ARN or an AWS access key to access your bucket.
-        - **AWS Role ARN** (recommended): enter the AWS IAM role ARN value. If you don't have an IAM role for the bucket yet, you can create it using the provided AWS CloudFormation template by clicking **Click here to create new one with AWS CloudFormation** and following the instructions on the screen. Alternatively, you can manually create an IAM role ARN for the bucket.
+    - **Storage Provider**: select **Amazon S3**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `s3://[bucket_name]/[data_source_folder]/[file_name].csv`. For example, `s3://mybucket/myfolder/TableName.01.csv`.
+        - When importing multiple files, enter the source folder URI in the following format `s3://[bucket_name]/[data_source_folder]/`. For example, `s3://mybucket/myfolder/`.
+    - **Credentials**: you can use either an AWS Role ARN or an AWS access key to access your bucket. For more information, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
+        - **AWS Role ARN** (recommended): enter the AWS Role ARN value. If you do not have a Role ARN yet, click **Click here to create new one with AWS CloudFormation** and follow the instructions on the screen, or expand **Having trouble? Create Role ARN manually** in the dialog to get the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for your cluster, and then create the IAM role manually.
         - **AWS Access Key**: enter the AWS access key ID and AWS secret access key.
-        - For detailed instructions on both methods, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding CSV files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `s3://[bucket_name]/[data_source_folder]/[file_name].csv` format. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `s3://mybucket/myfolder/my-data1.csv`: a single CSV file named `my-data1.csv` in `myfolder` will be imported into the target table.
-        - `s3://mybucket/myfolder/my-data?.csv`: all CSV files starting with `my-data` followed by one character (such as `my-data1.csv` and `my-data2.csv`) in `myfolder` will be imported into the same target table.
-        - `s3://mybucket/myfolder/my-data*.csv`: all CSV files starting with `my-data` (such as `my-data10.csv` and `my-data100.csv`) in `myfolder` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
+            - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+    If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -149,32 +160,44 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Cloud Storage** page, provide the following information for the source CSV files:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **CSV**.
-    - **Edit CSV Configuration**: if necessary, configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
-    - **Folder URI**: enter the source folder URI in the `gs://[bucket_name]/[data_source_folder]/` format. The path must end with a `/`. For example, `gs://sampledata/ingest/`.
-    - **Google Cloud Service Account ID**: TiDB Cloud provides a unique Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). You must grant this Service Account ID the necessary IAM permissions (such as "Storage Object Viewer") on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
+    - **Storage Provider**: select **Google Cloud Storage**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `gs://[bucket_name]/[data_source_folder]/[file_name].csv`. For example, `gs://mybucket/myfolder/TableName.01.csv`.
+        - When importing multiple files, enter the source folder URI in the following format `gs://[bucket_name]/[data_source_folder]/`. For example, `gs://mybucket/myfolder/`.
+    - **Credentials**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding CSV files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `gs://[bucket_name]/[data_source_folder]/[file_name].csv` format. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `gs://mybucket/myfolder/my-data1.csv`: a single CSV file named `my-data1.csv` in `myfolder` will be imported into the target table.
-        - `gs://mybucket/myfolder/my-data?.csv`: all CSV files starting with `my-data` followed by one character (such as `my-data1.csv` and `my-data2.csv`) in `myfolder` will be imported into the same target table.
-        - `gs://mybucket/myfolder/my-data*.csv`: all CSV files starting with `my-data` (such as `my-data10.csv` and `my-data100.csv`) in `myfolder` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
+            - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+    If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -190,28 +213,28 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Azure Blob Storage** page, provide the following information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **CSV**.
+    - **Storage Provider**: select **Azure Blob Storage**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].csv`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/TableName.01.csv`.
+        - When importing multiple files, enter the source folder URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage:
 
         - **Public** (default): connects over the public internet. Use this option when the storage account allows public network access.
         - **Private Link**: connects through an Azure private endpoint for network-isolated access. Use this option when the storage account blocks public access or when your security policy requires private connectivity. If you select **Private Link**, you also need to fill in the additional field **Azure Blob Storage Resource ID**. To find the resource ID:
-            
+
             1. Go to the [Azure portal](https://portal.azure.com/).
             2. Navigate to your storage account and click **Overview** > **JSON View**.
             3. Copy the value of the `id` property. The resource ID is in the format `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<account_name>`.
 
-    - **Edit CSV Configuration**: if necessary, configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
-    - **Folder URI**: enter the Azure Blob Storage URI where your source files are located using the format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. The path must end with a `/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/`.
-    - **SAS Token**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you don't have one yet, you can create it using the provided Azure ARM template by clicking **Click here to create a new one with Azure ARM template** and following the instructions on the screen. Alternatively, you can manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
+    - **Credentials**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you do not have one yet, click **Click here to create a new one with Azure ARM template** and follow the instructions on the screen, or manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-    If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the connection can proceed:
+    If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the wizard can proceed:
 
     1. Go to the [Azure portal](https://portal.azure.com/) and navigate to your storage account.
     2. Click **Networking** > **Private endpoint connections**.
@@ -220,22 +243,34 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     > **Note:**
     >
-    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry the connection.
+    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding CSV files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].csv` format. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `https://myaccount.blob.core.windows.net/mycontainer/myfolder/my-data1.csv`: a single CSV file named `my-data1.csv` in `myfolder` will be imported into the target table.
-        - `https://myaccount.blob.core.windows.net/mycontainer/myfolder/my-data?.csv`: all CSV files starting with `my-data` followed by one character (such as `my-data1.csv` and `my-data2.csv`) in `myfolder` will be imported into the same target table.
-        - `https://myaccount.blob.core.windows.net/mycontainer/myfolder/my-data*.csv`: all CSV files starting with `my-data` (such as `my-data10.csv` and `my-data100.csv`) in `myfolder` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
+            - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+    If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -254,10 +289,10 @@ If you get an importing error, do the following:
 
 ### Resolve warnings during data import
 
-After clicking **Start Import**, if you see a warning message such as `can't find the corresponding source files`, resolve this by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or using **Advanced Settings** to make changes.
+If the **Pre-check** step shows a warning such as `can't find the corresponding source files`, resolve it by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or returning to the **Destination Mapping** step and switching to manual mapping rules.
 
-After resolving these issues, you need to import the data again.
+After resolving these issues, return to the wizard and run the import again.
 
 ### Zero rows in the imported tables
 
-After the import progress shows **Completed**, check the imported tables. If the number of rows is zero, it means no data files matched the Bucket URI that you entered. In this case, resolve this issue by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or using **Advanced Settings** to make changes. After that, import those tables again.
+After the import progress shows **Completed**, check the imported tables. If the number of rows is zero, it means no data files matched the source URI that you entered. In this case, resolve this issue by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or returning to the **Destination Mapping** step and switching to manual mapping rules. After that, import those tables again.

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -36,7 +36,7 @@ This document describes how to import CSV files from Amazon Simple Storage Servi
     > - You only need to compress the data files, not the database or table schema files.
     > - To achieve better performance, it is recommended to limit the size of each compressed file to 100 MiB.
     > - The Snappy compressed file must be in the [official Snappy format](https://github.com/google/snappy). Other variants of Snappy compression are not supported.
-    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and deselect **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** step of [Step 4](#step-4-import-csv-files-to-tidb-cloud) to manually map your source files to a single target table.
+    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and deselect **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** step of [Step 4](#step-4-import-csv-files-to-tidb-cloud) to manually map your source files to a single target table.
 
 ## Step 2. Create the target table schemas
 
@@ -126,13 +126,13 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 
@@ -179,13 +179,13 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 
@@ -252,13 +252,13 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -173,7 +173,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
     - **Source URI**:
         - When importing one file, enter the source file URI in the following format `gs://[bucket_name]/[data_source_folder]/[file_name].csv`. For example, `gs://mybucket/myfolder/TableName.01.csv`.
         - When importing multiple files, enter the source folder URI in the following format `gs://[bucket_name]/[data_source_folder]/`. For example, `gs://mybucket/myfolder/`.
-    - **Credentials**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
+    - **Google Cloud Service Account ID**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
 
 4. Click **Next**.
 
@@ -235,7 +235,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
             2. Navigate to your storage account and click **Overview** > **JSON View**.
             3. Copy the value of the `id` property. The resource ID is in the format `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<account_name>`.
 
-    - **Credentials**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you do not have one yet, click **Click here to create a new one with Azure ARM template** and follow the instructions on the screen, or manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
+    - **SAS Token**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you do not have one yet, click **Click here to create a new one with Azure ARM template** and follow the instructions on the screen, or manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
 
 4. Click **Next**.
 

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -110,7 +110,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Amazon S3**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `s3://[bucket_name]/[data_source_folder]/[file_name].csv`. For example, `s3://mybucket/myfolder/TableName.01.csv`.
         - When importing multiple files, enter the source folder URI in the following format `s3://[bucket_name]/[data_source_folder]/`. For example, `s3://mybucket/myfolder/`.
     - **Credentials**: you can use either an AWS Role ARN or an AWS access key to access your bucket. For more information, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
@@ -121,11 +121,11 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
@@ -165,7 +165,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Google Cloud Storage**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `gs://[bucket_name]/[data_source_folder]/[file_name].csv`. For example, `gs://mybucket/myfolder/TableName.01.csv`.
         - When importing multiple files, enter the source folder URI in the following format `gs://[bucket_name]/[data_source_folder]/`. For example, `gs://mybucket/myfolder/`.
     - **Credentials**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
@@ -174,11 +174,11 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
@@ -218,7 +218,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Azure Blob Storage**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].csv`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/TableName.01.csv`.
         - When importing multiple files, enter the source folder URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage:
@@ -247,11 +247,11 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -8,6 +8,11 @@ aliases: ['/tidbcloud/migrate-from-amazon-s3-or-gcs','/tidbcloud/migrate-from-au
 
 This document describes how to import CSV files from Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), or Azure Blob Storage into TiDB Cloud Dedicated.
 
+> **Tip:**
+>
+> - For TiDB Cloud Starter or TiDB Cloud Essential, see [Import CSV Files from Cloud Storage into TiDB Cloud Starter or Essential](/tidb-cloud/import-csv-files-serverless.md).
+> - For TiDB Cloud Premium, see [Import CSV Files from Cloud Storage into TiDB Cloud Premium](/tidb-cloud/premium/import-csv-files-premium.md).
+
 ## Limitations
 
 - To ensure data consistency, TiDB Cloud allows importing CSV files into empty tables only. To import data into an existing table that already contains data, you can use TiDB Cloud to import the data into a temporary empty table by following this document, and then use the `INSERT SELECT` statement to copy the data to the target existing table.

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -10,8 +10,7 @@ This document describes how to import CSV files from Amazon Simple Storage Servi
 
 > **Tip:**
 >
-> - For TiDB Cloud Starter or TiDB Cloud Essential, see [Import CSV Files from Cloud Storage into TiDB Cloud Starter or Essential](/tidb-cloud/import-csv-files-serverless.md).
-> - For TiDB Cloud Premium, see [Import CSV Files from Cloud Storage into TiDB Cloud Premium](/tidb-cloud/premium/import-csv-files-premium.md).
+> For TiDB Cloud Starter or TiDB Cloud Essential, see [Import CSV Files from Cloud Storage into TiDB Cloud Starter or Essential](/tidb-cloud/import-csv-files-serverless.md).
 
 ## Limitations
 

--- a/tidb-cloud/import-csv-files.md
+++ b/tidb-cloud/import-csv-files.md
@@ -31,7 +31,7 @@ This document describes how to import CSV files from Amazon Simple Storage Servi
     > - You only need to compress the data files, not the database or table schema files.
     > - To achieve better performance, it is recommended to limit the size of each compressed file to 100 MiB.
     > - The Snappy compressed file must be in the [official Snappy format](https://github.com/google/snappy). Other variants of Snappy compression are not supported.
-    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and unselect **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** step of [Step 4](#step-4-import-csv-files-to-tidb-cloud) to manually map your source files to a single target table.
+    > - For uncompressed files, if you cannot update the CSV filenames according to the preceding rules (for example, the CSV file links are also used by your other programs), you can keep the filenames unchanged and deselect **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** step of [Step 4](#step-4-import-csv-files-to-tidb-cloud) to manually map your source files to a single target table.
 
 ## Step 2. Create the target table schemas
 
@@ -121,17 +121,17 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
             - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
@@ -140,7 +140,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 
@@ -174,17 +174,17 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
             - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
@@ -193,7 +193,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 
@@ -247,17 +247,17 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **CSV** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source CSV files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source CSV files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].csv` format. For example, `TableName.01.csv`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.csv`: matches all CSV files that start with `my-data` followed by a single character, such as `my-data1.csv` and `my-data2.csv`.
             - `my-data*.csv`: matches all CSV files that start with `my-data`, such as `my-data-2023.csv` and `my-data-final.csv`.
@@ -266,7 +266,7 @@ To import the CSV files to TiDB Cloud, take the following steps:
 
     If necessary, click **Edit CSV Configuration** to configure the options according to your CSV files. You can set the separator and delimiter characters, specify whether to use backslashes for escaped characters, and specify whether your files contain a header row.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 

--- a/tidb-cloud/import-parquet-files.md
+++ b/tidb-cloud/import-parquet-files.md
@@ -7,6 +7,10 @@ summary: Learn how to import Apache Parquet files from Amazon S3, GCS, or Azure 
 
 This document describes how to import Apache Parquet files from Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), or Azure Blob Storage into TiDB Cloud Dedicated. You can import Parquet files that are either uncompressed or compressed with [Google Snappy](https://github.com/google/snappy). Other Parquet compression codecs are not supported.
 
+> **Tip:**
+>
+> For TiDB Cloud Starter or TiDB Cloud Essential, see [Import Apache Parquet Files from Cloud Storage into TiDB Cloud Starter or Essential](/tidb-cloud/import-parquet-files-serverless.md).
+
 ## Limitations
 
 - To ensure data consistency, TiDB Cloud allows to import Parquet files into empty tables only. To import data into an existing table that already contains data, you can use TiDB Cloud to import the data into a temporary empty table by following this document, and then use the `INSERT SELECT` statement to copy the data to the target existing table.

--- a/tidb-cloud/import-parquet-files.md
+++ b/tidb-cloud/import-parquet-files.md
@@ -127,24 +127,24 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
             - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
 
         - **Target Database** and **Target Table**: enter the target database and table to import the data to.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 
@@ -178,24 +178,24 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
             - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
 
         - **Target Database** and **Target Table**: enter the target database and table to import the data to.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 
@@ -249,24 +249,24 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
-        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. TiDB Cloud only supports the `*` and `?` wildcards.
 
             - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
             - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
 
         - **Target Database** and **Target Table**: enter the target database and table to import the data to.
 
-6. Click **Next**. TiDB Cloud scans the source files accordingly.
+6. Click **Next**. TiDB Cloud scans the source files.
 
 7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
 

--- a/tidb-cloud/import-parquet-files.md
+++ b/tidb-cloud/import-parquet-files.md
@@ -40,7 +40,7 @@ This document describes how to import Apache Parquet files from Amazon Simple St
 
     > **Note:**
     >
-    > - If you cannot update the Parquet filenames according to the preceding rules in some cases (for example, the Parquet file links are also used by your other programs), you can keep the filenames unchanged and use the **Mapping Settings** in [Step 4](#step-4-import-parquet-files-to-tidb-cloud) to import your source data to a single target table.
+    > - If you cannot update the Parquet filenames according to the preceding rules (for example, the Parquet file links are also used by your other programs), you can keep the filenames unchanged and deselect **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** in the **Destination Mapping** substep of [Step 4](#step-4-import-parquet-files-to-tidb-cloud) to manually map your source files to a single target table.
     > - The Snappy compressed file must be in the [official Snappy format](https://github.com/google/snappy). Other variants of Snappy compression are not supported.
 
 ## Step 2. Create the target table schemas
@@ -131,13 +131,13 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
@@ -182,13 +182,13 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
@@ -253,13 +253,13 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
+    When you specify a directory in **Source URI**, TiDB Cloud selects the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option by default.
 
     > **Note:**
     >
-    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When you specify a single file in **Source URI**, TiDB Cloud does not display the **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option and automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
+    - To let TiDB Cloud automatically map all source files that follow the [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
     - To manually configure the mapping rules to associate your source Parquet files with the target database and table, deselect this option, and then fill in the following fields:
 
@@ -317,10 +317,10 @@ The following table lists the supported Parquet data types that can be imported 
 
 ### Resolve warnings during data import
 
-After clicking **Start Import**, if you see a warning message such as `can't find the corresponding source files`, resolve this by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or using **Advanced Settings** to make changes.
+If the **Pre-check** step shows a warning such as `can't find the corresponding source files`, resolve it by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or returning to the **Destination Mapping** step and switching to manual mapping rules.
 
-After resolving these issues, you need to import the data again.
+After resolving these issues, return to the wizard and run the import again.
 
 ### Zero rows in the imported tables
 
-After the import progress shows **Completed**, check the imported tables. If the number of rows is zero, it means no data files matched the Bucket URI that you entered. In this case, resolve this issue by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or using **Advanced Settings** to make changes. After that, import those tables again.
+After the import progress shows **Completed**, check the imported tables. If the number of rows is zero, it means no data files matched the source URI that you entered. In this case, resolve this issue by providing the correct source file, renaming the existing one according to [Naming Conventions for Data Import](/tidb-cloud/naming-conventions-for-data-import.md), or returning to the **Destination Mapping** step and switching to manual mapping rules. After that, import those tables again.

--- a/tidb-cloud/import-parquet-files.md
+++ b/tidb-cloud/import-parquet-files.md
@@ -111,34 +111,44 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Amazon S3** page, provide the following information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **Parquet**.
-    - **Folder URI**: enter the source folder URI in the `s3://[bucket_name]/[data_source_folder]/` format. The path must end with a `/`. For example, `s3://sampledata/ingest/`.
-    - **Bucket Access**: you can use either an AWS IAM role ARN or an AWS access key to access your bucket.
-        - **AWS Role ARN** (recommended): enter the AWS IAM role ARN value. If you don't have an IAM role for the bucket yet, you can create it using the provided AWS CloudFormation template by clicking **Click here to create new one with AWS CloudFormation** and following the instructions on the screen. Alternatively, you can manually create an IAM role ARN for the bucket.
+    - **Storage Provider**: select **Amazon S3**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `s3://[bucket_name]/[data_source_folder]/[file_name].parquet`. For example, `s3://mybucket/myfolder/TableName.01.parquet`.
+        - When importing multiple files, enter the source folder URI in the following format `s3://[bucket_name]/[data_source_folder]/`. For example, `s3://mybucket/myfolder/`.
+    - **Credentials**: you can use either an AWS Role ARN or an AWS access key to access your bucket. For more information, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
+        - **AWS Role ARN** (recommended): enter the AWS Role ARN value. If you do not have a Role ARN yet, click **Click here to create new one with AWS CloudFormation** and follow the instructions on the screen, or expand **Having trouble? Create Role ARN manually** in the dialog to get the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for your cluster, and then create the IAM role manually.
         - **AWS Access Key**: enter the AWS access key ID and AWS secret access key.
-        - For detailed instructions on both methods, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding Parquet files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `s3://[bucket_name]/[data_source_folder]/[file_name].parquet` format. For example, `s3://sampledata/ingest/TableName.01.parquet`. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `s3://[bucket_name]/[data_source_folder]/my-data1.parquet`: a single Parquet file named `my-data1.parquet` in `[data_source_folder]` will be imported into the target table.
-        - `s3://[bucket_name]/[data_source_folder]/my-data?.parquet`: all Parquet files starting with `my-data` followed by one character (such as `my-data1.parquet` and `my-data2.parquet`) in `[data_source_folder]` will be imported into the same target table.
-        - `s3://[bucket_name]/[data_source_folder]/my-data*.parquet`: all Parquet files starting with `my-data` (such as `my-data10.parquet` and `my-data100.parquet`) in `[data_source_folder]` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
+            - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -154,31 +164,42 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Cloud Storage** page, provide the following information for the source Parquet files:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **Parquet**.
-    - **Folder URI**: enter the source folder URI in the `gs://[bucket_name]/[data_source_folder]/` format. The path must end with a `/`. For example, `gs://sampledata/ingest/`.
-    - **Google Cloud Service Account ID**: TiDB Cloud provides a unique Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). You must grant this Service Account ID the necessary IAM permissions (such as "Storage Object Viewer") on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
+    - **Storage Provider**: select **Google Cloud Storage**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `gs://[bucket_name]/[data_source_folder]/[file_name].parquet`. For example, `gs://mybucket/myfolder/TableName.01.parquet`.
+        - When importing multiple files, enter the source folder URI in the following format `gs://[bucket_name]/[data_source_folder]/`. For example, `gs://mybucket/myfolder/`.
+    - **Credentials**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding Parquet files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `gs://[bucket_name]/[data_source_folder]/[file_name].parquet` format. For example, `gs://sampledata/ingest/TableName.01.parquet`. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `gs://[bucket_name]/[data_source_folder]/my-data1.parquet`: a single Parquet file named `my-data1.parquet` in `[data_source_folder]` will be imported into the target table.
-        - `gs://[bucket_name]/[data_source_folder]/my-data?.parquet`: all Parquet files starting with `my-data` followed by one character (such as `my-data1.parquet` and `my-data2.parquet`) in `[data_source_folder]` will be imported into the same target table.
-        - `gs://[bucket_name]/[data_source_folder]/my-data*.parquet`: all Parquet files starting with `my-data` (such as `my-data10.parquet` and `my-data100.parquet`) in `[data_source_folder]` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
+            - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -194,27 +215,28 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Azure Blob Storage** page, provide the following information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: if the source folder contains the target table schema files (such as `${db_name}-schema-create.sql`), select **Yes**. Otherwise, select **No**.
-    - **Data Format**: select **Parquet**.
+    - **Storage Provider**: select **Azure Blob Storage**.
+    - **Source Files URI**:
+        - When importing one file, enter the source file URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].parquet`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/TableName.01.parquet`.
+        - When importing multiple files, enter the source folder URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage:
 
         - **Public** (default): connects over the public internet. Use this option when the storage account allows public network access.
         - **Private Link**: connects through an Azure private endpoint for network-isolated access. Use this option when the storage account blocks public access or when your security policy requires private connectivity. If you select **Private Link**, you also need to fill in the additional field **Azure Blob Storage Resource ID**. To find the resource ID:
-            
+
             1. Go to the [Azure portal](https://portal.azure.com/).
             2. Navigate to your storage account and click **Overview** > **JSON View**.
             3. Copy the value of the `id` property. The resource ID is in the format `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<account_name>`.
 
-    - **Folder URI**: enter the Azure Blob Storage URI where your source files are located using the format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. The path must end with a `/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/data-ingestion/`.
-    - **SAS Token**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you don't have one yet, you can create it using the provided Azure ARM template by clicking **Click here to create a new one with Azure ARM template** and following the instructions on the screen. Alternatively, you can manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
+    - **Credentials**: enter an account SAS token to allow TiDB Cloud to access the source files in your Azure Blob Storage container. If you do not have one yet, click **Click here to create a new one with Azure ARM template** and follow the instructions on the screen, or manually create an account SAS token. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
 
-4. Click **Connect**.
+4. Click **Next**.
 
-    If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the connection can proceed:
+    If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the wizard can proceed:
 
     1. Go to the [Azure portal](https://portal.azure.com/) and navigate to your storage account.
     2. Click **Networking** > **Private endpoint connections**.
@@ -223,22 +245,32 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
     > **Note:**
     >
-    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry the connection.
+    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry.
 
-5. In the **Destination** section, select the target database and table.
+5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When importing multiple files, you can use **Advanced Settings** > **Mapping Settings** to customize the mapping of individual target tables to their corresponding Parquet files. For each target database and table:
+    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
-    - **Target Database**: select the corresponding database name from the list.
-    - **Target Table**: select the corresponding table name from the list.
-    - **Source File URIs and Names**: enter the full URI of the source file, including the folder and file name, making sure it is in the `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].parquet` format. For example, `https://myaccount.blob.core.windows.net/mycontainer/data-ingestion/TableName.01.parquet`. You can also use wildcards (`?` and `*`) to match multiple files. For example:
-        - `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/my-data1.parquet`: a single Parquet file named `my-data1.parquet` in `[data_source_folder]` will be imported into the target table.
-        - `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/my-data?.parquet`: all Parquet files starting with `my-data` followed by one character (such as `my-data1.parquet` and `my-data2.parquet`) in `[data_source_folder]` will be imported into the same target table.
-        - `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/my-data*.parquet`: all Parquet files starting with `my-data` (such as `my-data10.parquet` and `my-data100.parquet`) in `[data_source_folder]` will be imported into the same target table.
+    > **Note:**
+    >
+    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
-6. Click **Start Import**.
+    - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
-7. When the import progress shows **Completed**, check the imported tables.
+    - To manually configure the mapping rules to associate your source Parquet files with the target database and table, unselect this option, and then fill in the following fields:
+
+        - **Source**: enter the file name pattern in the `[file_name].parquet` format. For example, `TableName.01.parquet`. You can also use wildcards to match multiple files. Only `*` and `?` wildcards are supported.
+
+            - `my-data?.parquet`: matches all Parquet files that start with `my-data` followed by a single character, such as `my-data1.parquet` and `my-data2.parquet`.
+            - `my-data*.parquet`: matches all Parquet files that start with `my-data`, such as `my-data10.parquet` and `my-data100.parquet`.
+
+        - **Target Database** and **Target Table**: enter the target database and table to import the data to.
+
+6. Click **Next**. TiDB Cloud scans the source files accordingly.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 

--- a/tidb-cloud/import-parquet-files.md
+++ b/tidb-cloud/import-parquet-files.md
@@ -116,7 +116,7 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Amazon S3**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `s3://[bucket_name]/[data_source_folder]/[file_name].parquet`. For example, `s3://mybucket/myfolder/TableName.01.parquet`.
         - When importing multiple files, enter the source folder URI in the following format `s3://[bucket_name]/[data_source_folder]/`. For example, `s3://mybucket/myfolder/`.
     - **Credentials**: you can use either an AWS Role ARN or an AWS access key to access your bucket. For more information, see [Configure Amazon S3 access](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access).
@@ -127,11 +127,11 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
@@ -169,7 +169,7 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Google Cloud Storage**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `gs://[bucket_name]/[data_source_folder]/[file_name].parquet`. For example, `gs://mybucket/myfolder/TableName.01.parquet`.
         - When importing multiple files, enter the source folder URI in the following format `gs://[bucket_name]/[data_source_folder]/`. For example, `gs://mybucket/myfolder/`.
     - **Credentials**: TiDB Cloud provides a unique Google Cloud Service Account ID on this page (such as `example-service-account@your-project.iam.gserviceaccount.com`). Grant this Service Account ID the necessary IAM permissions (such as `Storage Object Viewer`) on your GCS bucket within your Google Cloud project. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
@@ -178,11 +178,11 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 
@@ -220,7 +220,7 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 3. On the **Import Data from Cloud Storage** page, provide the following information:
 
     - **Storage Provider**: select **Azure Blob Storage**.
-    - **Source Files URI**:
+    - **Source URI**:
         - When importing one file, enter the source file URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/[file_name].parquet`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/TableName.01.parquet`.
         - When importing multiple files, enter the source folder URI in the following format `https://[account_name].blob.core.windows.net/[container_name]/[data_source_folder]/`. For example, `https://myaccount.blob.core.windows.net/mycontainer/myfolder/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage:
@@ -249,11 +249,11 @@ To import the Parquet files to TiDB Cloud, take the following steps:
 
 5. In the **Destination Mapping** section, specify how source files are mapped to target tables.
 
-    When a directory is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
+    When a directory is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is selected by default.
 
     > **Note:**
     >
-    > When a single file is specified in **Source Files URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
+    > When a single file is specified in **Source URI**, the **Use [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** option is not displayed, and TiDB Cloud automatically populates the **Source** field with the file name. In this case, you only need to enter the target database and table for data import.
 
     - To let TiDB Cloud automatically map all source files that follow the [File naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) to their corresponding tables, keep this option selected and select **Parquet** as the data format. If your source folder includes schema files (such as `${db_name}-schema-create.sql` and `${db_name}.${table_name}-schema.sql`), TiDB Cloud uses them to create the target databases and tables when they do not already exist.
 

--- a/tidb-cloud/import-sample-data.md
+++ b/tidb-cloud/import-sample-data.md
@@ -20,18 +20,24 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Amazon S3** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**. 
-    - **Folder URI** or **File URI**: enter the sample data URI `s3://tidbcloud-sample-data/data-ingestion/`.
-    - **Bucket Access**: for the sample data, you can only use a Role ARN to access its bucket. For your own data, you can use either an AWS access key or a Role ARN to access your bucket.
-        - **AWS Role ARN**: enter `arn:aws:iam::801626783489:role/import-sample-access`.
+    - **Storage Provider**: select **Amazon S3**.
+    - **Source URI**: enter the sample data URI `s3://tidbcloud-sample-data/data-ingestion/`.
+    - **Credentials**: select **AWS Role ARN**, and then enter `arn:aws:iam::801626783489:role/import-sample-access`.
         - **AWS Access Key**: skip this option for the sample data.
 
-4. Click **Connect** > **Start Import**.
+4. Click **Next**.
+
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 <div label="Google Cloud">
@@ -46,18 +52,23 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from GCS** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**.
-    - **Folder URI** or **File URI**: enter the sample data URI `gs://tidbcloud-samples-us-west1/`.
-    - **Bucket Access**: you can use a GCS IAM Role to access your bucket. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
+    - **Storage Provider**: select **Google Cloud Storage**.
+    - **Source URI**: enter the sample data URI `gs://tidbcloud-samples-us-west1/`.
+    - **Google Cloud Service Account ID**: TiDB Cloud displays a Google Cloud Service Account ID on this page. You can proceed directly when using the sample data URI.
 
-    If the region of the bucket is different from your cluster, confirm the compliance of cross region.
+4. Click **Next**.
 
-4. Click **Connect** > **Start Import**.
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -73,12 +84,12 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Azure Blob Storage** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**.
+    - **Storage Provider**: select **Azure Blob Storage**.
+    - **Source URI**: enter the sample data URI `https://tcidmsampledata.blob.core.windows.net/sql/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage. To import the sample data, you can use the default connectivity method.
 
         - **Public** (default): connects over the public internet. Use this option when the storage account allows public network access.
@@ -88,14 +99,12 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
             2. Navigate to your storage account and click **Overview** > **JSON View**.
             3. Copy the value of the `id` property. The resource ID is in the format `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<account_name>`.
 
-    - **Folder URI**: enter the sample data URI `https://tcidmsampledata.blob.core.windows.net/sql/`.
-    - **SAS Token**: 
+    - **SAS Token**:
+
         - For the sample data, use the following **SAS Token**: `sv=2015-04-05&ss=b&srt=co&sp=rl&se=2099-03-01T00%3A00%3A01.0000000Z&sig=cQHvaofmVsUJEbgyf4JFkAwTJGsFOmbQHx03GvVMrNc%3D`.
         - For your own data, you can use a SAS token to access your Azure Blob Storage. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
 
-    If the region of the storage account is different from your cluster, confirm the compliance of cross region.
-
-4. Click **Connect**.
+4. Click **Next**.
 
     If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the connection can proceed:
 
@@ -106,9 +115,15 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     > **Note:**
     >
-    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry the connection.
+    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry.
 
-5. Click **Start Import**.
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 </SimpleTab>

--- a/tidb-cloud/import-sample-data.md
+++ b/tidb-cloud/import-sample-data.md
@@ -20,7 +20,6 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
 2. Click **Import data from Cloud Storage**.
 
 3. On the **Import Data from Cloud Storage** page, provide the following information:

--- a/tidb-cloud/import-sample-data.md
+++ b/tidb-cloud/import-sample-data.md
@@ -21,17 +21,24 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
 2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Amazon S3** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**. 
-    - **Folder URI** or **File URI**: enter the sample data URI `s3://tidbcloud-sample-data/data-ingestion/`.
-    - **Bucket Access**: for the sample data, you can only use a Role ARN to access its bucket. For your own data, you can use either an AWS access key or a Role ARN to access your bucket.
-        - **AWS Role ARN**: enter `arn:aws:iam::801626783489:role/import-sample-access`.
+    - **Storage Provider**: select **Amazon S3**.
+    - **Source URI**: enter the sample data URI `s3://tidbcloud-sample-data/data-ingestion/`.
+    - **Credentials**: select **AWS Role ARN**, and then enter `arn:aws:iam::801626783489:role/import-sample-access`.
         - **AWS Access Key**: skip this option for the sample data.
 
-4. Click **Connect** > **Start Import**.
+4. Click **Next**.
+
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 <div label="Google Cloud">
@@ -46,18 +53,23 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from GCS** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**.
-    - **Folder URI** or **File URI**: enter the sample data URI `gs://tidbcloud-samples-us-west1/`.
-    - **Bucket Access**: you can use a GCS IAM Role to access your bucket. For more information, see [Configure GCS access](/tidb-cloud/dedicated-external-storage.md#configure-gcs-access).
+    - **Storage Provider**: select **Google Cloud Storage**.
+    - **Source URI**: enter the sample data URI `gs://tidbcloud-samples-us-west1/`.
+    - **Google Cloud Service Account ID**: TiDB Cloud displays a Google Cloud Service Account ID on this page. You can proceed directly when using the sample data URI.
 
-    If the region of the bucket is different from your cluster, confirm the compliance of cross region.
+4. Click **Next**.
 
-4. Click **Connect** > **Start Import**.
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 
@@ -73,12 +85,12 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     2. Click the name of your target cluster to go to its overview page, and then click **Data** > **Import** in the left navigation pane.
 
-2. Select **Import data from Cloud Storage**.
+2. Click **Import data from Cloud Storage**.
 
-3. On the **Import Data from Azure Blob Storage** page, configure the following source data information:
+3. On the **Import Data from Cloud Storage** page, provide the following information:
 
-    - **Included Schema Files**: for the sample data, select **Yes**.
-    - **Data Format**: select **SQL**.
+    - **Storage Provider**: select **Azure Blob Storage**.
+    - **Source URI**: enter the sample data URI `https://tcidmsampledata.blob.core.windows.net/sql/`.
     - **Connectivity Method**: select how TiDB Cloud connects to your Azure Blob Storage. To import the sample data, you can use the default connectivity method.
 
         - **Public** (default): connects over the public internet. Use this option when the storage account allows public network access.
@@ -88,14 +100,12 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
             2. Navigate to your storage account and click **Overview** > **JSON View**.
             3. Copy the value of the `id` property. The resource ID is in the format `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<account_name>`.
 
-    - **Folder URI**: enter the sample data URI `https://tcidmsampledata.blob.core.windows.net/sql/`.
-    - **SAS Token**: 
+    - **SAS Token**:
+
         - For the sample data, use the following **SAS Token**: `sv=2015-04-05&ss=b&srt=co&sp=rl&se=2099-03-01T00%3A00%3A01.0000000Z&sig=cQHvaofmVsUJEbgyf4JFkAwTJGsFOmbQHx03GvVMrNc%3D`.
         - For your own data, you can use a SAS token to access your Azure Blob Storage. For more information, see [Configure Azure Blob Storage access](/tidb-cloud/dedicated-external-storage.md#configure-azure-blob-storage-access).
 
-    If the region of the storage account is different from your cluster, confirm the compliance of cross region.
-
-4. Click **Connect**.
+4. Click **Next**.
 
     If you selected **Private Link** as the connectivity method, TiDB Cloud creates a private endpoint for your storage account. You need to approve this endpoint request in the Azure portal before the connection can proceed:
 
@@ -106,9 +116,15 @@ This document describes how to import the sample data (SQL files) into TiDB Clou
 
     > **Note:**
     >
-    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry the connection.
+    > If the endpoint is not yet approved, TiDB Cloud displays a message indicating that the connection is pending approval. Approve the request in the [Azure portal](https://portal.azure.com/) and retry.
 
-5. Click **Start Import**.
+5. In the **Destination Mapping** section, keep **Use [TiDB file naming conventions](/tidb-cloud/naming-conventions-for-data-import.md) for automatic mapping** selected, and then select **SQL** as the data format.
+
+6. Click **Next**. TiDB Cloud scans the source files.
+
+7. Review the scan results, check the data files found and corresponding target tables, and then click **Start Import**.
+
+8. When the import progress shows **Completed**, check the imported tables.
 
 </div>
 </SimpleTab>

--- a/tidb-cloud/naming-conventions-for-data-import.md
+++ b/tidb-cloud/naming-conventions-for-data-import.md
@@ -121,7 +121,7 @@ If the SQL file is exported through TiDB Dumpling with the default configuration
 
 If the source data file of CSV or Parquet does not conform to the naming convention, you can manually map the source data file to the target table using a file name pattern. This feature does not support Aurora Snapshot and SQL data files.
 
-In the import wizard, on the **Destination Mapping** step, unselect **Use File naming conventions for automatic mapping**, and then fill in the **Source**, **Target Database**, and **Target Table** fields. The **Source** field accepts a file name pattern that supports the `*` and `?` wildcards.
+In the import wizard, on the **Destination Mapping** step, deselect **Use TiDB file naming conventions for automatic mapping**, and then fill in the **Source**, **Target Database**, and **Target Table** fields. The **Source** field accepts a file name pattern that supports the `*` and `?` wildcards.
 
 - For CSV files, see [Step 4. Import CSV files to TiDB Cloud](/tidb-cloud/import-csv-files.md#step-4-import-csv-files-to-tidb-cloud).
 - For Parquet files, see [Step 4. Import Parquet files to TiDB Cloud](/tidb-cloud/import-parquet-files.md#step-4-import-parquet-files-to-tidb-cloud).

--- a/tidb-cloud/naming-conventions-for-data-import.md
+++ b/tidb-cloud/naming-conventions-for-data-import.md
@@ -119,7 +119,9 @@ If the SQL file is exported through TiDB Dumpling with the default configuration
 
 ## File pattern
 
-If the source data file of CSV or Parquet does not conform to the naming convention, you can use the file pattern feature to establish the name mapping relationship between the source data file and the target table. This feature does not support Aurora Snapshot and SQL data files.
+If the source data file of CSV or Parquet does not conform to the naming convention, you can manually map the source data file to the target table using a file name pattern. This feature does not support Aurora Snapshot and SQL data files.
 
-- For CSV files, see **Advanced Settings** > **Mapping Settings** in [Step 4. Import CSV files to TiDB Cloud](/tidb-cloud/import-csv-files.md#step-4-import-csv-files-to-tidb-cloud)
-- For Parquet files, see **Advanced Settings** > **Mapping Settings** in [Step 4. Import Parquet files to TiDB Cloud](/tidb-cloud/import-parquet-files.md#step-4-import-parquet-files-to-tidb-cloud) 
+In the import wizard, on the **Destination Mapping** step, unselect **Use File naming conventions for automatic mapping**, and then fill in the **Source**, **Target Database**, and **Target Table** fields. The **Source** field accepts a file name pattern that supports the `*` and `?` wildcards.
+
+- For CSV files, see [Step 4. Import CSV files to TiDB Cloud](/tidb-cloud/import-csv-files.md#step-4-import-csv-files-to-tidb-cloud).
+- For Parquet files, see [Step 4. Import Parquet files to TiDB Cloud](/tidb-cloud/import-parquet-files.md#step-4-import-parquet-files-to-tidb-cloud).

--- a/tidb-cloud/troubleshoot-import-access-denied-error.md
+++ b/tidb-cloud/troubleshoot-import-access-denied-error.md
@@ -17,11 +17,19 @@ This section describes how to troubleshoot the issue that TiDB Cloud cannot assu
 
 ### Check the trust entity
 
-1. In the AWS Management Console, go to **IAM** > **Access Management** > **Roles**. 
-2. In the list of roles, find and click the role you have created for the target TiDB cluster. The role summary page is displayed. 
-3. On the role summary page, click the **Trust relationships** tab, and you will see the trusted entities.
+The TiDB Cloud Account ID and TiDB Cloud External ID are environment-specific and per-cluster, so do not copy literal values from this document. Instead, get them from the TiDB Cloud console:
 
-The following is a sample trust entity:
+1. In the [TiDB Cloud console](https://tidbcloud.com/), go to your target cluster, and then click **Data** > **Import** in the left navigation pane.
+2. Click **Import data from Cloud Storage**.
+3. In the **Credentials** section, click **Click here to create new one with AWS CloudFormation** to open the **Add New Role ARN** dialog, and then expand **Having trouble? Create Role ARN manually** to display the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for this cluster.
+
+Then verify the trust entity on your IAM role:
+
+1. In the AWS Management Console, go to **IAM** > **Access Management** > **Roles**.
+2. In the list of roles, find and click the role you have created for the target TiDB cluster. The role summary page is displayed.
+3. On the role summary page, click the **Trust relationships** tab to view the trusted entities.
+
+The trust entity should look like the following sample, with `<TiDB-Cloud-Account-ID>` and `<TiDB-Cloud-External-ID>` replaced by the values you obtained from the console:
 
 ```
 {
@@ -30,12 +38,12 @@ The following is a sample trust entity:
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::380838443567:root"
+                "AWS": "arn:aws:iam::<TiDB-Cloud-Account-ID>:root"
             },
             "Action": "sts:AssumeRole",
             "Condition": {
                 "StringEquals": {
-                    "sts:ExternalId": "696e6672612d617069a79c22fa5740944bf8bb32e4a0c4e3fe"
+                    "sts:ExternalId": "<TiDB-Cloud-External-ID>"
                 }
             }
         }
@@ -43,10 +51,7 @@ The following is a sample trust entity:
 }
 ```
 
-In the sample trust entity:
-
-- `380838443567` is the TiDB Cloud Account ID. Make sure that this field in your trust entity matches your TiDB Cloud Account ID.
-- `696e6672612d617069a79c22fa5740944bf8bb32e4a0c4e3fe` is the TiDB Cloud External ID. Make sure that this field in your trusted entity matches your TiDB Cloud External ID.
+Make sure that the `Principal.AWS` field matches the **TiDB Cloud Account ID** shown in the console, and that the `sts:ExternalId` condition matches the **TiDB Cloud External ID** shown in the console.
 
 ### Check whether the IAM role exists
 

--- a/tidb-cloud/troubleshoot-import-access-denied-error.md
+++ b/tidb-cloud/troubleshoot-import-access-denied-error.md
@@ -21,7 +21,8 @@ The TiDB Cloud Account ID and TiDB Cloud External ID are environment-specific an
 
 1. In the [TiDB Cloud console](https://tidbcloud.com/), go to your target cluster, and then click **Data** > **Import** in the left navigation pane.
 2. Click **Import data from Cloud Storage**.
-3. In the **Credentials** section, click **Click here to create new one with AWS CloudFormation** to open the **Add New Role ARN** dialog, and then expand **Having trouble? Create Role ARN manually** to display the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for this cluster.
+3. On the **Import Data from Cloud Storage** page, select **Amazon S3** as the cloud provider.
+4. In the **Credentials** section, click **Click here to create new one with AWS CloudFormation** to open the **Add New Role ARN** dialog, and then expand **Having trouble? Create Role ARN manually** to display the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for this cluster.
 
 Then verify the trust entity on your IAM role:
 


### PR DESCRIPTION
## Summary

Update the TiDB Cloud Dedicated import docs to match the new 3-step wizard introduced in [tidb-cloud-console#4617](https://github.com/pingcap/tidb-cloud-console/pull/4617). Mirrors the Serverless rewrite from #21361.

**Files changed:**

- \`tidb-cloud/import-csv-files.md\` - rewrite the per-provider walkthroughs (S3, GCS, Azure Blob)
- \`tidb-cloud/import-parquet-files.md\` - same rewrite for Parquet
- \`tidb-cloud/troubleshoot-import-access-denied-error.md\` - replace literal sample IDs with placeholders + add discovery procedure

**Key changes (per provider walkthrough):**

- Replace per-provider \"Import Data from X\" pages with the unified \"Import Data from Cloud Storage\" page that exposes a **Storage Provider** dropdown
- Rename **File URI** / **Folder URI** to **Source Files URI** and document both single-file and folder URI formats
- Rename **Bucket Access** to **Credentials**; for AWS, point users at the **Having trouble? Create Role ARN manually** expandable to fetch the **TiDB Cloud Account ID** and **TiDB Cloud External ID** for their cluster
- Replace **Connect** + **Destination** + **Start Import** with the new **Destination Mapping** step that supports automatic mapping via file naming conventions or manual mapping rules with wildcard patterns
- Document the new **Pre-check** step (separate from manual scan retries)
- Preserve the Azure Blob Storage Private Link content from #22427

**Troubleshoot doc fix:**

The page previously hard-coded \`380838443567\` as \"the TiDB Cloud Account ID\" and a literal hex External ID. These values are environment-specific and per-cluster, so this PR replaces them with \`<TiDB-Cloud-Account-ID>\` and \`<TiDB-Cloud-External-ID>\` placeholders and adds a short discovery procedure that points users at the wizard's **Add New Role ARN** -> **Having trouble? Create Role ARN manually** expandable to fetch the actual values from the console.

## Background

Captured the new wizard end-to-end against three Dedicated clusters (AWS, Azure, GCP) on the staging deploy preview \`deploy-preview-4617--staging-tidbcloud.netlify.app\`. The full AS-IS report with screenshots, observations, and the doc-update plan is at https://pingcap.feishu.cn/wiki/I5lgwOQnSibElNka3U4cX899nud

Deferrals: Azure Blob and GCS provider walkthroughs were modeled after the Serverless rewrite (#21361) and the existing Azure Private Link content (#22427); they were not exercised end-to-end in this session and would benefit from a follow-up validation pass before the wizard ships to GA.

## Test plan

- [ ] Markdownlint passes locally
- [ ] Verify-link-anchors passes locally
- [ ] Vale CI passes
- [ ] Gemini Code Assist review
- [ ] Visual review of the rendered page in the docs preview environment
- [ ] Confirm the Azure Blob Storage Private Link section from #22427 is preserved

## Related

- DM-12710 (parent - Dedicated Data Import new UX)
- DM-12798 (bug filed: misleading \"Resource not found\" Pre-check error)
- DM-12799 (bug filed: outdated Account ID literal in troubleshoot doc - this PR resolves it)
- #21361 (precedent: Cloud: Import ux optimization for Serverless)
- #22427 (precedent: cloud: document Azure Blob Storage Private Link import)
- AS-IS report: https://pingcap.feishu.cn/wiki/I5lgwOQnSibElNka3U4cX899nud