### PR TITLE
system variables: document tidb_opt_index_join_build_v2 compat

### DIFF
--- a/system-variable-reference.md
+++ b/system-variable-reference.md
@@ -3069,6 +3069,12 @@ Referenced in:
 - [System Variables](/system-variables.md#tidb_opt_hash_join_cost_factor-new-in-v853-and-v900)
 - [TiDB 8.5.3 Release Notes](/releases/release-8.5.3.md)
 
+### tidb_opt_index_join_build_v2
+
+Documents that refer to this variable:
+
+- [System Variables](/system-variables.md#tidb_opt_index_join_build_v2-introduced-in-v900)
+
 ### tidb_opt_index_join_cost_factor
 
 Referenced in:

--- a/system-variables.md
+++ b/system-variables.md
@@ -5201,6 +5201,17 @@ SHOW WARNINGS;
 - Range: `[0, 2147483647]`
 - Default value: `1`
 
+### `tidb_opt_index_join_build_v2` <span class="version-mark">New in v9.0.0</span>
+
+- Scope: SESSION | GLOBAL
+- Persists to cluster: Yes
+- Controlled by the Hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
+- Type: Boolean
+- Default value: `ON`
+- This variable is retained for compatibility only. TiDB always uses the Index Join build v2 path, and you cannot switch back to v1 through this variable.
+- If you set this variable to `OFF`, TiDB returns an error indicating that this capability is always enabled.
+- After upgrading from an earlier version, even if the historical value of this variable is retained in `mysql.global_variables`, TiDB still treats it as `ON`.
+
 ### tidb_opt_index_join_cost_factor <span class="version-mark">New in v8.5.3 and v9.0.0</span>
 
 > **Warning:**


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Document the compatibility behavior of `tidb_opt_index_join_build_v2`.

- Add the system variable entry in `system-variables.md`.
- Clarify that TiDB always uses index join build v2 now.
- Clarify that setting this variable to `OFF` returns an error and cannot switch back to v1.
- Clarify that historical values left in `mysql.global_variables` after upgrade are still treated as `ON`.
- Add the corresponding entry to `system-variable-reference.md`.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/21434
- Other reference link(s):
  - https://github.com/pingcap/tidb/pull/66871

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
