### PR TITLE
cloud: clarify serverless private endpoint VPC scope

### DIFF
--- a/tidb-cloud/set-up-private-endpoint-connections-serverless.md
+++ b/tidb-cloud/set-up-private-endpoint-connections-serverless.md
@@ -53,7 +53,7 @@ To connect to your {{{ .starter }}} or {{{ .essential }}} instance via a private
 
     > **Note:**
     >
-    > For each VPC in an AWS Region, you only need to create one private endpoint. The endpoint can be used by all {{{ .starter }}} or {{{ .essential }}} instances in that Region from the same VPC, but cannot be shared across VPCs.
+    > For each VPC in an AWS region, you only need to create one private endpoint. The endpoint can be used by all {{{ .starter }}} or {{{ .essential }}} instances in that AWS region from the same VPC, but cannot be shared across VPCs.
 
 ### Step 2. Create an AWS interface endpoint
 

--- a/tidb-cloud/set-up-private-endpoint-connections-serverless.md
+++ b/tidb-cloud/set-up-private-endpoint-connections-serverless.md
@@ -53,7 +53,7 @@ To connect to your {{{ .starter }}} or {{{ .essential }}} instance via a private
 
     > **Note:**
     >
-    > You only need to create one private endpoint per AWS region, which can be shared by all {{{ .starter }}} or {{{ .essential }}} instances located in the same region.
+    > For each VPC in an AWS Region, you only need to create one private endpoint. The endpoint can be used by all {{{ .starter }}} or {{{ .essential }}} instances in that Region from the same VPC, but cannot be shared across VPCs.
 
 ### Step 2. Create an AWS interface endpoint
 
@@ -141,7 +141,7 @@ After you have created the interface endpoint, go back to the TiDB Cloud console
 >
 > If you cannot connect to the {{{ .starter }}} or Essential instance, the reason might be that the security group of your VPC endpoint in AWS is not properly set. See [this FAQ](#troubleshooting) for solutions.
 >
-> When creating a VPC endpoint, if you encounter an error `private-dns-enabled cannot be set because there is already a conflicting DNS domain for gatewayXX-privatelink.XX.prod.aws.tidbcloud.com in the VPC vpc-XXXXX`, it is due to that a private endpoint has already been created, and creating a new one is unnecessary.
+> When creating a VPC endpoint, if you encounter an error `private-dns-enabled cannot be set because there is already a conflicting DNS domain for gatewayXX-privatelink.XX.prod.aws.tidbcloud.com in the VPC vpc-XXXXX`, a private endpoint has already been created in that VPC, and creating another one for the same private DNS name is unnecessary.
 
 ## Troubleshooting
 

--- a/tidb-cloud/set-up-private-endpoint-connections-serverless.md
+++ b/tidb-cloud/set-up-private-endpoint-connections-serverless.md
@@ -53,7 +53,7 @@ To connect to your {{{ .starter }}} or {{{ .essential }}} instance via a private
 
     > **Note:**
     >
-    > For each VPC in an AWS region, you only need to create one private endpoint. The endpoint can be used by all {{{ .starter }}} or {{{ .essential }}} instances in that AWS region from the same VPC, but cannot be shared across VPCs.
+    > For each VPC in an AWS region, you only need to create one private endpoint. The endpoint can be used by all {{{ .starter }}} or {{{ .essential }}} instances in the same VPC of that AWS region , but cannot be shared across VPCs.
 
 ### Step 2. Create an AWS interface endpoint
 

--- a/tidb-cloud/set-up-private-endpoint-connections-serverless.md
+++ b/tidb-cloud/set-up-private-endpoint-connections-serverless.md
@@ -141,7 +141,7 @@ After you have created the interface endpoint, go back to the TiDB Cloud console
 >
 > If you cannot connect to the {{{ .starter }}} or Essential instance, the reason might be that the security group of your VPC endpoint in AWS is not properly set. See [this FAQ](#troubleshooting) for solutions.
 >
-> When creating a VPC endpoint, if you encounter an error `private-dns-enabled cannot be set because there is already a conflicting DNS domain for gatewayXX-privatelink.XX.prod.aws.tidbcloud.com in the VPC vpc-XXXXX`, a private endpoint has already been created in that VPC, and creating another one for the same private DNS name is unnecessary.
+> When creating a VPC endpoint, if you encounter an error `private-dns-enabled cannot be set because there is already a conflicting DNS domain for gatewayXX-privatelink.XX.prod.aws.tidbcloud.com in the VPC vpc-XXXXX`, a private endpoint already exists in that VPC. You do not need to create another one for the same private DNS name.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Clarify the customer-side scope of private endpoints for TiDB Cloud Starter or Essential instances over AWS PrivateLink:

- Clarify that for each VPC in an AWS Region, one private endpoint is enough for all Starter or Essential instances in that Region from the same VPC.
- Clarify that private endpoints cannot be shared across VPCs.
- Clarify the duplicate private DNS error tip by mentioning the existing endpoint is in the same VPC.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - https://docs.pingcap.com/zh/tidbcloud/set-up-private-endpoint-connections-serverless/?plan=starter
  - https://github.com/pingcap/docs/pull/13139

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch