### PR TITLE
Fix broken external links

### DIFF
--- a/dr-solution-introduction.md
+++ b/dr-solution-introduction.md
@@ -95,7 +95,7 @@ In this architecture, TiDB cluster 1 is deployed in region 1. BR regularly backs
 
 The DR solution based on BR provides an RPO lower than 5 minutes and an RTO that varies with the size of the data to be restored. For BR v6.5.0, you can refer to [Performance and impact of snapshot restore](/br/br-snapshot-guide.md#performance-and-impact-of-snapshot-restore) and [Performance and impact of PITR](/br/br-pitr-guide.md#performance-capabilities-of-pitr) to learn about the restore speed. Usually, the feature of backup across regions is considered the last resort of data security and also a must-have solution for most systems. For more information about this solution, see [DR solution based on BR](/dr-backup-restore.md).
 
-Meanwhile, starting from v6.5.0, BR supports [restoring a TiDB cluster from EBS volume snapshots](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-ebs-snapshot-across-multiple-kubernetes/#gatsby-focus-wrapper). If your cluster is running on Kubernetes and you want to restore the cluster as fast as possible without affecting the cluster, you can use this feature to reduce the RTO of your system.
+Meanwhile, starting from v6.5.0, BR supports [restoring a TiDB cluster from EBS volume snapshots](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-ebs-snapshot-across-multiple-kubernetes). If your cluster is running on Kubernetes and you want to restore the cluster as fast as possible without affecting the cluster, you can use this feature to reduce the RTO of your system.
 
 ### Other DR solutions
 

--- a/dr-solution-introduction.md
+++ b/dr-solution-introduction.md
@@ -95,7 +95,7 @@ In this architecture, TiDB cluster 1 is deployed in region 1. BR regularly backs
 
 The DR solution based on BR provides an RPO lower than 5 minutes and an RTO that varies with the size of the data to be restored. For BR v6.5.0, you can refer to [Performance and impact of snapshot restore](/br/br-snapshot-guide.md#performance-and-impact-of-snapshot-restore) and [Performance and impact of PITR](/br/br-pitr-guide.md#performance-capabilities-of-pitr) to learn about the restore speed. Usually, the feature of backup across regions is considered the last resort of data security and also a must-have solution for most systems. For more information about this solution, see [DR solution based on BR](/dr-backup-restore.md).
 
-Meanwhile, starting from v6.5.0, BR supports [restoring a TiDB cluster from EBS volume snapshots](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-aws-s3-by-snapshot). If your cluster is running on Kubernetes and you want to restore the cluster as fast as possible without affecting the cluster, you can use this feature to reduce the RTO of your system.
+Meanwhile, starting from v6.5.0, BR supports [restoring a TiDB cluster from EBS volume snapshots](https://docs.pingcap.com/tidb-in-kubernetes/stable/restore-from-ebs-snapshot-across-multiple-kubernetes/#gatsby-focus-wrapper). If your cluster is running on Kubernetes and you want to restore the cluster as fast as possible without affecting the cluster, you can use this feature to reduce the RTO of your system.
 
 ### Other DR solutions
 

--- a/grafana-tikv-dashboard.md
+++ b/grafana-tikv-dashboard.md
@@ -12,7 +12,7 @@ The Grafana dashboard is divided into a series of sub dashboards which include O
 
 ## TiKV-Details dashboard
 
-You can get an overview of the component TiKV status from the **TiKV-Details** dashboard, where the key metrics are displayed. According to the [Performance Map](https://asktug.com/_/tidb-performance-map/#/), you can check whether the status of the cluster is as expected.
+You can get an overview of the component TiKV status from the **TiKV-Details** dashboard, where the key metrics are displayed.
 
 This section provides a detailed description of these key metrics on the **TiKV-Details** dashboard.
 

--- a/tidb-cloud/data-service-integrations.md
+++ b/tidb-cloud/data-service-integrations.md
@@ -35,6 +35,6 @@ To integrate your Data App with GPTs, perform the following steps:
 
 ## Integrate your Data App with Dify
 
-You can integrate your Data App with [Dify](https://docs.dify.ai/guides/tools) to enhance your applications with intelligent capabilities, such as vector distance calculations, advanced similarity searches, and vector analysis.
+You can integrate your Data App with [Dify](https://dify.ai/) to enhance your applications with intelligent capabilities, such as vector distance calculations, advanced similarity searches, and vector analysis.
 
 To integrate your Data App with Dify, follow the same steps as for [GPTs integration](#integrate-your-data-app-with-gpts). The only difference is that on the **Integrations** tab, you need to click **Get Configuration** in the **Integrate with Dify** area.

--- a/tidb-cloud/integrate-tidbcloud-with-airbyte.md
+++ b/tidb-cloud/integrate-tidbcloud-with-airbyte.md
@@ -94,7 +94,7 @@ The following steps use TiDB as both a source and a destination. Other connector
 
     ![Set up connection](/media/tidb-cloud/integration-airbyte-connection.jpg)
 
-7. Set **Normalization & Transformation** to **Normalized tabular data** to use the default normalization mode, or you can set the dbt file for your job. For more information about normalization, refer to [Transformations and Normalization](https://docs.airbyte.com/operator-guides/transformation-and-normalization/transformations-with-dbt).
+7. Set **Normalization & Transformation** to **Normalized tabular data** to use the default normalization mode, or you can set the dbt file for your job.
 8. Click **Set up connection**.
 9. Once the connection is established, click **ENABLED** to activate the synchronization task. You can also click **Sync now** to sync immediately.
 

--- a/tidb-cloud/integrate-tidbcloud-with-zapier.md
+++ b/tidb-cloud/integrate-tidbcloud-with-zapier.md
@@ -17,7 +17,7 @@ This guide gives a high-level introduction to the TiDB Cloud app on Zapier and a
 
 ## Quick start with template
 
-[Zap Templates](https://platform.zapier.com/partners/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
+[Zap Templates](https://docs.zapier.com/integrations/publish/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
 
 In this section, we will use the **Add new Github global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
 

--- a/tidb-cloud/monitor-alert-flashduty.md
+++ b/tidb-cloud/monitor-alert-flashduty.md
@@ -23,7 +23,7 @@ To receive alert notifications of <CustomContent plan="essential">{{{ .essential
 
 ### Step 1. Generate a Flashduty webhook URL
 
-1. Generate a webhook URL by following the instructions in [Flashduty Prometheus Integration](https://docs.flashcat.cloud/en/flashduty/prometheus-integration-guide).
+1. Generate a webhook URL by following the instructions in [Flashduty Prometheus Integration](https://docs.flashcat.cloud/en/on-call/integration/alert-integration/alert-sources/prometheus).
 2. Save the generated webhook URL to use in the next step.
 
 ### Step 2. Subscribe from TiDB Cloud

--- a/tidb-cloud/releases/release-notes-2024.md
+++ b/tidb-cloud/releases/release-notes-2024.md
@@ -198,7 +198,7 @@ This page lists the release notes of [TiDB Cloud](https://www.pingcap.com/tidb-c
 
     If your table contains [vector data types](/ai/reference/vector-search-data-types.md), you can automatically generate a vector search endpoint that calculates vector distances based on your selected distance function.
 
-    This feature enables seamless integration with AI platforms such as [Dify](https://docs.dify.ai/guides/tools) and [GPTs](https://openai.com/blog/introducing-gpts), enhancing your applications with advanced natural language processing and AI capabilities for more complex tasks and intelligent solutions.
+    This feature enables seamless integration with AI platforms such as [Dify](https://dify.ai/) and [GPTs](https://openai.com/blog/introducing-gpts), enhancing your applications with advanced natural language processing and AI capabilities for more complex tasks and intelligent solutions.
 
     For more information, see [Generate an endpoint automatically](/tidb-cloud/data-service-manage-endpoint.md#generate-an-endpoint-automatically) and [Integrate a Data App with Third-Party Tools](/tidb-cloud/data-service-integrations.md).
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix broken external links reported in #22897:

- Update the TiDB Operator EBS snapshot restore link.
- Replace stale Dify, Zapier, and Flashduty documentation links with current destinations.
- Remove references to external pages that no longer have stable reachable targets.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): Fixes #22897

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
