### PR TITLE
tidb-cloud: add CREATE VIEW to DM target user GRANT example

### DIFF
--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -466,7 +466,7 @@ For production workloads, it is recommended to have a dedicated user for replica
 For example, you can execute the following `GRANT` statement in your target TiDB Cloud cluster to grant corresponding privileges:
 
 ```sql
-GRANT CREATE, SELECT, INSERT, UPDATE, DELETE, ALTER, DROP, INDEX ON *.* TO 'dm_target_user'@'%';
+GRANT CREATE, SELECT, INSERT, UPDATE, DELETE, ALTER, DROP, INDEX, CREATE VIEW ON *.* TO 'dm_target_user'@'%';
 ```
 
 ## Step 1: Go to the Data Migration page


### PR DESCRIPTION
## Summary

The privilege table on line 464 of `tidb-cloud/migrate-from-mysql-using-data-migration.md` already lists `CREATE VIEW` as required (for views used by migration), but the copy-pasteable `GRANT` example on line 469 omits it. This causes TiDB Lightning to abort at `errormanager.Init` with `Error 1142` for any user who follows the example literally.

This 1-line fix brings the GRANT example in line with the privilege table.

## Reproduction

Standalone Lightning lab covering 8 scenarios across logical and physical modes against TiDB v8.5.5: https://github.com/alastori/tidb-sandbox/pull/11

The diff in this PR is exactly the difference between scenarios L1 (fail with `Error 1142`) and L2 (clean exit) in the lab.

## Why this hasn't been a flood of reports

Most users grant `ALL PRIVILEGES` to the import target user, which silently includes `CREATE VIEW`. The bug is only visible to users who follow the docs literally and minimize grants for security or compliance reasons.

## Related

- pingcap/tidb#67598: upstream Lightning issue (opaque failure at `errormanager.Init`)
- pingcap/tidb#52306, pingcap/tidb#52307: design + implementation of `conflict_view` (2024)
- pingcap/tiflow#11811: sibling closed bug, same `errormanager.Init` failure path

## Follow-up (not in this PR)

- The same line 469 also exists on `master`. If preferred, the fix should be cherry-picked or a parallel master PR opened.
- `tidb-lightning/tidb-lightning-requirements.md` lines 26 and 61 (the OSS Lightning prereq doc) have the same gap and need a separate update.

## Test plan

- [x] No code changes; documentation-only fix.
- [x] Reproduction confirmed in 8-scenario lab against TiDB v8.5.5 + Lightning v8.5.5.
- [x] L1 (docs grant verbatim): `Error 1142`. L2 (docs grant + `CREATE VIEW`): clean exit. The diff in this PR is the difference between L1 and L2.

cc @gmhdbjd as DM lead and the engineer who closed the sibling Lightning errormanager bug (`pingcap/tiflow#11811`)
