### PR TITLE
Remove Security entry from EN-JA terms glossary

### DIFF
--- a/resources/terms-en-ja.md
+++ b/resources/terms-en-ja.md
@@ -103,7 +103,6 @@
 | Scattering | Scattering | Technical term, keep in English. |
 | Secondary Cluster | セカンダリクラスター |  |
 | Secure | セキュリティ |  |
-| Security | Security | When used as a configuration section heading, keep in English. Do not translate to 「安全」. |
 | Sequence | シーケンス |  |
 | server | サーバー | Use long vowel mark. |
 | single point of failure | 単一障害点 |  |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove the `Security` entry from `resources/terms-en-ja.md`.

The entry mapped 'Security' → 'Security' (keep in English), causing the translation AI to leave the word untranslated in non-config contexts where `セキュリティ` is the natural Japanese form. Same side effect as the `storage` entry removed in #23100.

Removing this entry because:
- The side effect is too broad: `Security` appears frequently across the docs in non-config contexts.
- Going forward, translation is per diff, not per file. If `Security` should remain English in specific cases (e.g. config section headings), it can be handled individually at the diff level.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): #23100, https://github.com/pingcap/docs/pull/23099#discussion_r3432709108

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch