### PR TITLE
ci: remove ZH dispatch from JA translation cron

### DIFF
--- a/.github/workflows/translation-cron.yml
+++ b/.github/workflows/translation-cron.yml
@@ -1,8 +1,8 @@
-name: Translation Cron
+name: Translation Cron JA
 
 on:
   schedule:
-    # every Wednesday at 11:00 AM
+    # Runs JA translation every Wednesday at 11:00 UTC.
     - cron: "0 11 * * 3"
   workflow_dispatch:
     inputs:
@@ -17,22 +17,7 @@ env:
   CLOUD_BRANCH: i18n-ja-release-8.5
 
 jobs:
-  dispatch-translation-zh:
-    if: github.repository == 'pingcap/docs'
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - name: Dispatch translation-zh workflow
-        run: |
-          curl \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ github.token }}" \
-          https://api.github.com/repos/${{ github.repository }}/actions/workflows/translation-zh.yaml/dispatches \
-          -d '{"ref":"master","inputs":{"file_names":${{ toJSON(inputs.file_names || '') }}}}'
-
-  # build a matrix of branches to translate, including LTS and Cloud
+  # Build a matrix of JA branches to translate, including LTS and Cloud.
   build-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/translation-cron.yml
+++ b/.github/workflows/translation-cron.yml
@@ -2,7 +2,7 @@ name: Translation Cron JA
 
 on:
   schedule:
-    # Runs JA translation every Wednesday at 11:00 UTC.
+    # Runs JA translation at 19:00 every Wednesday (Beijing time, UTC+8)
     - cron: "0 11 * * 3"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

**Purpose:** 

This avoids duplicate ZH translation runs because `translation-zh.yaml` already has its own scheduled trigger.

**Changes:**

- Remove the `dispatch-translation-zh` job from `translation-cron.yml` so the JA translation cron no longer dispatches the ZH translation workflow.
- Rename the workflow to `Translation Cron JA` and clarify the JA-related schedule and matrix comments.



### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): `translation-zh.yaml` already schedules ZH translation directly.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

### Validation

- `git diff --check -- .github/workflows/translation-cron.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/translation-cron.yml"); puts "YAML ok"'`
