### PR TITLE
workflows: support source PR range sync

### DIFF
--- a/.github/workflows/sync-doc-pr-zh-to-en.yml
+++ b/.github/workflows/sync-doc-pr-zh-to-en.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       source_pr_url:
-        description: 'Source PR URL (Chinese docs repository)'
+        description: 'Source PR URL, or PR files commit range URL (Chinese docs repository)'
         required: true
         type: string
         default: ''
@@ -62,19 +62,26 @@ jobs:
           SOURCE_URL: ${{ github.event.inputs.source_pr_url }}
           TARGET_URL: ${{ github.event.inputs.target_pr_url }}
         run: |
-          if [[ ! "$SOURCE_URL" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
+          SOURCE_PATTERN='^https://github\.com/(pingcap)/(docs-cn)/pull/([0-9]+)(/files/([0-9a-fA-F]{7,40})\.\.([0-9a-fA-F]{7,40}))?/?(\?[-A-Za-z0-9._~=&%]*)?$'
+          TARGET_PATTERN='^https://github\.com/(pingcap)/(docs)/pull/([0-9]+)/?(\?[-A-Za-z0-9._~=&%]*)?$'
+
+          if [[ ! "$SOURCE_URL" =~ $SOURCE_PATTERN ]]; then
             echo "❌ Invalid source PR URL format"; exit 1
           fi
-          if [[ ! "$TARGET_URL" =~ ^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$ ]]; then
+          SOURCE_OWNER="${BASH_REMATCH[1]}"
+          SOURCE_REPO="${BASH_REMATCH[2]}"
+          SOURCE_PR="${BASH_REMATCH[3]}"
+          SOURCE_RANGE=""
+          if [[ -n "${BASH_REMATCH[5]}" && -n "${BASH_REMATCH[6]}" ]]; then
+            SOURCE_RANGE="${BASH_REMATCH[5]}..${BASH_REMATCH[6]}"
+          fi
+
+          if [[ ! "$TARGET_URL" =~ $TARGET_PATTERN ]]; then
             echo "❌ Invalid target PR URL format"; exit 1
           fi
-          
-          SOURCE_OWNER=$(echo "$SOURCE_URL" | cut -d'/' -f4)
-          SOURCE_REPO=$(echo "$SOURCE_URL" | cut -d'/' -f5)
-          SOURCE_PR=$(echo "$SOURCE_URL" | cut -d'/' -f7)
-          TARGET_OWNER=$(echo "$TARGET_URL" | cut -d'/' -f4)
-          TARGET_REPO=$(echo "$TARGET_URL" | cut -d'/' -f5)
-          TARGET_PR=$(echo "$TARGET_URL" | cut -d'/' -f7)
+          TARGET_OWNER="${BASH_REMATCH[1]}"
+          TARGET_REPO="${BASH_REMATCH[2]}"
+          TARGET_PR="${BASH_REMATCH[3]}"
 
           if [[ "$SOURCE_OWNER/$SOURCE_REPO" != "pingcap/docs-cn" ]]; then
             echo "❌ Unsupported source repository: only pingcap/docs-cn is supported"; exit 1
@@ -92,7 +99,11 @@ jobs:
             echo "target_pr<<EOF"; echo "$TARGET_PR"; echo "EOF"
           } >> $GITHUB_OUTPUT
           
-          echo "Source: ${SOURCE_OWNER}/${SOURCE_REPO}#${SOURCE_PR}"
+          if [[ -n "$SOURCE_RANGE" ]]; then
+            echo "Source: ${SOURCE_OWNER}/${SOURCE_REPO}#${SOURCE_PR} (${SOURCE_RANGE})"
+          else
+            echo "Source: ${SOURCE_OWNER}/${SOURCE_REPO}#${SOURCE_PR}"
+          fi
           echo "Target: ${TARGET_OWNER}/${TARGET_REPO}#${TARGET_PR}"
 
       - name: Get target PR branch info


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the `sync-doc-pr-zh-to-en` workflow so the source PR input accepts either a plain `pingcap/docs-cn` PR URL or a PR files commit-range URL such as `https://github.com/pingcap/docs-cn/pull/<pr>/files/<base>..<head>`.

This is intended to support syncing incremental updates from an existing Chinese source PR into an existing English target PR after an earlier translation run has already completed. With this change, maintainers can provide only the new source diff range, and the workflow will pass that full range URL to `ai-pr-translator` while still keeping the target PR URL as a plain `pingcap/docs` PR.

Benefits:

- The workflow no longer rejects valid PR files commit-range URLs before `ai-pr-translator` runs.
- Plain PR URLs continue to work for both source and target inputs.
- Source and target repositories are validated explicitly as `pingcap/docs-cn` and `pingcap/docs`.
- URL parsing uses regex capture instead of `cut`, which makes PR number extraction safer for range URLs and optional query strings.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - `.github/workflows/sync-doc-pr-zh-to-en.yml`

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch