### PR TITLE
pessimistic-transaction: clarify Point Get lock behavior for non-existing keys under different isolation levels

### DIFF
--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -81,7 +81,7 @@ Pessimistic transactions in TiDB behave similarly to those in MySQL. See the min
 
     > **Note:**
     >
-    > This behavior applies only to the `REPEATABLE READ` isolation level. Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do not lock non-existent keys.
+    > This behavior applies only to the [Repeatable Read](/transaction-isolation-levels.md#repeatable-read-isolation-level) isolation level. Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do not lock non-existent keys.
 
 - TiDB supports the `FOR UPDATE OF TABLES` syntax. For a statement that joins multiple tables, TiDB only applies pessimistic locks on the rows that are associated with the tables in `OF TABLES`.
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -79,6 +79,10 @@ Pessimistic transactions in TiDB behave similarly to those in MySQL. See the min
 
 - If the `Point Get` and `Batch Point Get` operators do not read data, they still lock the given primary key or unique key, which blocks other transactions from locking or writing data to the same primary key or unique key.
 
+    > **Note:**
+    >
+    > This behavior applies only to the `REPEATABLE READ` isolation level. Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do not lock non-existent keys.
+
 - TiDB supports the `FOR UPDATE OF TABLES` syntax. For a statement that joins multiple tables, TiDB only applies pessimistic locks on the rows that are associated with the tables in `OF TABLES`.
 
 ## Differences from MySQL InnoDB

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -81,7 +81,7 @@ Pessimistic transactions in TiDB behave similarly to those in MySQL. See the min
 
     > **Note:**
     >
-    > This behavior applies only to the [Repeatable Read](/transaction-isolation-levels.md#repeatable-read-isolation-level) isolation level. Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do not lock non-existent keys.
+    > This behavior applies only to the [Repeatable Read](/transaction-isolation-levels.md#repeatable-read-isolation-level) isolation level. Under the [Read Committed](/transaction-isolation-levels.md#read-committed-isolation-level) isolation level, `Point Get` and `Batch Point Get` operators do not lock non-existent keys.
 
 - TiDB supports the `FOR UPDATE OF TABLES` syntax. For a statement that joins multiple tables, TiDB only applies pessimistic locks on the rows that are associated with the tables in `OF TABLES`.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Added a **Note** in the `Behaviors` section of `pessimistic-transaction.md` to clarify that the Point Get and Batch Point Get lock behavior for non-existing keys applies **only to the `REPEATABLE READ` isolation level**.

Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do **not** lock non-existent keys. This is a behavioral difference that can affect applications using `SELECT FOR UPDATE` for existence checks followed by `INSERT`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- Related documentation: https://docs.pingcap.com/tidbcloud/pessimistic-transaction/#behaviors

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch

### Verification

This behavior was verified on TiDB v8.5.3:

| # | Access Method | Isolation Level | Non-existing Key | Lock Acquired? |
|---|---------------|-----------------|------------------|----------------|
| 1 | Point Get | Repeatable Read | `id = 999` | **Yes** |
| 2 | Point Get | Read Committed | `id = 888` | **No** |
| 3 | Batch Point Get | Repeatable Read | `id IN (777, 888)` | **Yes** |
| 4 | Range Scan | Repeatable Read | `id BETWEEN 100 AND 200` | **No** (no gap lock) |

A test script was provided in the PR comments for reviewers to verify the behavior locally.