### PR TITLE
terms: remove storage entry from EN-JA terms glossary

### DIFF
--- a/resources/terms-en-ja.md
+++ b/resources/terms-en-ja.md
@@ -110,7 +110,6 @@
 | Stability | 安定性 | Do not translate to 「安定」. |
 | Stale Read | ステイル読み取り | Do not translate to 「古い読み取り」. |
 | Starter | Starter | TiDB Cloud tier name, keep in English. |
-| storage | storage | When used as a configuration section heading, keep in English. Do not translate to 「保管所」. |
 | TEXT | TEXT | SQL data type, keep in English. |
 | TiCDC Canal | TiCDC Canal | Feature name, keep in English. Do not translate to 「TiCDC運河」. |
 | TiCDC Changefeed | TiCDC Changefeed | Keep space between TiCDC and Changefeed. |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove the `storage` entry from `resources/terms-en-ja.md`.

The entry mapped 'storage' → 'storage' (keep in English), causing the translation AI to leave the word untranslated in all contexts. This produced unnatural Japanese with English `storage` mixed into Japanese text, e.g. `行ベースstorage`, `ドキュメントのstorage`.

Removing this entry because:
- The side effect is too broad: `storage` appears frequently across the docs in non-config contexts where `ストレージ` (katakana) is the natural Japanese form.
- Going forward, translation is per diff, not per file. If `storage` should remain English in specific cases (e.g. config section headings), it can be handled individually at the diff level.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): https://github.com/pingcap/docs/blame/e489e38ca0b40aad1db8a614f9dd0cb5c3bc9d9e/resources/terms-en-ja.md#L113

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch