### PR TITLE
cloud: document Essential and Premium transaction limits

### DIFF
--- a/follower-read.md
+++ b/follower-read.md
@@ -46,6 +46,14 @@ To enable TiDB's Follower Read feature, modify the value of the `tidb_replica_re
 set [session | global] tidb_replica_read = '<target value>';
 ```
 
+<CustomContent platform="tidb-cloud" plan="essential,premium">
+
+> **Note:**
+>
+> For [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium), `tidb_replica_read` is read-only and fixed to `leader`. Other read modes are not supported.
+
+</CustomContent>
+
 Scope: SESSION | GLOBAL
 
 Default: leader

--- a/pipelined-dml.md
+++ b/pipelined-dml.md
@@ -46,6 +46,14 @@ Currently, Pipelined DML has the following limitations:
     - When [foreign key constraints](/foreign-key.md) are enabled (`foreign_key_checks = ON`), target tables must not include foreign key relationships.
 - When executing `INSERT IGNORE ... ON DUPLICATE KEY UPDATE` statements, conflicting updates might result in `Duplicate entry` errors.
 
+<CustomContent platform="tidb-cloud" plan="essential,premium">
+
+> **Note:**
+>
+> Pipelined DML is not supported for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). You cannot enable Pipelined DML by setting [`tidb_dml_type`](/system-variables.md#tidb_dml_type-new-in-v800) to `"bulk"` or by using the [`SET_VAR`](/optimizer-hints.md#set_varvar_namevar_value) hint.
+
+</CustomContent>
+
 ## Usage
 
 This section describes how to enable Pipelined DML and verify whether it takes effect.

--- a/pipelined-dml.md
+++ b/pipelined-dml.md
@@ -50,7 +50,7 @@ Currently, Pipelined DML has the following limitations:
 
 > **Note:**
 >
-> Pipelined DML is not supported for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). You cannot enable Pipelined DML by setting [`tidb_dml_type`](/system-variables.md#tidb_dml_type-new-in-v800) to `"bulk"` or by using the [`SET_VAR`](/optimizer-hints.md#set_varvar_namevar_value) hint.
+> For [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium), Pipelined DML is not supported, and you cannot enable Pipelined DML by setting [`tidb_dml_type`](/system-variables.md#tidb_dml_type-new-in-v800) to `"bulk"` or by using the [`SET_VAR`](/optimizer-hints.md#set_varvar_namevar_value) hint.
 
 </CustomContent>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -5614,7 +5614,7 @@ SHOW WARNINGS;
 
 > **Note:**
 >
-> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter), [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential), and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). For [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium), the value is fixed to `leader`, and other read modes are not supported.
+> For [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter), [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential), and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium), this variable is read-only and fixed to `leader`, which means other read modes are not supported.
 
 </CustomContent>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1946,7 +1946,7 @@ Assume that you have a cluster with 4 TiDB nodes and multiple TiKV nodes. In thi
 
 > **Note:**
 >
-> This variable is read-only for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). The value is fixed to `"standard"`, so Pipelined DML cannot be enabled by setting this variable to `"bulk"`.
+> This variable is read-only for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). The value is fixed to `"standard"`, so you cannot enable Pipelined DML by setting this variable to `"bulk"`.
 
 </CustomContent>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1934,9 +1934,21 @@ Assume that you have a cluster with 4 TiDB nodes and multiple TiKV nodes. In thi
 >
 > The bulk DML execution mode (`tidb_dml_type = "bulk"`) is an experimental feature. It is not recommended that you use it in the production environment. This feature might be changed or removed without prior notice. If you find a bug, you can report an [issue](https://github.com/pingcap/tidb/issues). In the current version, when TiDB performs large transactions using the bulk DML mode, it might affect the memory usage and execution efficiency of TiCDC, TiFlash, and the resolved-ts module of TiKV, and might cause OOM issues. Additionally, BR might be blocked and fail to process when encountering locks. Therefore, it is not recommended to use this mode when these components or features are enabled.
 
+<CustomContent platform="tidb-cloud" plan="starter">
+
 > **Note:**
 >
-> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter) and [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential).
+> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter).
+
+</CustomContent>
+
+<CustomContent platform="tidb-cloud" plan="essential,premium">
+
+> **Note:**
+>
+> This variable is read-only for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). The value is fixed to `"standard"`, so Pipelined DML cannot be enabled by setting this variable to `"bulk"`.
+
+</CustomContent>
 
 - Scope: SESSION
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): Yes
@@ -5598,19 +5610,11 @@ SHOW WARNINGS;
 
 ### tidb_replica_read <span class="version-mark">New in v4.0</span>
 
-<CustomContent platform="tidb-cloud" plan="starter,essential">
+<CustomContent platform="tidb-cloud" plan="starter,essential,premium">
 
 > **Note:**
 >
-> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter) and [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential).
-
-</CustomContent>
-
-<CustomContent platform="tidb-cloud" plan="premium">
-
-> **Note:**
->
-> This variable is read-only for [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium).
+> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter), [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential), and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium). For [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium), the value is fixed to `leader`, and other read modes are not supported.
 
 </CustomContent>
 
@@ -6625,7 +6629,7 @@ For details, see [Identify Slow Queries](/identify-slow-queries.md).
 - Persists to cluster: Yes
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
 - Type: Enumeration
-- Default value: `FAST`
+- Default value: `STRICT` for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium); `FAST` for other deployment options
 - Possible values: `OFF`, `FAST`, `STRICT`
 - This variable is used to control the assertion level. Assertion is a consistency check between data and indexes, which checks whether a key being written exists in the transaction commit process. For more information, see [Troubleshoot Inconsistency Between Data and Indexes](/troubleshoot-data-inconsistency-errors.md).
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -882,7 +882,7 @@ For pessimistic transaction usage, refer to [TiDB Pessimistic Transaction Mode](
 + For scenarios with conflicts, after enabling this configuration, TiDB includes auto-commit transactions into the global lock-waiting management, which avoids deadlocks and mitigates the latency spike brought by deadlock-causing conflicts.
 + For scenarios with no conflicts, if there are many auto-commit transactions (the specific number is determined by the real scenarios. For example, the number of auto-commit transactions accounts for more than half of the total number of applications), and a single transaction operates a large data volume, enabling this configuration causes performance regression. For example, the auto-commit `INSERT INTO SELECT` statement.
 + When the session-level system variable [`tidb_dml_type`](/system-variables.md#tidb_dml_type-new-in-v800) is set to `"bulk"`, the effect of this configuration in the session is equivalent to setting it to `false`.
-+ Default value: `false`
++ Default value: `true` for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium); `false` for other deployment options
 
 ### constraint-check-in-place-pessimistic <span class="version-mark">New in v6.4.0</span>
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -882,7 +882,7 @@ For pessimistic transaction usage, refer to [TiDB Pessimistic Transaction Mode](
 + For scenarios with conflicts, after enabling this configuration, TiDB includes auto-commit transactions into the global lock-waiting management, which avoids deadlocks and mitigates the latency spike brought by deadlock-causing conflicts.
 + For scenarios with no conflicts, if there are many auto-commit transactions (the specific number is determined by the real scenarios. For example, the number of auto-commit transactions accounts for more than half of the total number of applications), and a single transaction operates a large data volume, enabling this configuration causes performance regression. For example, the auto-commit `INSERT INTO SELECT` statement.
 + When the session-level system variable [`tidb_dml_type`](/system-variables.md#tidb_dml_type-new-in-v800) is set to `"bulk"`, the effect of this configuration in the session is equivalent to setting it to `false`.
-+ Default value: `true` for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium); `false` for other deployment options
++ Default value: `false` for TiDB Self-Managed and [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter); `true` for [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) and [{{{ .premium }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier/#premium)
 
 ### constraint-check-in-place-pessimistic <span class="version-mark">New in v6.4.0</span>
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Document TiDB Cloud Essential and TiDB Cloud Premium behavior differences for transaction-related variables and configuration:

- `tidb_dml_type` is fixed to `"standard"`, so Pipelined DML cannot be enabled by setting it to `"bulk"`.
- `tidb_replica_read` is fixed to `leader`, and other read modes are not supported.
- `tidb_txn_assertion_level` defaults to `STRICT`.
- `pessimistic-auto-commit` defaults to `true`.
- Add corresponding notes to the Pipelined DML and Follower Read feature docs.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- Other reference link(s): pingcap/tidb#68388

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TiDB Cloud plan-specific restrictions for replica reads and Pipelined DML.
  * Documented plan-specific behavior for DML type, transaction assertion level, and replica read settings.
  * Updated the default `pessimistic-auto-commit` value for Essential and Premium TiDB Cloud clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->