### PR TITLE
Clarify temporary PD lifecycle in pd-recover

### DIFF
--- a/pd-recover.md
+++ b/pd-recover.md
@@ -62,7 +62,7 @@ Since this method relies on a minority PD node to recover the service, the node 
 
 ### Step 4: Restart the PD node
 
-Once you see the prompt message `recovery is successful`, stop the temporary PD process started with `--force-new-cluster` in Step 2, and then restart the PD node normally without the `--force-new-cluster` parameter.
+Once you see the prompt message `recovery is successful`, stop the temporary PD process that starts with `--force-new-cluster` in Step 2, and then restart the PD node normally without the `--force-new-cluster` parameter.
 
 ### Step 5: Scale out PD and start the cluster
 

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -39,6 +39,8 @@ Start the surviving PD node using the `--force-new-cluster` startup parameter, a
 ./bin/pd-server --force-new-cluster --name=pd-127.0.0.10-2379 --data-dir=/path/to/existing/pd/data --client-urls=http://0.0.0.0:2379 --advertise-client-urls=http://127.0.0.1:2379 --peer-urls=http://0.0.0.0:2380 --advertise-peer-urls=http://127.0.0.1:2380 --config=conf/pd.toml
 ```
 
+This command starts a temporary single-node PD, allowing `pd-recover` in the next step to connect and repair the metadata. Keep this PD process running, and perform the next step in another terminal window.
+
 > **Note:**
 >
 > - If `--data-dir` is not specified in the command line, ensure that `data-dir` in `conf/pd.toml` correctly points to the original data directory of the surviving PD node. Otherwise `pd-recover` might fail in subsequent operations.
@@ -60,11 +62,11 @@ Since this method relies on a minority PD node to recover the service, the node 
 
 ### Step 4: Restart the PD node
 
-Once you see the prompt message `recovery is successful`, restart the PD node.
+Once you see the prompt message `recovery is successful`, stop the temporary PD process started with `--force-new-cluster` in Step 2, and then restart the PD node normally without the `--force-new-cluster` parameter.
 
 ### Step 5: Scale out PD and start the cluster
 
-Scale out the PD cluster using the deployment tool and start the other components in the cluster. At this point, the PD service is available.
+After confirming that the PD in Step 4 has started normally and is providing service, scale out the PD cluster using the deployment tool and start the other components in the cluster. At this point, the service is restored.
 
 ## Method 2: Entirely rebuild a PD cluster
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

补充 `pd-recover` 从存活 PD 节点重建集群时的步骤依赖说明：

- 第 2 步启动的 `--force-new-cluster` PD 是临时单节点 PD，需要保持运行，供第 3 步 `pd-recover` 连接。
- 第 3 步需要另开终端窗口执行。
- 第 4 步明确需要停止第 2 步的临时 PD，并不带 `--force-new-cluster` 正常重启。
- 第 5 步明确在 PD 正常启动并提供服务后再扩容 PD 和启动其他组件。

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/21676
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
