### PR TITLE
docs: roll back v8.5.6 TopSQL multidimensional docs

### DIFF
--- a/dashboard/top-sql.md
+++ b/dashboard/top-sql.md
@@ -1,37 +1,32 @@
 ---
 title: TiDB Dashboard Top SQL page
-summary: Use Top SQL to identify queries that consume the most CPU, network, and logical IO resources
+summary: TiDB Dashboard Top SQL allows real-time monitoring and visualization of CPU overhead for SQL statements in your database. It helps optimize performance by identifying high CPU load statements and provides detailed execution information. It's suitable for analyzing performance issues and can be accessed through TiDB Dashboard or a browser. The feature has a slight impact on cluster performance and is now generally available for production use.
 ---
 
 # TiDB Dashboard Top SQL Page
 
-On the Top SQL page of TiDB Dashboard, you can view and analyze the most resource-consuming SQL queries on a specified TiDB or TiKV node over a period of time.
-
-- After you enable Top SQL, this feature continuously collects CPU workload data from existing TiDB and TiKV nodes and retains the data for up to 30 days.
-- Starting from v8.5.6, you can also enable **TiKV Network IO collection (multi-dimensional)** in the Top SQL settings to further view metrics such as `Network Bytes` and `Logical IO Bytes` for specified TiKV nodes, and perform aggregation analysis in dimensions of `By Query`, `By Table`, `By DB`, and `By Region`.
+With Top SQL, you can monitor and visually explore the CPU overhead of each SQL statement in your database in real-time, which helps you optimize and resolve database performance issues. Top SQL continuously collects and stores CPU load data summarized by SQL statements at any seconds from all TiDB and TiKV instances. The collected data can be stored for up to 30 days. Top SQL presents you with visual charts and tables to quickly pinpoint which SQL statements are contributing the high CPU load of a TiDB or TiKV instance over a certain period of time.
 
 Top SQL provides the following features:
 
-* Visualize the top `5`, `20`, or `100` SQL queries with the most resource consumption in the current time range through charts and tables, with the remaining records automatically summarized as `Others`.
-* Display resource consumption hotspots sorted by CPU time or network bytes. When selecting a TiKV node, you can also sort by logical IO bytes.
-* Display SQL and execution plan details by query. When selecting a TiKV node, you can also aggregate analysis in dimensions of `By Table`, `By DB`, and `By Region`.
-* Zoom in on a selected time range in the chart, manually refresh data, enable auto refresh, and export table data to CSV.
+* Visualize the top 5 types of SQL statements with the highest CPU overhead through charts and tables.
+* Display detailed execution information such as queries per second, average latency, and query plan.
 * Collect all SQL statements that are executed, including those that are still running.
-* Display data of a specific TiDB or TiKV node.
+* Allow viewing data of a specific TiDB and TiKV instance.
 
 ## Recommended scenarios
 
 Top SQL is suitable for analyzing performance issues. The following are some typical Top SQL scenarios:
 
-* You discovered that an individual TiDB or TiKV node in the cluster has a very high CPU usage. You want to quickly locate which type of SQL is consuming a lot of CPU resources.
-* The overall cluster queries become slow. You want to find out which SQL is currently consuming the most resources, or compare the main query differences before and after the workload changes.
-* You need to locate hotspots from a higher dimension and want to aggregate and view resource consumption on the TiKV side by `Table`, `DB`, or `Region`.
-* You need to troubleshoot TiKV hotspots from the perspective of network traffic or logical IO, not just limited to the CPU dimension.
+* You discovered that an individual TiKV instance in the cluster has a very high CPU usage through the Grafana charts. You want to know which SQL statements cause the CPU hotspots so that you can optimize them and better leverage all of your distributed resources.
+* You discovered that the cluster has a very high CPU usage overall and queries are slow. You want to quickly figure out which SQL statements are currently consuming the most CPU resources so that you can optimize them.
+* The CPU usage of the cluster has drastically changed and you want to know the major cause.
+* Analyze the most resource-intensive SQL statements in the cluster and optimize them to reduce hardware costs.
 
 Top SQL cannot be used in the following scenarios:
 
 - Top SQL cannot be used to pinpoint non-performance issues, such as incorrect data or abnormal crashes.
-- Top SQL is not suitable for directly analyzing lock conflicts, transaction semantic errors, or other issues not caused by resource consumption.
+- Top SQL does not support analyzing database performance issues that are not caused by high CPU load, such as transaction lock conflicts.
 
 ## Access the page
 
@@ -39,9 +34,9 @@ You can access the Top SQL page using either of the following methods:
 
 * After logging in to TiDB Dashboard, click **Top SQL** in the left navigation menu.
 
-  ![Top SQL](/media/dashboard/v8.5-top-sql-access.png)
+  ![Top SQL](/media/dashboard/top-sql-access.png)
 
-* Visit <http://127.0.0.1:2379/dashboard/#/topsql> in your browser. Replace `127.0.0.1:2379` with the actual PD node address and port.
+* Visit <http://127.0.0.1:2379/dashboard/#/topsql> in your browser. Replace `127.0.0.1:2379` with the actual PD instance address and port.
 
 ## Enable Top SQL
 
@@ -52,10 +47,10 @@ You can access the Top SQL page using either of the following methods:
 Top SQL is not enabled by default as it has a slight impact on cluster performance (within 3% on average) when enabled. You can enable Top SQL by the following steps:
 
 1. Visit the [Top SQL page](#access-the-page).
-2. Click **Open Settings**. In the **Settings** area on the right side of the page, enable the **Enable Feature** switch.
+2. Click **Open Settings**. On the right side of the **Settings** area, switch on **Enable Feature**.
 3. Click **Save**.
 
-After enabling Top SQL, you can only view data collected starting from this point in time, while historical data before enabling will not be backfilled. Data display usually has a delay of about 1 minute, so you need to wait a moment to see new data. After disabling Top SQL, if historical data has not expired, the Top SQL page still displays this historical data, but new data will no longer be collected or displayed.
+After enabling the feature, wait up to 1 minute for Top SQL to load the data. Then you can see the CPU load details.
 
 In addition to the UI, you can also enable the Top SQL feature by setting the TiDB system variable [`tidb_enable_top_sql`](/system-variables.md#tidb_enable_top_sql-new-in-v540):
 
@@ -65,103 +60,56 @@ In addition to the UI, you can also enable the Top SQL feature by setting the Ti
 SET GLOBAL tidb_enable_top_sql = 1;
 ```
 
-### (Optional) Enable TiKV Network IO collection <span class="version-mark">New in v8.5.6</span>
-
-To view Top SQL by `Order By Network` or `Order By Logical IO` for TiKV nodes, or to use the `By Region` aggregation, you can enable the **Enable TiKV Network IO collection (multi-dimensional)** switch in Top SQL settings and save the changes.
-
-- **Order By Network**: Sorts by the number of network bytes generated during TiKV request processing.
-- **Order By Logical IO**: Sorts by the amount of logical data (in bytes) processed by TiKV at the storage layer for TiKV requests, such as the data scanned or processed during reads and the data written by write requests.
-
-As shown in the following screenshot, the right **Settings** panel displays both the **Enable Feature** and **Enable TiKV Network IO collection (multi-dimensional)** switches.
-
-![Enable TiKV Network IO collection](/media/dashboard/v8.5-top-sql-settings-enable-tikv-network-io.png)
-
-**Enabling TiKV Network IO collection (multi-dimensional)** increases storage and query overhead. After enabling, the configuration is delivered to all current TiKV nodes; data display might also have a delay of about 1 minute. If some TiKV nodes fail to enable this feature, the page shows a warning, and new data might be incomplete.
-
-For newly added TiKV nodes, this switch does not take effect automatically. You need to set the **Enable TiKV Network IO collection (multi-dimensional)** switch to all enabled in the Top SQL settings panel and save, so the configuration is delivered to all TiKV nodes again. If you want newly added TiKV nodes to automatically enable this feature, add the following configuration under `server_configs.tikv` in the TiUP cluster topology file and use TiUP to re-deliver the TiKV configuration:
-
-```yaml
-server_configs:
-  tikv:
-    resource-metering.enable-network-io-collection: true
-```
-
-For more information about TiUP topology configuration, see [TiUP cluster topology file configuration](/tiup/tiup-cluster-topology-reference.md).
-
 ## Use Top SQL
 
 The following are the common steps to use Top SQL.
 
 1. Visit the [Top SQL page](#access-the-page).
 
-2. Select a particular TiDB or TiKV node that you want to observe the workload.
+2. Select a particular TiDB or TiKV instance that you want to observe the load.
 
-    ![Select a TiDB or TiKV node](/media/dashboard/v8.5-top-sql-usage-select-instance.png)
+    ![Select Instance](/media/dashboard/top-sql-usage-select-instance.png)
 
-    If you are not sure which node to observe, you can first locate the node with abnormal workload from Grafana or the [TiDB Dashboard Overview page](/dashboard/dashboard-overview.md), and then return to the Top SQL page for further analysis.
+    If you are unsure of which TiDB or TiKV instance to observe, you can select an arbitrary instance. Also, when the cluster CPU load is extremely unbalanced, you can first use Grafana charts to determine the specific instance you want to observe.
 
-3. Set the time range and refresh data as needed.
+3. Observe the charts and tables presented by Top SQL.
 
-    You can adjust the time range in the time picker or zoom the observation window by selecting a time range in the chart. Setting a smaller time range displays more fine-grained data, with a precision of up to 1 second.
+    ![Chart and Table](/media/dashboard/top-sql-usage-chart.png)
 
-    ![Change time range](/media/dashboard/v8.5-top-sql-usage-change-timerange.png)
+    The size of the bars in the bar chart represents the size of CPU resources consumed by the SQL statement at that moment. Different colors distinguish different types of SQL statements. In most cases, you only need to focus on the SQL statements that have a higher CPU resource overhead in the corresponding time range in the chart.
 
-    If the chart is out of date, click **Refresh** to refresh once, or select the data auto-refresh frequency from the **Refresh** drop-down list.
+4. Click a SQL statement in the table to show more information. You can see detailed execution metrics of different plans of that statement, such as Call/sec (average queries per second) and Scan Indexes/sec (average number of index rows scanned per second).
 
-    ![Refresh](/media/dashboard/v8.5-top-sql-usage-refresh.png)
+    ![Details](/media/dashboard/top-sql-details.png)
 
-4. Select the observation mode.
+5. Based on these initial clues, you can further explore the [SQL Statement](/dashboard/dashboard-statement-list.md) or [Slow Queries](/dashboard/dashboard-slow-query.md) page to find the root cause of high CPU consumption or large data scans of the SQL statement.
 
-    - Use `Limit` to display the Top `5`, `20`, or `100` SQL queries.
-    - The default aggregation dimension is `By Query`. If you select a TiKV node, you can also aggregate in dimensions of `By Table`, `By DB`, or `By Region`.
+    You can adjust the time range in the time picker or select a time range in the chart to get a more precise and detailed look at the problem. A smaller time range can provide more detailed data, with precision of up to 1 second.
 
-        ![Select aggregation dimension](/media/dashboard/v8.5-top-sql-usage-select-agg-by.png)
+    ![Change time range](/media/dashboard/top-sql-usage-change-timerange.png)
 
-    - The default sort order is `Order By CPU` (sorted by CPU time). If you select a TiKV node and have [enabled TiKV Network IO collection (multi-dimensional)](#optional-enable-tikv-network-io-collection-new-in-v856), you can also select `Order By Network` (sorted by network bytes) or `Order By Logical IO` (sorted by logical IO bytes).
+    If the chart is out of date, you can click the **Refresh** button or select Auto Refresh options from the **Refresh** drop-down list.
 
-        ![Select order by](/media/dashboard/v8.5-top-sql-usage-select-order-by.png)
+    ![Refresh](/media/dashboard/top-sql-usage-refresh.png)
 
-    > **Note**
-    >
-    > `By Region`, `Order By Network`, and `Order By Logical IO` are only available when [TiKV Network IO collection (multi-dimensional)](#optional-enable-tikv-network-io-collection-new-in-v856) is enabled. If this feature is not enabled but historical data still exists, the page continues to display historical data and prompt that new data cannot be fully collected.
+6. View the CPU resource usage by table or database level to quickly identify resource usage at a higher level. Currently, only TiKV instances are supported.
 
-5. Observe the resource consumption hotspot records in the chart and table.
+    Select a TiKV instance, and then select **By TABLE** or **By DB**:
 
-    ![Chart and Table](/media/dashboard/v8.5-top-sql-usage-chart.png)
+    ![Select aggregation dimension](/media/dashboard/top-sql-usage-select-agg-by.png)
 
-    The bar chart shows resource consumption under the current sort dimension, with different colors representing different records. The table displays cumulative values according to the current sort dimension, and provides an `Others` row at the end to summarize all non-Top N records.
+    View the aggregated results at a higher level:
 
-6. In the `By Query` view, click a row in the table to view the execution plan details for that type of SQL.
-
-    ![Details](/media/dashboard/v8.5-top-sql-details.png)
-
-    In the SQL statement details, you can view the corresponding SQL template, Query template ID, Plan template ID, and execution plan text. The SQL statement details table displays different metrics depending on the node type:
-
-    - TiDB nodes usually show `Call/sec` and `Latency/call`.
-    - TiKV nodes usually show `Call/sec`, `Scan Rows/sec`, and `Scan Indexes/sec`.
-
-    > **Note**
-    >
-    > If you select the `By Table`, `By DB`, or `By Region` aggregation view, the page displays the aggregation results and does not show SQL statement details by SQL execution plan.
-
-    In the `By Query` view, you can also click **Search in SQL Statements** in the Top SQL table to jump to the corresponding SQL Statement Analysis page. If you need to analyze the current table results offline, you can click **Download to CSV** above the table to export the current table data.
-
-7. On TiKV nodes, if you need to locate hotspots from a higher dimension, you can switch to `By Table`, `By DB`, or `By Region` to view the aggregated results.
-
-    ![Aggregated results at DB level](/media/dashboard/v8.5-top-sql-usage-agg-by-db-detail.png)
-
-8. Based on these initial clues, you can further analyze the root cause using the [SQL Statement](/dashboard/dashboard-statement-list.md) or [Slow Queries](/dashboard/dashboard-slow-query.md) page.
+    ![Aggregated results at DB level](/media/dashboard/top-sql-usage-agg-by-db-detail.png)
 
 ## Disable Top SQL
 
 You can disable this feature by following these steps:
 
-1. Visit the [Top SQL page](#access-the-page).
-2. Click the gear icon in the upper right corner to open the settings pane and disable the **Enable Feature** switch.
+1. Visit [Top SQL page](#access-the-page).
+2. Click the gear icon in the upper right corner to open the settings screen and switch off **Enable Feature**.
 3. Click **Save**.
 4. In the popped-up dialog box, click **Disable**.
-
-After you disable Top SQL, new Top SQL data collection will stop, but historical data can still be viewed before it expires.
 
 In addition to the UI, you can also disable the Top SQL feature by setting the TiDB system variable [`tidb_enable_top_sql`](/system-variables.md#tidb_enable_top_sql-new-in-v540):
 
@@ -171,15 +119,6 @@ In addition to the UI, you can also disable the Top SQL feature by setting the T
 SET GLOBAL tidb_enable_top_sql = 0;
 ```
 
-### Disable TiKV Network IO collection
-
-If you only want to stop collecting multi-dimensional data such as `Network Bytes` and `Logical IO Bytes` for TiKV, while retaining the CPU dimension analysis capability of Top SQL, disable the **Enable TiKV Network IO collection (multi-dimensional)** switch in the Top SQL settings panel.
-
-After disabling:
-
-- The Top SQL page can still display previously collected, unexpired historical network IO and logical IO data.
-- New network IO and logical IO data, as well as `By Region` data, will no longer be collected.
-
 ## Frequently asked questions
 
 **1. Top SQL cannot be enabled and the UI displays "required component NgMonitoring is not started"**.
@@ -188,37 +127,24 @@ See [TiDB Dashboard FAQ](/dashboard/dashboard-faq.md#a-required-component-ngmoni
 
 **2. Will performance be affected after enabling Top SQL?**
 
-Enabling Top SQL has a slight impact on cluster performance. According to measurements, the average performance impact is less than 3%. If you also enable TiKV Network IO collection (multi-dimensional), there will be additional storage and query overhead.
+This feature has a slight impact on cluster performance. According to our benchmark, the average performance impact is usually less than 3% when the feature is enabled.
 
 **3. What is the status of this feature?**
 
 It is now a generally available (GA) feature and can be used in production environments.
 
-**4. What does `Others` mean in the UI?**
+**4. What is the meaning of "Other Statements"?**
 
-`Others` represents the summary result of all non-Top N records under the current sort dimension. You can use it to understand how much of the total workload comes from the Top N records.
+"Other Statement" counts the total CPU overhead of all non-Top 5 statements. With this information, you can learn the CPU overhead contributed by the Top 5 statements compared with the overall.
 
 **5. What is the relationship between the CPU overhead displayed by Top SQL and the actual CPU usage of the process?**
 
 Their correlation is strong but they are not exactly the same thing. For example, the cost of writing multiple replicas is not counted in the TiKV CPU overhead displayed by Top SQL. In general, SQL statements with higher CPU usage result in higher CPU overhead displayed in Top SQL.
 
-**6. What does the Y-axis of the Top SQL chart mean?**
+**6. What is the meaning of the Y-axis of the Top SQL chart?**
 
-The Y-axis of the Top SQL chart represents the resource consumption under the current sort dimension.
-
-- When `Order By CPU` is selected, the Y-axis represents CPU time.
-- When `Order By Network` is selected, the Y-axis represents network bytes.
-- When `Order By Logical IO` is selected, the Y-axis represents logical IO bytes.
+It represents the size of CPU resources consumed. The more resources consumed by a SQL statement, the higher the value is. In most cases, you do not need to care about the meaning or unit of the specific value.
 
 **7. Does Top SQL collect running (unfinished) SQL statements?**
 
-Yes. After you enable Top SQL, TiDB Dashboard collects resource consumption for all running SQL statements, including unfinished ones.
-
-**8. Why is there no new data for `Order By Network`, `Order By Logical IO`, or `By Region`?**
-
-These views depend on TiKV Network IO collection (multi-dimensional). You can check the following items:
-
-- You have selected a TiKV node.
-- The **Enable TiKV Network IO collection (multi-dimensional)** switch in the Top SQL settings panel is enabled.
-- The relevant TiKV nodes in the cluster have all successfully enabled this configuration. If only some nodes enable this configuration, the Top SQL page prompts that new data might be incomplete.
-- For newly added TiKV nodes, you need to manually enable the **Enable TiKV Network IO collection (multi-dimensional)** switch in the Top SQL settings panel and save the changes again. To make this setting automatically enabled for newly added nodes, also enable `resource-metering.enable-network-io-collection` in the TiKV default configuration of TiUP.
+Yes. The bars displayed in the Top SQL chart at each moment indicate the CPU overhead of all running SQL statements at that moment.

--- a/releases/release-8.5.6.md
+++ b/releases/release-8.5.6.md
@@ -43,14 +43,6 @@ Quick access: [Quick start](https://docs.pingcap.com/tidb/v8.5/quick-start-with-
 
     For more information, see [documentation](https://docs.pingcap.com/tidb/v8.5/identify-slow-queries).
 
-- The Top SQL page in TiDB Dashboard now supports collecting and displaying TiKV network traffic and logical I/O metrics [#62916](https://github.com/pingcap/tidb/issues/62916) @[yibin87](https://github.com/yibin87)
-
-    In earlier versions, TiDB Dashboard identified Top SQL queries based only on CPU-related metrics, making it difficult to identify performance bottlenecks related to network or storage access in complex scenarios.
-
-    Starting from v8.5.6, you can enable **TiKV Network IO collection (multi-dimensional)** in the Top SQL settings to view metrics such as `Network Bytes` and `Logical IO Bytes` for TiKV nodes. You can also analyze these metrics across multiple dimensions, including `By Query`, `By Table`, `By DB`, and `By Region`, helping you identify resource hotspots more comprehensively.
-
-    For more information, see [documentation](https://docs.pingcap.com/tidb/v8.5/top-sql).
-
 ### SQL
 
 - Support column-level privilege management [#61706](https://github.com/pingcap/tidb/issues/61706) @[CbcWestwolf](https://github.com/CbcWestwolf) @[fzzf678](https://github.com/fzzf678)
@@ -117,7 +109,6 @@ For TiDB clusters newly deployed in v8.5.5 (that is, not upgraded from versions 
 | TiKV | [`gc.auto-compaction.mvcc-read-aware-enabled`](https://docs.pingcap.com/tidb/v8.5/tikv-configuration-file#mvcc-read-aware-enabled-new-in-v856) | Newly added | Controls whether to enable MVCC-read-aware compaction. The default value is `false`. |
 | TiKV | [`gc.auto-compaction.mvcc-read-weight`](https://docs.pingcap.com/tidb/v8.5/tikv-configuration-file#mvcc-read-weight-new-in-v856) | Newly added | The weight multiplier applied to MVCC read activity when calculating the compaction priority score for a Region. The default value is `3.0`. |
 | TiKV | [`gc.auto-compaction.mvcc-scan-threshold`](https://docs.pingcap.com/tidb/v8.5/tikv-configuration-file#mvcc-scan-threshold-new-in-v856) | Newly added | The minimum number of MVCC versions scanned per read request to mark a Region as a compaction candidate. The default value is `1000`. |
-| TiKV | [`resource-metering.enable-network-io-collection`](https://docs.pingcap.com/tidb/v8.5/tikv-configuration-file#enable-network-io-collection-new-in-v856) | Newly added | Controls whether TiKV network traffic and logical I/O metrics are additionally collected in Top SQL. The default value is `false`. |
 | TiCDC | [`sink.csv.output-field-header`](https://docs.pingcap.com/tidb/v8.5/ticdc-csv#use-csv) | Newly added | Controls whether a header row is output in CSV files. The default value is `false`. This parameter applies only to the TiCDC new architecture. |
 
 ### System table changes
@@ -143,8 +134,6 @@ For TiDB clusters newly deployed in v8.5.5 (that is, not upgraded from versions 
 
     - Introduce a load-based compaction mechanism, which detects MVCC read overhead and prioritizes compaction for Regions with higher read cost to improve query performance [#19133](https://github.com/tikv/tikv/issues/19133) @[mittalrishabh](https://github.com/mittalrishabh)
     - Optimize the stale range cleanup logic during cluster scale-out and scale-in operations by deleting stale keys directly instead of cleaning them up through SST file ingestion, thereby reducing the impact on online request latency [#18042](https://github.com/tikv/tikv/issues/18042) @[LykxSassinator](https://github.com/LykxSassinator)
-    - Support collecting TiKV network traffic and logical I/O metrics for Top SQL, which helps you diagnose SQL performance issues more accurately [#18815](https://github.com/tikv/tikv/issues/18815) @[yibin87](https://github.com/yibin87)
-
 + PD
 
     - Return `404` instead of `200` when deleting a non-existent label [#10089](https://github.com/tikv/pd/issues/10089) @[lhy1024](https://github.com/lhy1024)

--- a/tidb-cloud/tidb-cloud-clinic.md
+++ b/tidb-cloud/tidb-cloud-clinic.md
@@ -25,11 +25,11 @@ To view the **Cluster** page, take the following steps:
 
 2. From the organization list, select your target organization. The clusters in the selected project are displayed.
 
-3. Click the name of your target cluster. The cluster overview page is displayed, where you can view detailed information about your cluster, including:
+3. Click the name of your target TiDB Cloud Dedicated cluster. The cluster overview page is displayed, where you can view detailed information about your cluster, including:
 
     - Advanced Metrics
     - Top Slow Queries (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
-    - TopSQL (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
+    - Top SQL (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
     - Benchmark Report
 
 ## Monitor advanced metrics
@@ -91,21 +91,21 @@ The retention policy for slow queries is 7 days.
 
 For more information, see [Slow Queries in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-slow-query).
 
-## Monitor TopSQL
+## Monitor Top SQL
 
-TiDB Cloud Clinic provides TopSQL information, enabling you to monitor and visually explore the CPU overhead of each SQL statement in your database in real time. This helps you optimize and resolve database performance issues.
+TiDB Cloud Clinic provides Top SQL information to help you visually analyze the most resource-intensive queries on a specific TiDB or TiKV node over a period of time. By default, Top SQL continuously collects CPU load data. For TiKV nodes, if TiKV network IO collection is enabled, you can also inspect `Network Bytes` and `Logical IO Bytes`, and analyze hotspots by `Query`, `Table`, `DB`, or `Region`. This helps you identify and troubleshoot performance issues across multiple resource dimensions, not just CPU.
 
-To view TopSQL, take the following steps:
+To view Top SQL, take the following steps:
 
 1. In the [TiDB Cloud Clinic console](https://clinic.pingcap.com/), navigate to the **Cluster** page of a cluster.
 
-2. Click **TopSQL**.
+2. Click **Top SQL**.
 
-3. Select a specific TiDB or TiKV instance to observe its load. You can use the time picker or select a time range in the chart to refine your analysis.
+3. Select a specific TiDB or TiKV node to observe its workload. You can use the time picker or select a time range in the chart to refine your analysis.
 
-4. Analyze the charts and tables displayed by TopSQL.
+4. Analyze the charts and tables displayed by Top SQL. Depending on the selected node and enabled metrics, you can use `Order By` and the available aggregation dimensions to inspect CPU, network, or logical I/O hotspots.
 
-For more information, see [TopSQL in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/top-sql). 
+For more information, see [Top SQL in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/top-sql).
 
 ## Generate benchmark reports
 

--- a/tidb-cloud/tidb-cloud-clinic.md
+++ b/tidb-cloud/tidb-cloud-clinic.md
@@ -25,11 +25,11 @@ To view the **Cluster** page, take the following steps:
 
 2. From the organization list, select your target organization. The clusters in the selected project are displayed.
 
-3. Click the name of your target TiDB Cloud Dedicated cluster. The cluster overview page is displayed, where you can view detailed information about your cluster, including:
+3. Click the name of your target cluster. The cluster overview page is displayed, where you can view detailed information about your cluster, including:
 
     - Advanced Metrics
     - Top Slow Queries (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
-    - Top SQL (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
+    - TopSQL (only supported when the TiDB version of the cluster is v8.1.1 or later, v7.5.4 or later)
     - Benchmark Report
 
 ## Monitor advanced metrics
@@ -91,21 +91,21 @@ The retention policy for slow queries is 7 days.
 
 For more information, see [Slow Queries in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/dashboard-slow-query).
 
-## Monitor Top SQL
+## Monitor TopSQL
 
-TiDB Cloud Clinic provides Top SQL information to help you visually analyze the most resource-intensive queries on a specific TiDB or TiKV node over a period of time. By default, Top SQL continuously collects CPU load data. For TiKV nodes, if TiKV network IO collection is enabled, you can also inspect `Network Bytes` and `Logical IO Bytes`, and analyze hotspots by `Query`, `Table`, `DB`, or `Region`. This helps you identify and troubleshoot performance issues across multiple resource dimensions, not just CPU.
+TiDB Cloud Clinic provides TopSQL information, enabling you to monitor and visually explore the CPU overhead of each SQL statement in your database in real time. This helps you optimize and resolve database performance issues.
 
-To view Top SQL, take the following steps:
+To view TopSQL, take the following steps:
 
 1. In the [TiDB Cloud Clinic console](https://clinic.pingcap.com/), navigate to the **Cluster** page of a cluster.
 
-2. Click **Top SQL**.
+2. Click **TopSQL**.
 
-3. Select a specific TiDB or TiKV node to observe its workload. You can use the time picker or select a time range in the chart to refine your analysis.
+3. Select a specific TiDB or TiKV instance to observe its load. You can use the time picker or select a time range in the chart to refine your analysis.
 
-4. Analyze the charts and tables displayed by Top SQL. Depending on the selected node and enabled metrics, you can use `Order By` and the available aggregation dimensions to inspect CPU, network, or logical I/O hotspots.
+4. Analyze the charts and tables displayed by TopSQL.
 
-For more information, see [Top SQL in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/top-sql).
+For more information, see [TopSQL in TiDB Dashboard](https://docs.pingcap.com/tidb/stable/top-sql). 
 
 ## Generate benchmark reports
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1,14 +1,13 @@
 ---
 title: TiKV Configuration File
 summary: Learn the TiKV configuration file.
-aliases: ['/docs/dev/tikv-configuration-file/','/docs/dev/reference/configuration/tikv-server/configuration-file/']
 ---
 
 # TiKV Configuration File
 
 <!-- markdownlint-disable MD001 -->
 
-The TiKV configuration file supports more options than command-line parameters. You can find the default configuration file in [etc/config-template.toml](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) and rename it to `config.toml`.
+The TiKV configuration file supports more options than command-line parameters. You can find the default configuration file in [etc/config-template.toml](https://github.com/tikv/tikv/blob/release-8.5/etc/config-template.toml) and rename it to `config.toml`.
 
 This document only describes the parameters that are not included in command-line parameters. For more details, see [command-line parameter](/command-line-flags-for-tikv-configuration.md).
 
@@ -153,7 +152,7 @@ This document only describes the parameters that are not included in command-lin
 + The number of gRPC worker threads. When you modify the size of the gRPC thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: 
 
-    + Starting from v8.5.4 and v9.0.0, the default value is adjusted to `grpc-raft-conn-num * 3 + 2`, which is calculated based on the value of [`grpc-raft-conn-num`](#grpc-raft-conn-num). For example, when the number of CPU cores is 8, the default value of `grpc-raft-conn-num` is 1. Accordingly, the default value of `grpc-concurrency` is `1 * 3 + 2 = 5`.
+    + Starting from v8.5.4, the default value is adjusted to `grpc-raft-conn-num * 3 + 2`, which is calculated based on the value of [`grpc-raft-conn-num`](#grpc-raft-conn-num). For example, when the number of CPU cores is 8, the default value of `grpc-raft-conn-num` is 1. Accordingly, the default value of `grpc-concurrency` is `1 * 3 + 2 = 5`.
     + In v8.5.3 and earlier versions, the default value is `5`.
 
 + Minimum value: `1`
@@ -175,7 +174,7 @@ This document only describes the parameters that are not included in command-lin
 + The maximum number of connections between TiKV nodes for Raft communication
 + Default value: 
 
-    + Starting from v8.5.4 and v9.0.0, the default value is adjusted to `MAX(1, MIN(4, CPU cores / 8))`, where `MIN(4, CPU cores / 8)` indicates that when the number of CPU cores is greater than or equal to 32, the default maximum number of connections is 4. 
+    + Starting from v8.5.4, the default value is adjusted to `MAX(1, MIN(4, CPU cores / 8))`, where `MIN(4, CPU cores / 8)` indicates that when the number of CPU cores is greater than or equal to 32, the default maximum number of connections is 4. 
     + In v8.5.3 and earlier versions, the default value is `1`.
 
 + Minimum value: `1`
@@ -206,7 +205,7 @@ This document only describes the parameters that are not included in command-lin
 + Default value: `"3s"`
 + Minimum value: `"1s"`
 
-### `graceful-shutdown-timeout` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
+### `graceful-shutdown-timeout` <span class="version-mark">New in v8.5.5</span>
 
 + Specifies the timeout duration for TiKV graceful shutdown.
     + When this value is greater than `0s`, TiKV attempts to transfer all leaders on this node to other TiKV nodes within the specified timeout before shutting down. If there are still leaders that have not been transferred when the timeout is reached, TiKV skips the remaining leader transfers and proceeds directly to the shutdown process.
@@ -297,7 +296,7 @@ This document only describes the parameters that are not included in command-lin
 + Sets the size of the connection pool for service and forwarding requests to the server. Setting it to too small a value affects the request latency and load balancing.
 + Default value: `4`
 
-### `inspect-network-interval` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
+### `inspect-network-interval` <span class="version-mark">New in v8.5.5</span>
 
 + Controls the interval at which the TiKV HealthChecker actively performs network detection to PD and other TiKV nodes. TiKV calculates a `NetworkSlowScore` based on the network detection results and reports the network status of slow nodes to PD.
 + Setting this value to `0` disables the network detection. Setting it to a smaller value increases the detection frequency, which helps detect network jitter more quickly, but it also consumes more network bandwidth and CPU resources.
@@ -343,7 +342,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 + Controls whether to automatically adjust the thread pool size. When it is enabled, the read performance of TiKV is optimized by automatically adjusting the UnifyReadPool thread pool size based on the current CPU usage. The possible range of the thread pool is `[max-thread-count, MAX(4, CPU)]`. The maximum value is the same as the one of [`max-thread-count`](#max-thread-count).
 + Default value: `false`
 
-### `cpu-threshold` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
+### `cpu-threshold` <span class="version-mark">New in v8.5.5</span>
 
 + Specifies the CPU utilization threshold for the unified read pool. For example, if you set this value to `0.8`, the thread pool can use up to 80% of the CPU.
 
@@ -513,9 +512,9 @@ Configuration items related to storage.
 
 + When TiKV is started, some space is reserved on the disk as disk protection. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts: 80% of the reserved space is used as the extra disk space required for operations when the disk space is insufficient, and the other 20% is used to store the temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file serves as the last protection for restoring services.
 + The name of the temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, if you restart TiKV, the temporary file is automatically deleted and TiKV tries to reclaim the space.
-+ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the protection is related to the size of the reserved space. The size of the reserved space is the larger value between 5% of the disk capacity and this configuration value. When the value of this configuration item is `"0MiB"`, TiKV disables this disk protection feature.
++ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the protection is related to the size of the reserved space. The size of the reserved space is the larger value between 5% of the disk capacity and this configuration value. If this configuration item is set to `0`, or to a zero value with any supported unit (for example, `0KiB`, `0MiB`, or `0GiB`), TiKV disables this disk protection feature.
 + Default value: `"5GiB"`
-+ Unit: MiB|GiB
++ Unit: B|KB|KiB|MB|MiB|GB|GiB|TB|TiB|PB|PiB
 
 ### `enable-ttl`
 
@@ -636,33 +635,6 @@ Configuration items related to the I/O rate limiter.
 + Determines which types of I/O operations are counted and restrained below the `max-bytes-per-sec` threshold. Currently, only the write-only mode is supported.
 + Value options: `"read-only"`, `"write-only"`, and `"all-io"`
 + Default value: `"write-only"`
-
-## storage.max-ts
-
-Configuration items related to `max-ts`.
-
-`max-ts` is the maximum read timestamp known to the current TiKV node. It ensures linearizability and transaction concurrency control semantics for async commit and one-phase commit (1PC) transactions.
-
-### `action-on-invalid-update` <span class="version-mark">New in v9.0.0</span>
-
-+ Determines how TiKV handles invalid `max-ts` update requests. If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and [`max-drift`](#max-drift-new-in-v900)**, TiKV considers it an invalid `max-ts` update request. Invalid `max-ts` update requests might break the linearizability and transaction concurrency control semantics of the TiDB cluster.
-+ Value options:
-    + `"panic"`: TiKV panics. If the PD TSO cached in TiKV is not updated in time, TiKV uses an approximate method for validation, in which case invalid requests do not cause TiKV panic.
-    + `"error"`: TiKV returns an error and stops processing the request.
-    + `"log"`: TiKV prints an error log but still processes the request.
-+ Default value: `"panic"`
-
-### `cache-sync-interval` <span class="version-mark">New in v9.0.0</span>
-
-+ Controls the interval at which TiKV updates its local PD TSO cache. TiKV periodically retrieves the latest timestamp from PD and caches it locally to check the validity of `max-ts`.
-+ Default value: `"15s"`
-
-### `max-drift` <span class="version-mark">New in v9.0.0</span>
-
-+ Specifies the maximum time by which the timestamp of a read or write request can exceed the PD TSO cached in TiKV.
-+ If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and `max-drift`**, TiKV considers it an invalid `max-ts` update request and handles it according to the [`action-on-invalid-update`](#action-on-invalid-update-new-in-v900) configuration.
-+ Default value: `"60s"`
-+ It is recommended to set this value to at least three times the value of [`cache-sync-interval`](#cache-sync-interval-new-in-v900).
 
 ## pd
 
@@ -865,7 +837,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.check-interval`](#check-interval-new-in-v757-v854-and-v900).
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.check-interval`](#check-interval-new-in-v757-and-v854).
 
 + The time interval at which to check whether it is necessary to manually trigger RocksDB compaction. `0` means that this feature is disabled.
 + Default value: `"5m"`
@@ -875,7 +847,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated.
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated.
 
 + The number of Regions checked at one time for each round of manual compaction
 + Default value:
@@ -888,7 +860,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-v854-and-v900).
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-and-v854).
 
 + The number of tombstones required to trigger RocksDB compaction
 + Default value: `10000`
@@ -898,7 +870,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-v854-and-v900).
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-and-v854).
 
 + The proportion of tombstone required to trigger RocksDB compaction
 + Default value: `30`
@@ -909,7 +881,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-v854-and-v900).
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-and-v854).
 
 + The number of redundant MVCC rows required to trigger RocksDB compaction.
 + Default value: `50000`
@@ -919,7 +891,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-v854-and-v900).
+> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-and-v854).
 
 + The percentage of redundant MVCC rows required to trigger RocksDB compaction.
 + Default value: `20`
@@ -1196,7 +1168,7 @@ Configuration items related to Raftstore.
 ### `inspect-kvdb-interval` <span class="version-mark">New in v8.1.2</span>
 
 + The interval and timeout for checking the KV disk during slow node detection in TiKV. If KVDB and RaftDB share the same mount path, this value is overridden by `0` (no detection).
-+ Default value: `2s`
++ Default value: `100ms`. In v8.5.2 and earlier versions, the default value is `2s`.
 
 ### `min-pending-apply-region-count` <span class="version-mark">New in v8.0.0</span>
 
@@ -1326,7 +1298,7 @@ Configuration items related to RocksDB
 ### `max-manifest-file-size`
 
 + The maximum size of a RocksDB Manifest file
-+ Default value: `"256MiB"`. Before v8.5.4 and v9.0.0, the default value is `"128MiB"`.
++ Default value: `"256MiB"`. For v8.5.3 and earlier v8.5.x versions, the default value is `"128MiB"`.
 + Minimum value: `0`
 + Unit: B|KiB|MiB|GiB
 
@@ -1706,7 +1678,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 + The maximum number of files at L0 that trigger write stall.
 + In v8.5.4 and earlier versions: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is directly overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold).
-+ Starting from v8.5.5 and v9.0.0: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold) only when its value is greater than `storage.flow-control.l0-files-threshold`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
++ Starting from v8.5.5: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold) only when its value is greater than `storage.flow-control.l0-files-threshold`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
 + Default value: `20`
 + Minimum value: `0`
 
@@ -1764,7 +1736,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 + The soft limit on the pending compaction bytes.
 + In v8.5.4 and earlier versions: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is directly overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit).
-+ Starting from v8.5.5 and v9.0.0: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit) only when its value is greater than `storage.flow-control.soft-pending-compaction-bytes-limit`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
++ Starting from v8.5.5: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit) only when its value is greater than `storage.flow-control.soft-pending-compaction-bytes-limit`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
 + Default value: `"192GiB"`
 + Unit: KiB|MiB|GiB
 
@@ -2333,60 +2305,60 @@ Configuration items related to TiDB Lightning import and BR restore.
 
 Configures the behavior of TiKV automatic compaction.
 
-### `check-interval` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `check-interval` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
 + The interval at which TiKV checks whether to trigger automatic compaction. Within this interval, Regions that meet the automatic compaction conditions are processed based on priority. When the interval elapses, TiKV rescans Region information and recalculates priorities.
 + Default value: `"300s"`
 
-### `tombstone-num-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `tombstone-num-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
-+ The number of RocksDB tombstones required to trigger TiKV automatic compaction. When the number of tombstones reaches this threshold, or when the percentage of tombstones reaches [`tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
++ The number of RocksDB tombstones required to trigger TiKV automatic compaction. When the number of tombstones reaches this threshold, or when the percentage of tombstones reaches [`tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is disabled.
 + Default value: `10000`
 + Minimum value: `0`
 
-### `tombstone-percent-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `tombstone-percent-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
-+ The percentage of RocksDB tombstones required to trigger TiKV automatic compaction. When the percentage of tombstones reaches this threshold, or when the number of tombstones reaches [`tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
++ The percentage of RocksDB tombstones required to trigger TiKV automatic compaction. When the percentage of tombstones reaches this threshold, or when the number of tombstones reaches [`tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is disabled.
 + Default value: `30`
 + Minimum value: `0`
 + Maximum value: `100`
 
-### `redundant-rows-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `redundant-rows-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
-+ The number of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches this threshold, or when the percentage of these rows reaches [`redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
++ The number of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches this threshold, or when the percentage of these rows reaches [`redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is enabled.
 + Default value: `50000`
 + Minimum value: `0`
 
-### `redundant-rows-percent-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `redundant-rows-percent-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
-+ The percentage of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches [`redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-v854-and-v900), or when the percentage of these rows reaches `redundant-rows-percent-threshold`, TiKV triggers automatic compaction.
++ The percentage of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches [`redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-and-v854), or when the percentage of these rows reaches `redundant-rows-percent-threshold`, TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is enabled.
 + Default value: `20`
 + Minimum value: `0`
 + Maximum value: `100`
 
-### `bottommost-level-force` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
+### `bottommost-level-force` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
 
 + Controls whether to force compaction on the bottommost files in RocksDB.
 + Default value: `true`
 
-### `mvcc-read-aware-enabled` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
+### `mvcc-read-aware-enabled` <span class="version-mark">New in v8.5.6</span>
 
 + Controls whether to enable MVCC-read-aware compaction. When enabled, TiKV tracks the number of MVCC versions scanned during read requests and uses this information to prioritize compaction for Regions with high MVCC read amplification. This reduces read latency for hot Regions that encounter many stale versions during scans.
 + Default value: `false`
 
-### `mvcc-scan-threshold` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
+### `mvcc-scan-threshold` <span class="version-mark">New in v8.5.6</span>
 
-+ The minimum number of MVCC versions scanned per read request to mark a Region as a compaction candidate. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856-and-v900) is set to `true`.
++ The minimum number of MVCC versions scanned per read request to mark a Region as a compaction candidate. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856) is set to `true`.
 + Default value: `1000`
 + Minimum value: `0`
 
-### `mvcc-read-weight` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
+### `mvcc-read-weight` <span class="version-mark">New in v8.5.6</span>
 
-+ The weight multiplier applied to MVCC read activity when calculating the compaction priority score for a Region. A higher value gives more weight to MVCC read amplification relative to other compaction triggers, such as tombstone density. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856-and-v900) is set to `true`.
++ The weight multiplier applied to MVCC read activity when calculating the compaction priority score for a Region. A higher value gives more weight to MVCC read amplification relative to other compaction triggers, such as tombstone density. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856) is set to `true`.
 + Default value: `3.0`
 + Minimum value: `0.0`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1,13 +1,14 @@
 ---
 title: TiKV Configuration File
 summary: Learn the TiKV configuration file.
+aliases: ['/docs/dev/tikv-configuration-file/','/docs/dev/reference/configuration/tikv-server/configuration-file/']
 ---
 
 # TiKV Configuration File
 
 <!-- markdownlint-disable MD001 -->
 
-The TiKV configuration file supports more options than command-line parameters. You can find the default configuration file in [etc/config-template.toml](https://github.com/tikv/tikv/blob/release-8.5/etc/config-template.toml) and rename it to `config.toml`.
+The TiKV configuration file supports more options than command-line parameters. You can find the default configuration file in [etc/config-template.toml](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) and rename it to `config.toml`.
 
 This document only describes the parameters that are not included in command-line parameters. For more details, see [command-line parameter](/command-line-flags-for-tikv-configuration.md).
 
@@ -152,7 +153,7 @@ This document only describes the parameters that are not included in command-lin
 + The number of gRPC worker threads. When you modify the size of the gRPC thread pool, refer to [Performance tuning for TiKV thread pools](/tune-tikv-thread-performance.md#performance-tuning-for-tikv-thread-pools).
 + Default value: 
 
-    + Starting from v8.5.4, the default value is adjusted to `grpc-raft-conn-num * 3 + 2`, which is calculated based on the value of [`grpc-raft-conn-num`](#grpc-raft-conn-num). For example, when the number of CPU cores is 8, the default value of `grpc-raft-conn-num` is 1. Accordingly, the default value of `grpc-concurrency` is `1 * 3 + 2 = 5`.
+    + Starting from v8.5.4 and v9.0.0, the default value is adjusted to `grpc-raft-conn-num * 3 + 2`, which is calculated based on the value of [`grpc-raft-conn-num`](#grpc-raft-conn-num). For example, when the number of CPU cores is 8, the default value of `grpc-raft-conn-num` is 1. Accordingly, the default value of `grpc-concurrency` is `1 * 3 + 2 = 5`.
     + In v8.5.3 and earlier versions, the default value is `5`.
 
 + Minimum value: `1`
@@ -174,7 +175,7 @@ This document only describes the parameters that are not included in command-lin
 + The maximum number of connections between TiKV nodes for Raft communication
 + Default value: 
 
-    + Starting from v8.5.4, the default value is adjusted to `MAX(1, MIN(4, CPU cores / 8))`, where `MIN(4, CPU cores / 8)` indicates that when the number of CPU cores is greater than or equal to 32, the default maximum number of connections is 4. 
+    + Starting from v8.5.4 and v9.0.0, the default value is adjusted to `MAX(1, MIN(4, CPU cores / 8))`, where `MIN(4, CPU cores / 8)` indicates that when the number of CPU cores is greater than or equal to 32, the default maximum number of connections is 4. 
     + In v8.5.3 and earlier versions, the default value is `1`.
 
 + Minimum value: `1`
@@ -205,7 +206,7 @@ This document only describes the parameters that are not included in command-lin
 + Default value: `"3s"`
 + Minimum value: `"1s"`
 
-### `graceful-shutdown-timeout` <span class="version-mark">New in v8.5.5</span>
+### `graceful-shutdown-timeout` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
 
 + Specifies the timeout duration for TiKV graceful shutdown.
     + When this value is greater than `0s`, TiKV attempts to transfer all leaders on this node to other TiKV nodes within the specified timeout before shutting down. If there are still leaders that have not been transferred when the timeout is reached, TiKV skips the remaining leader transfers and proceeds directly to the shutdown process.
@@ -296,7 +297,7 @@ This document only describes the parameters that are not included in command-lin
 + Sets the size of the connection pool for service and forwarding requests to the server. Setting it to too small a value affects the request latency and load balancing.
 + Default value: `4`
 
-### `inspect-network-interval` <span class="version-mark">New in v8.5.5</span>
+### `inspect-network-interval` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
 
 + Controls the interval at which the TiKV HealthChecker actively performs network detection to PD and other TiKV nodes. TiKV calculates a `NetworkSlowScore` based on the network detection results and reports the network status of slow nodes to PD.
 + Setting this value to `0` disables the network detection. Setting it to a smaller value increases the detection frequency, which helps detect network jitter more quickly, but it also consumes more network bandwidth and CPU resources.
@@ -342,7 +343,7 @@ Configuration items related to the single thread pool serving read requests. Thi
 + Controls whether to automatically adjust the thread pool size. When it is enabled, the read performance of TiKV is optimized by automatically adjusting the UnifyReadPool thread pool size based on the current CPU usage. The possible range of the thread pool is `[max-thread-count, MAX(4, CPU)]`. The maximum value is the same as the one of [`max-thread-count`](#max-thread-count).
 + Default value: `false`
 
-### `cpu-threshold` <span class="version-mark">New in v8.5.5</span>
+### `cpu-threshold` <span class="version-mark">New in v8.5.5 and v9.0.0</span>
 
 + Specifies the CPU utilization threshold for the unified read pool. For example, if you set this value to `0.8`, the thread pool can use up to 80% of the CPU.
 
@@ -512,9 +513,9 @@ Configuration items related to storage.
 
 + When TiKV is started, some space is reserved on the disk as disk protection. When the remaining disk space is less than the reserved space, TiKV restricts some write operations. The reserved space is divided into two parts: 80% of the reserved space is used as the extra disk space required for operations when the disk space is insufficient, and the other 20% is used to store the temporary file. In the process of reclaiming space, if the storage is exhausted by using too much extra disk space, this temporary file serves as the last protection for restoring services.
 + The name of the temporary file is `space_placeholder_file`, located in the `storage.data-dir` directory. When TiKV goes offline because its disk space ran out, if you restart TiKV, the temporary file is automatically deleted and TiKV tries to reclaim the space.
-+ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the protection is related to the size of the reserved space. The size of the reserved space is the larger value between 5% of the disk capacity and this configuration value. If this configuration item is set to `0`, or to a zero value with any supported unit (for example, `0KiB`, `0MiB`, or `0GiB`), TiKV disables this disk protection feature.
++ When the remaining space is insufficient, TiKV does not create the temporary file. The effectiveness of the protection is related to the size of the reserved space. The size of the reserved space is the larger value between 5% of the disk capacity and this configuration value. When the value of this configuration item is `"0MiB"`, TiKV disables this disk protection feature.
 + Default value: `"5GiB"`
-+ Unit: B|KB|KiB|MB|MiB|GB|GiB|TB|TiB|PB|PiB
++ Unit: MiB|GiB
 
 ### `enable-ttl`
 
@@ -635,6 +636,33 @@ Configuration items related to the I/O rate limiter.
 + Determines which types of I/O operations are counted and restrained below the `max-bytes-per-sec` threshold. Currently, only the write-only mode is supported.
 + Value options: `"read-only"`, `"write-only"`, and `"all-io"`
 + Default value: `"write-only"`
+
+## storage.max-ts
+
+Configuration items related to `max-ts`.
+
+`max-ts` is the maximum read timestamp known to the current TiKV node. It ensures linearizability and transaction concurrency control semantics for async commit and one-phase commit (1PC) transactions.
+
+### `action-on-invalid-update` <span class="version-mark">New in v9.0.0</span>
+
++ Determines how TiKV handles invalid `max-ts` update requests. If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and [`max-drift`](#max-drift-new-in-v900)**, TiKV considers it an invalid `max-ts` update request. Invalid `max-ts` update requests might break the linearizability and transaction concurrency control semantics of the TiDB cluster.
++ Value options:
+    + `"panic"`: TiKV panics. If the PD TSO cached in TiKV is not updated in time, TiKV uses an approximate method for validation, in which case invalid requests do not cause TiKV panic.
+    + `"error"`: TiKV returns an error and stops processing the request.
+    + `"log"`: TiKV prints an error log but still processes the request.
++ Default value: `"panic"`
+
+### `cache-sync-interval` <span class="version-mark">New in v9.0.0</span>
+
++ Controls the interval at which TiKV updates its local PD TSO cache. TiKV periodically retrieves the latest timestamp from PD and caches it locally to check the validity of `max-ts`.
++ Default value: `"15s"`
+
+### `max-drift` <span class="version-mark">New in v9.0.0</span>
+
++ Specifies the maximum time by which the timestamp of a read or write request can exceed the PD TSO cached in TiKV.
++ If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and `max-drift`**, TiKV considers it an invalid `max-ts` update request and handles it according to the [`action-on-invalid-update`](#action-on-invalid-update-new-in-v900) configuration.
++ Default value: `"60s"`
++ It is recommended to set this value to at least three times the value of [`cache-sync-interval`](#cache-sync-interval-new-in-v900).
 
 ## pd
 
@@ -837,7 +865,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.check-interval`](#check-interval-new-in-v757-and-v854).
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.check-interval`](#check-interval-new-in-v757-v854-and-v900).
 
 + The time interval at which to check whether it is necessary to manually trigger RocksDB compaction. `0` means that this feature is disabled.
 + Default value: `"5m"`
@@ -847,7 +875,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated.
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated.
 
 + The number of Regions checked at one time for each round of manual compaction
 + Default value:
@@ -860,7 +888,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-and-v854).
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-v854-and-v900).
 
 + The number of tombstones required to trigger RocksDB compaction
 + Default value: `10000`
@@ -870,7 +898,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-and-v854).
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-v854-and-v900).
 
 + The proportion of tombstone required to trigger RocksDB compaction
 + Default value: `30`
@@ -881,7 +909,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-and-v854).
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-v854-and-v900).
 
 + The number of redundant MVCC rows required to trigger RocksDB compaction.
 + Default value: `50000`
@@ -891,7 +919,7 @@ Configuration items related to Raftstore.
 
 > **Warning:**
 >
-> Starting from v7.5.7 and v8.5.4, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-and-v854).
+> Starting from v7.5.7, v8.5.4, and v9.0.0, this configuration item is deprecated and replaced by [`gc.auto-compaction.redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-v854-and-v900).
 
 + The percentage of redundant MVCC rows required to trigger RocksDB compaction.
 + Default value: `20`
@@ -1168,7 +1196,7 @@ Configuration items related to Raftstore.
 ### `inspect-kvdb-interval` <span class="version-mark">New in v8.1.2</span>
 
 + The interval and timeout for checking the KV disk during slow node detection in TiKV. If KVDB and RaftDB share the same mount path, this value is overridden by `0` (no detection).
-+ Default value: `100ms`. In v8.5.2 and earlier versions, the default value is `2s`.
++ Default value: `2s`
 
 ### `min-pending-apply-region-count` <span class="version-mark">New in v8.0.0</span>
 
@@ -1298,7 +1326,7 @@ Configuration items related to RocksDB
 ### `max-manifest-file-size`
 
 + The maximum size of a RocksDB Manifest file
-+ Default value: `"256MiB"`. For v8.5.3 and earlier v8.5.x versions, the default value is `"128MiB"`.
++ Default value: `"256MiB"`. Before v8.5.4 and v9.0.0, the default value is `"128MiB"`.
 + Minimum value: `0`
 + Unit: B|KiB|MiB|GiB
 
@@ -1678,7 +1706,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 + The maximum number of files at L0 that trigger write stall.
 + In v8.5.4 and earlier versions: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is directly overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold).
-+ Starting from v8.5.5: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold) only when its value is greater than `storage.flow-control.l0-files-threshold`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
++ Starting from v8.5.5 and v9.0.0: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), the value of this configuration item is overridden by [`storage.flow-control.l0-files-threshold`](/tikv-configuration-file.md#l0-files-threshold) only when its value is greater than `storage.flow-control.l0-files-threshold`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
 + Default value: `20`
 + Minimum value: `0`
 
@@ -1736,7 +1764,7 @@ Configuration items related to `rocksdb.defaultcf`, `rocksdb.writecf`, and `rock
 
 + The soft limit on the pending compaction bytes.
 + In v8.5.4 and earlier versions: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is directly overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit).
-+ Starting from v8.5.5: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit) only when its value is greater than `storage.flow-control.soft-pending-compaction-bytes-limit`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
++ Starting from v8.5.5 and v9.0.0: when the flow control mechanism is enabled ([`storage.flow-control.enable`](/tikv-configuration-file.md#enable) is `true`), this configuration item is overridden by [`storage.flow-control.soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit) only when its value is greater than `storage.flow-control.soft-pending-compaction-bytes-limit`. This behavior prevents weakening RocksDB's compaction acceleration mechanism when you increase the flow control threshold.
 + Default value: `"192GiB"`
 + Unit: KiB|MiB|GiB
 
@@ -2305,60 +2333,60 @@ Configuration items related to TiDB Lightning import and BR restore.
 
 Configures the behavior of TiKV automatic compaction.
 
-### `check-interval` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `check-interval` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
 + The interval at which TiKV checks whether to trigger automatic compaction. Within this interval, Regions that meet the automatic compaction conditions are processed based on priority. When the interval elapses, TiKV rescans Region information and recalculates priorities.
 + Default value: `"300s"`
 
-### `tombstone-num-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `tombstone-num-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
-+ The number of RocksDB tombstones required to trigger TiKV automatic compaction. When the number of tombstones reaches this threshold, or when the percentage of tombstones reaches [`tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
++ The number of RocksDB tombstones required to trigger TiKV automatic compaction. When the number of tombstones reaches this threshold, or when the percentage of tombstones reaches [`tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is disabled.
 + Default value: `10000`
 + Minimum value: `0`
 
-### `tombstone-percent-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `tombstone-percent-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
-+ The percentage of RocksDB tombstones required to trigger TiKV automatic compaction. When the percentage of tombstones reaches this threshold, or when the number of tombstones reaches [`tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
++ The percentage of RocksDB tombstones required to trigger TiKV automatic compaction. When the percentage of tombstones reaches this threshold, or when the number of tombstones reaches [`tombstone-num-threshold`](#tombstone-num-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is disabled.
 + Default value: `30`
 + Minimum value: `0`
 + Maximum value: `100`
 
-### `redundant-rows-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `redundant-rows-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
-+ The number of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches this threshold, or when the percentage of these rows reaches [`redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-and-v854), TiKV triggers automatic compaction.
++ The number of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches this threshold, or when the percentage of these rows reaches [`redundant-rows-percent-threshold`](#redundant-rows-percent-threshold-new-in-v757-v854-and-v900), TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is enabled.
 + Default value: `50000`
 + Minimum value: `0`
 
-### `redundant-rows-percent-threshold` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `redundant-rows-percent-threshold` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
-+ The percentage of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches [`redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-and-v854), or when the percentage of these rows reaches `redundant-rows-percent-threshold`, TiKV triggers automatic compaction.
++ The percentage of redundant MVCC rows required to trigger TiKV automatic compaction. Redundant rows include RocksDB tombstones, TiKV stale versions, and TiKV deletion tombstones. When the number of redundant MVCC rows reaches [`redundant-rows-threshold`](#redundant-rows-threshold-new-in-v757-v854-and-v900), or when the percentage of these rows reaches `redundant-rows-percent-threshold`, TiKV triggers automatic compaction.
 + This configuration item takes effect only when [Compaction Filter](/garbage-collection-configuration.md) is enabled.
 + Default value: `20`
 + Minimum value: `0`
 + Maximum value: `100`
 
-### `bottommost-level-force` <span class="version-mark">New in v7.5.7 and v8.5.4</span>
+### `bottommost-level-force` <span class="version-mark">New in v7.5.7, v8.5.4, and v9.0.0</span>
 
 + Controls whether to force compaction on the bottommost files in RocksDB.
 + Default value: `true`
 
-### `mvcc-read-aware-enabled` <span class="version-mark">New in v8.5.6</span>
+### `mvcc-read-aware-enabled` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
 
 + Controls whether to enable MVCC-read-aware compaction. When enabled, TiKV tracks the number of MVCC versions scanned during read requests and uses this information to prioritize compaction for Regions with high MVCC read amplification. This reduces read latency for hot Regions that encounter many stale versions during scans.
 + Default value: `false`
 
-### `mvcc-scan-threshold` <span class="version-mark">New in v8.5.6</span>
+### `mvcc-scan-threshold` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
 
-+ The minimum number of MVCC versions scanned per read request to mark a Region as a compaction candidate. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856) is set to `true`.
++ The minimum number of MVCC versions scanned per read request to mark a Region as a compaction candidate. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856-and-v900) is set to `true`.
 + Default value: `1000`
 + Minimum value: `0`
 
-### `mvcc-read-weight` <span class="version-mark">New in v8.5.6</span>
+### `mvcc-read-weight` <span class="version-mark">New in v8.5.6 and v9.0.0</span>
 
-+ The weight multiplier applied to MVCC read activity when calculating the compaction priority score for a Region. A higher value gives more weight to MVCC read amplification relative to other compaction triggers, such as tombstone density. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856) is set to `true`.
++ The weight multiplier applied to MVCC read activity when calculating the compaction priority score for a Region. A higher value gives more weight to MVCC read amplification relative to other compaction triggers, such as tombstone density. This configuration item takes effect only when [`mvcc-read-aware-enabled`](#mvcc-read-aware-enabled-new-in-v856-and-v900) is set to `true`.
 + Default value: `3.0`
 + Minimum value: `0.0`
 
@@ -2660,24 +2688,6 @@ To reduce write latency, TiKV periodically fetches and caches a batch of timesta
 + The maximum number of TSOs in a timestamp request.
 + In a default TSO physical time update interval (`50ms`), PD provides at most 262144 TSOs. When requested TSOs exceed this number, PD provides no more TSOs. This configuration item is used to avoid exhausting TSOs and the reverse impact of TSO exhaustion on other businesses. If you increase the value of this configuration item to improve high availability, you need to decrease the value of [`tso-update-physical-interval`](/pd-configuration-file.md#tso-update-physical-interval) at the same time to get enough TSOs.
 + Default value: `8192`
-
-## resource-metering
-
-Configuration items related to resource metering.
-
-### `enable-network-io-collection` <span class="version-mark">New in v8.5.6</span>
-
-+ Controls whether to collect TiKV network traffic and logical I/O information in [Top SQL](/dashboard/top-sql.md) in addition to CPU data.
-+ When enabled, TiKV additionally records inbound network bytes, outbound network bytes, logical read bytes, and logical write bytes during request processing.
-+ When reporting resource consumption, TiKV filters the Top N records based on CPU time, network traffic, and logical I/O, and additionally reports these statistics by Region for more fine-grained analysis of hotspot requests or resource usage sources.
-+ Default value: `false`
-
-> **Note:**
->
-> Logical I/O is not equivalent to physical I/O and cannot be directly correlated:
->
-> - Logical I/O refers to the logical amount of data processed by requests at the TiKV storage layer, such as data scanned or processed during reads and data written by write requests.
-> - Physical I/O refers to the actual disk read/write traffic on the underlying storage device, which is affected by block cache, compaction, flush, and other factors.
 
 ## resource-control
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- roll back the v8.5.6 TopSQL multidimensional docs changes introduced by #22734
- revert the related Top SQL, TiKV configuration, and TiDB Cloud Clinic descriptions to remove unsupported network IO and logical IO guidance in v8.5.6
- remove the related promotion from `releases/release-8.5.6.md`

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
  - https://github.com/pingcap/docs-cn/pull/21652
- Other reference link(s):
  - https://github.com/pingcap/docs/pull/22734

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
