### PR TITLE
ja translaton: support specifying files in translation cron

### DIFF
--- a/.github/workflows/translation-cron.yml
+++ b/.github/workflows/translation-cron.yml
@@ -5,6 +5,12 @@ on:
     # every Wednesday at 11:00 AM
     - cron: "0 11 * * 3"
   workflow_dispatch:
+    inputs:
+      file_names:
+        description: 'Specify file names to translate (comma-separated list)'
+        required: false
+        type: string
+        default: ''
 
 env:
   LTS_BRANCH: i18n-ja-release-8.5
@@ -24,7 +30,7 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ github.token }}" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/translation-zh.yaml/dispatches \
-          -d '{"ref":"master"}'
+          -d '{"ref":"master","inputs":{"file_names":${{ toJSON(inputs.file_names || '') }}}}'
 
   # build a matrix of branches to translate, including LTS and Cloud
   build-matrix:
@@ -75,6 +81,7 @@ jobs:
         with:
           config_file: latest_translation_commit.json
           working_directory: docs
+          files: ${{ inputs.file_names || '' }}
 
       - name: Show tmp directory structure
         run: |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Add a `file_names` input to the `translation-cron.yml` manual dispatch.
- Pass the specified files to the ZH translation workflow dispatch.
- Pass the same file list to the JA `file-diff-update` action so manual runs can translate selected files only.
- Keep the default empty input for scheduled runs so the existing commit-diff behavior is unchanged.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs/pull/21764

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "ok"' .github/workflows/translation-cron.yml`
- `git diff --check -- .github/workflows/translation-cron.yml`
