### PR TITLE
zh translation workflow: fix manual Cloud translation cursor updates

### DIFF
--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -184,7 +184,12 @@ jobs:
             exit 0
           fi
 
-          python -c 'import json, os; from pathlib import Path; Path("latest_translation_commit.json").write_text(json.dumps({"target": os.environ["SOURCE_BRANCH"], "sha": os.environ["HEAD_REF"]}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            python -c 'import json, os; from pathlib import Path; Path("latest_translation_commit.json").write_text(json.dumps({"target": os.environ["SOURCE_BRANCH"], "sha": os.environ["HEAD_REF"]}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
+          else
+            echo "Skipping latest_translation_commit.json update for ${GITHUB_EVENT_NAME} run."
+          fi
+
           echo "has_changes=true" >> "${GITHUB_OUTPUT}"
 
       - name: Set build metadata


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR updates the Cloud ZH translation workflow so `latest_translation_commit.json` is only advanced during scheduled sync runs.

Manual `workflow_dispatch` runs that translate specific files now keep the translated file changes but skip the global cursor update. This prevents manually scoped translation PRs from moving the scheduled translation cursor.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- Other reference link(s): https://github.com/pingcap/docs/pull/22847

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
