### PR TITLE
Translate SQL statement headings to English

### DIFF
--- a/sql-statements/sql-statement-delete.md
+++ b/sql-statements/sql-statement-delete.md
@@ -3,7 +3,7 @@ title: DELETE | TiDB SQL Statement Reference
 summary: TiDB データベースにおける DELETE の使用法の概要。
 ---
 
-# 消去 {#delete}
+# DELETE {#delete}
 
 `DELETE`ステートメントは、指定されたテーブルから行を削除します。
 

--- a/sql-statements/sql-statement-drop-database.md
+++ b/sql-statements/sql-statement-drop-database.md
@@ -3,7 +3,7 @@ title: DROP DATABASE | TiDB SQL Statement Reference
 summary: TiDB データベースの DROP DATABASE の使用法の概要。
 ---
 
-# データベースの削除 {#drop-database}
+# DROP DATABASE {#drop-database}
 
 `DROP DATABASE`文は、指定されたデータベーススキーマと、その中に作成されたすべてのテーブルとビューを永久に削除します。削除されたデータベースに関連付けられているユーザー権限は影響を受けません。
 

--- a/sql-statements/sql-statement-drop-index.md
+++ b/sql-statements/sql-statement-drop-index.md
@@ -3,7 +3,7 @@ title: DROP INDEX | TiDB SQL Statement Reference
 summary: TiDB データベースの DROP INDEX の使用法の概要。
 ---
 
-# インデックスの削除 {#drop-index}
+# DROP INDEX {#drop-index}
 
 このステートメントは、指定されたテーブルからインデックスを削除し、TiKV 内の領域を空きとしてマークします。
 

--- a/sql-statements/sql-statement-drop-resource-group.md
+++ b/sql-statements/sql-statement-drop-resource-group.md
@@ -3,7 +3,7 @@ title: DROP RESOURCE GROUP
 summary: TiDBにおけるDROP RESOURCE GROUPの使い方を学びましょう。
 ---
 
-# リソースグループを削除する {#drop-resource-group}
+# DROP RESOURCE GROUP {#drop-resource-group}
 
 `DROP RESOURCE GROUP`ステートメントを使用してリソース グループを削除できます。
 

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -3,7 +3,7 @@ title: DROP TABLE | TiDB SQL Statement Reference
 summary: TiDB データベースの DROP TABLE の使用法の概要。
 ---
 
-# テーブルを削除 {#drop-table}
+# DROP TABLE {#drop-table}
 
 このステートメントは、現在選択されているデータベースからテーブルを削除します。テーブルが存在しない場合は、 `IF EXISTS`修飾子を使用しない限り、エラーが返されます。
 

--- a/sql-statements/sql-statement-drop-user.md
+++ b/sql-statements/sql-statement-drop-user.md
@@ -3,7 +3,7 @@ title: DROP USER | TiDB SQL Statement Reference
 summary: TiDB データベースの DROP USER の使用法の概要。
 ---
 
-# ユーザーを削除 {#drop-user}
+# DROP USER {#drop-user}
 
 この文は、TiDBシステムデータベースからユーザーを削除します。オプションのキーワード`IF EXISTS`使用すると、ユーザーが存在しない場合にエラーを出力しません。この文には`CREATE USER`権限が必要です。
 

--- a/sql-statements/sql-statement-truncate.md
+++ b/sql-statements/sql-statement-truncate.md
@@ -3,7 +3,7 @@ title: TRUNCATE | TiDB SQL Statement Reference
 summary: TiDB データベースにおける TRUNCATE の使用法の概要。
 ---
 
-# 切り捨て {#truncate}
+# TRUNCATE {#truncate}
 
 `TRUNCATE`ステートメントは、非トランザクション方式でテーブルからすべてのデータを削除します。3 `TRUNCATE` 、前の定義の`DROP TABLE` + `CREATE TABLE`と意味的に同じであると考えることができます。
 


### PR DESCRIPTION
This PR changes the Markdown headings (H1/H2/H3) of SQL statement reference pages from Japanese translations back to their original English SQL keywords.

This makes the headings consistent with:
- The page file names (e.g., `sql-statement-truncate.md`)
- The SQL keywords used in code blocks
- Other language versions of the documentation

**Pages updated:**
- `# 切り捨て` → `# TRUNCATE`
- `# 消去` → `# DELETE`
- `# テーブルを削除` → `# DROP TABLE`
- `# ユーザーを削除` → `# DROP USER`
- `# データベースの削除` → `# DROP DATABASE`
- `# インデックスの削除` → `# DROP INDEX`
- `# リソースグループを削除する` → `# DROP RESOURCE GROUP`
- `privilege-management.md`: `### テーブルを切り捨てる` → `### TRUNCATE TABLE`
- `ai/guides/tables.md`: `## テーブル切り捨てる` → `## TRUNCATE TABLE`

Body text and descriptions are left unchanged.