### PR TITLE
cloud: mark Alibaba Cloud private endpoint auth optional

### DIFF
--- a/tidb-cloud/set-up-private-endpoint-connections-on-alibaba-cloud.md
+++ b/tidb-cloud/set-up-private-endpoint-connections-on-alibaba-cloud.md
@@ -22,7 +22,7 @@ To connect to your {{{ .starter }}} or {{{ .essential }}} instance via a private
 
 1. [Choose a {{{ .starter }}} or Essential instance](#step-1-choose-a-tidb-instance)
 2. [Create a private endpoint on Alibaba Cloud](#step-2-create-a-private-endpoint-on-alibaba-cloud)
-3. [Authorize your private endpoint in TiDB Cloud](#step-3-authorize-your-private-endpoint-in-tidb-cloud)
+3. [Authorize your private endpoint in TiDB Cloud (optional)](#step-3-authorize-your-private-endpoint-in-tidb-cloud-optional)
 4. [Connect to your {{{ .starter }}} or Essential instance using the private endpoint](#step-4-connect-to-your-instance-using-the-private-endpoint)
 
 ### Step 1. Choose a {{{ .starter }}} or Essential instance {#step-1-choose-a-tidb-instance}
@@ -51,9 +51,13 @@ To use the Alibaba Cloud Management Console to create a VPC interface endpoint, 
 8. Click **OK** to create the endpoint.
 9. Wait for the endpoint status to become **Active** and the connection status to become **Connected**.
 
-### Step 3. Authorize your private endpoint in TiDB Cloud
+### Step 3. Authorize your private endpoint in TiDB Cloud (optional)
 
-After creating the interface endpoint on Alibaba Cloud, you must add it to the allowlist of your target {{{ .starter }}} or {{{ .essential }}} instance.
+> **Note:**
+>
+> This step is optional. You only need to configure **Authorized Networks** when you want to restrict access to specific private endpoint connections. If no rules are configured, all private endpoint connections are allowed by default.
+
+After creating the interface endpoint on Alibaba Cloud, you can authorize it for your target {{{ .starter }}} or {{{ .essential }}} instance to restrict access.
 
 1. On the [**My TiDB**](https://tidbcloud.com/tidbs) page, click the name of your target {{{ .starter }}} or {{{ .essential }}} instance to go to its overview page.
 2. Click **Settings** > **Networking** in the left navigation pane.
@@ -65,8 +69,9 @@ After creating the interface endpoint on Alibaba Cloud, you must add it to the a
     - **Your Endpoint ID**: paste your 23-character endpoint ID from the Alibaba Cloud Management Console (starts with `ep-`).
 
     > **Tip:**
-    > 
-    > To allow all Private Endpoint connections from your cloud region (for testing or open access), enter a single asterisk (`*`) in the **Your Endpoint ID** field.
+    >
+    > - If you leave the **Authorized Networks** table empty, all private endpoint connections are allowed by default.
+    > - To allow all private endpoint connections from your cloud region (for testing or open access), enter a single asterisk (`*`) in the **Your Endpoint ID** field.
 
 5. Click **Submit**.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Mark Step 3 in the Alibaba Cloud private endpoint doc as optional.
- Align the Authorized Networks behavior with the serverless AWS private endpoint doc: empty rules allow all private endpoint connections by default.
- Add the empty-table note while preserving the Alibaba Cloud endpoint ID wording.

A follow-up to #22843.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): #22843

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

### Check

- [x] `../scripts/markdownlint tidb-cloud/set-up-private-endpoint-connections-on-alibaba-cloud.md`
- [x] `git diff --check -- set-up-private-endpoint-connections-on-alibaba-cloud.md`