### PR TITLE
lake: update TiDB Cloud Lake quick start steps

### DIFF
--- a/tidb-cloud-lake/lake-quick-start.md
+++ b/tidb-cloud-lake/lake-quick-start.md
@@ -1,6 +1,6 @@
 ---
 title: TiDB Cloud Lake Quick Start
-summary: Get started with TiDB Cloud Lake in three steps — sign up, create a warehouse, and explore it.
+summary: Get started with TiDB Cloud Lake in three steps — sign up, initialize TiDB Cloud Lake, and explore your workspace.
 ---
 
 # TiDB Cloud Lake Quick Start
@@ -13,25 +13,28 @@ This tutorial guides you through an easy way to get started with TiDB Cloud Lake
 
 2. Sign up for a TiDB Cloud account or log in with your existing account.
 
-## Step 2. Create a warehouse
+## Step 2. Initialize TiDB Cloud Lake
 
 1. In the left navigation bar, click **My Lake**.
 
-2. In the upper-right corner, click **Create Warehouse**.
+2. In the upper-right corner, click **Try TiDB Cloud Lake**. A new tab opens.
 
-3. On the **Create Warehouse** page, configure the following settings:
+3. Follow the onscreen instructions to initialize TiDB Cloud Lake:
 
-    - **Warehouse Name**: enter a name for your warehouse.
-    - **Warehouse Size**: select a size that fits your workload. You can start with **Small** and scale later.
-    - **Auto Suspend**: choose how long the warehouse can stay idle before it is automatically suspended.
+    - **Name**: enter a name for your Lake.
+    - **Plan**: select a plan that fits your use case.
+    - **Cloud Provider and Region**: select the deployment region.
 
-4. Click **Create**. The warehouse will be ready in a few moments.
+4. Click **Create** and wait for initialization to complete.
 
-## Step 3. Explore the warehouse
+## Step 3. Explore your lake workspace
 
-1. Go back to **My Lake** and click the warehouse name you just created.
-2. You will be redirected to `lake.tidbcloud.com` where you can view the warehouse details and connection information.
-3. Use the connection information to connect from your preferred driver, or application.
+1. After initialization completes, confirm the Lake information on the home page, such as the Lake name, plan, cloud provider, and region.
+2. Use the entry points on the home page to continue:
+
+    - **Connect**: get connection information.
+    - **Load Data** or **Load from Cloud Storage**: start loading data.
+    - **Query Data**: create a SQL worksheet.
 
 ## What's next
 

--- a/tidb-cloud-lake/lake-quick-start.md
+++ b/tidb-cloud-lake/lake-quick-start.md
@@ -1,6 +1,6 @@
 ---
 title: TiDB Cloud Lake Quick Start
-summary: Get started with TiDB Cloud Lake in three steps — sign up, initialize TiDB Cloud Lake, and explore your workspace.
+summary: Get started with TiDB Cloud Lake in three steps — sign up, initialize your lake, and explore your workspace.
 ---
 
 # TiDB Cloud Lake Quick Start

--- a/tidb-cloud-lake/lake-quick-start.md
+++ b/tidb-cloud-lake/lake-quick-start.md
@@ -1,6 +1,6 @@
 ---
 title: TiDB Cloud Lake Quick Start
-summary: Get started with TiDB Cloud Lake in three steps — sign up, initialize your lake, and explore your workspace.
+summary: Get started with TiDB Cloud Lake in three steps — sign up, initialize your lake, and explore your lake workspace.
 ---
 
 # TiDB Cloud Lake Quick Start

--- a/tidb-cloud-lake/lake-quick-start.md
+++ b/tidb-cloud-lake/lake-quick-start.md
@@ -29,7 +29,7 @@ This tutorial guides you through an easy way to get started with TiDB Cloud Lake
 
 ## Step 3. Explore your lake workspace
 
-1. After initialization completes, confirm the Lake information on the home page, such as the Lake name, plan, cloud provider, and region.
+1. After initialization completes, confirm the lake information on the home page, such as the lake name, plan, cloud provider, and region.
 2. Use the entry points on the home page to continue:
 
     - **Connect**: get connection information.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the TiDB Cloud Lake quick start guide to replace the warehouse creation flow with the Lake initialization flow. The guide now directs users to click **Try TiDB Cloud Lake**, configure the Lake name, plan, and region, and then explore the Lake home page.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] release-8.5
- [ ] release-8.4
- [ ] release-8.3
- [ ] release-8.2
- [ ] release-8.1
- [ ] release-8.0
- [ ] release-7.6
- [ ] release-7.5
- [ ] release-7.1
- [ ] release-6.5

### What is the related PR or file link(s)?

N/A

### Do your changes match any of the following descriptions?

- [x] The changes are about TiDB Cloud.

### Checklist

- [x] I have run `./scripts/markdownlint tidb-cloud-lake/lake-quick-start.md`.
