### PR TITLE
chore: include Premium TOC in Cloud ZH translation workflow

### DIFF
--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -19,7 +19,7 @@ env:
   SOURCE_REPO: pingcap/docs
   SOURCE_BRANCH: release-8.5
   CN_CLOUD_BRANCH: i18n-zh-release-8.5
-  CLOUD_TOC_FILES: TOC-tidb-cloud.md,TOC-tidb-cloud-starter.md,TOC-tidb-cloud-essential.md,TOC-tidb-cloud-releases.md
+  CLOUD_TOC_FILES: TOC-tidb-cloud.md,TOC-tidb-cloud-starter.md,TOC-tidb-cloud-essential.md,TOC-tidb-cloud-premium.md,TOC-tidb-cloud-releases.md
   AI_TRANSLATOR_REPO: qiancai/ai-pr-translator
   AI_TRANSLATOR_REF: main
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add `TOC-tidb-cloud-premium.md` to the Cloud ZH translation workflow scope so Premium documentation changes are included in the weekly automated Chinese translation.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

### Validation

- `git diff --check upstream/master..HEAD`
