### PR TITLE
Fix Dumpling capitalization in Japanese docs

### DIFF
--- a/releases/release-4.0.3.md
+++ b/releases/release-4.0.3.md
@@ -127,7 +127,7 @@ TiDB バージョン: 4.0.3
     -   `getSchedulers`データ競合を引き起こす可能性がある問題を修正[＃2638](https://github.com/pingcap/pd/pull/2638)
     -   スケジューラを削除するとデッドロックが発生する可能性がある問題を修正[＃2637](https://github.com/pingcap/pd/pull/2637)
     -   `balance-leader-scheduler`が有効になっているときに配置ルールが考慮されないバグを修正[＃2636](https://github.com/pingcap/pd/pull/2636)
-    -   サービス`safepoint`が正しく設定されない場合があり、 BRとダンプリングが失敗する可能性がある問題を修正しました[＃2635](https://github.com/pingcap/pd/pull/2635)
+    -   サービス`safepoint`が正しく設定されない場合があり、 BRとDumplingが失敗する可能性がある問題を修正しました[＃2635](https://github.com/pingcap/pd/pull/2635)
     -   `hot region scheduler`の対象店舗が誤って選択されている問題を修正[＃2627](https://github.com/pingcap/pd/pull/2627)
     -   PDリーダーが切り替えられたときにTSOリクエストに時間がかかりすぎる可能性がある問題を修正[＃2622](https://github.com/pingcap/pd/pull/2622)
     -   リーダー変更後の古いスケジューラの問題を修正[＃2608](https://github.com/pingcap/pd/pull/2608)

--- a/releases/release-4.0.3.md
+++ b/releases/release-4.0.3.md
@@ -127,7 +127,7 @@ TiDB バージョン: 4.0.3
     -   `getSchedulers`データ競合を引き起こす可能性がある問題を修正[＃2638](https://github.com/pingcap/pd/pull/2638)
     -   スケジューラを削除するとデッドロックが発生する可能性がある問題を修正[＃2637](https://github.com/pingcap/pd/pull/2637)
     -   `balance-leader-scheduler`が有効になっているときに配置ルールが考慮されないバグを修正[＃2636](https://github.com/pingcap/pd/pull/2636)
-    -   サービス`safepoint`が正しく設定されない場合があり、 BRとDumplingが失敗する可能性がある問題を修正しました[＃2635](https://github.com/pingcap/pd/pull/2635)
+    -   サービス`safepoint`が正しく設定されない場合があり、 BRとDumplingが失敗する可能性がある問題を修正[＃2635](https://github.com/pingcap/pd/pull/2635)
     -   `hot region scheduler`の対象店舗が誤って選択されている問題を修正[＃2627](https://github.com/pingcap/pd/pull/2627)
     -   PDリーダーが切り替えられたときにTSOリクエストに時間がかかりすぎる可能性がある問題を修正[＃2622](https://github.com/pingcap/pd/pull/2622)
     -   リーダー変更後の古いスケジューラの問題を修正[＃2608](https://github.com/pingcap/pd/pull/2608)

--- a/releases/release-4.0.8.md
+++ b/releases/release-4.0.8.md
@@ -80,7 +80,7 @@ TiDB バージョン: 4.0.8
 
     -   Dumpling
 
-        -   S3ストレージへのダンプリングデータの直接サポート[＃155](https://github.com/pingcap/dumpling/pull/155)
+        -   S3ストレージへのDumplingデータの直接サポート[＃155](https://github.com/pingcap/dumpling/pull/155)
         -   ダンプビューのサポート[＃158](https://github.com/pingcap/dumpling/pull/158)
         -   生成された列のみを含むテーブルのダンプをサポート[＃166](https://github.com/pingcap/dumpling/pull/166)
 


### PR DESCRIPTION
Fix katakana transliteration ダンプリング → Dumpling for the TiDB tool name