### PR TITLE
tidb-cloud: clarify restore region selection in backup-and-restore

### DIFF
--- a/tidb-cloud/backup-and-restore.md
+++ b/tidb-cloud/backup-and-restore.md
@@ -275,11 +275,7 @@ To restore your TiDB Cloud Dedicated cluster data from a backup to a new cluster
 
 2. Click **Restore**. The setting window displays.
 
-3. In **Restore Mode**, choose **Restore From Region**, indicating the region of backup stores.
-
-    > **Note**
-    >
-    > - The default value of the **Restore From Region** is the same as the backup cluster.
+3. The backup source is automatically determined by your cluster's region and cannot be changed.
 
 4. In **Restore Mode**, choose to restore data of any point in time or a selected backup to a new cluster.
 
@@ -303,7 +299,12 @@ To restore your TiDB Cloud Dedicated cluster data from a backup to a new cluster
     </div>
     </SimpleTab>
 
-5. In **Restore to Region**, select the same region as the **Primary Region** configured in the **Backup Setting**.
+5. In **Cloud Provider & Region**, select the target region for the new cluster.
+
+    > **Note**
+    >
+    > - By default, the new cluster is restored to the same region as the source cluster.
+    > - If **Dual Region Backup** is enabled in **Backup Setting**, you can also choose to restore the new cluster to the **Secondary Region** configured for dual region backup.
 
 6. In the **Restore** window, you can also make the following changes if necessary:
 

--- a/tidb-cloud/backup-and-restore.md
+++ b/tidb-cloud/backup-and-restore.md
@@ -275,9 +275,7 @@ To restore your TiDB Cloud Dedicated cluster data from a backup to a new cluster
 
 2. Click **Restore**. The setting window displays.
 
-3. The backup source is automatically determined by your cluster's region and cannot be changed.
-
-4. In **Restore Mode**, choose to restore data of any point in time or a selected backup to a new cluster.
+3. In **Restore Mode**, choose to restore data of any point in time or a selected backup to a new cluster.
 
     <SimpleTab>
     <div label="Select Time Point">
@@ -299,24 +297,24 @@ To restore your TiDB Cloud Dedicated cluster data from a backup to a new cluster
     </div>
     </SimpleTab>
 
-5. In **Cloud Provider & Region**, select the target region for the new cluster.
+4. In **Cloud Provider & Region**, select the target region for the new cluster.
 
     > **Note**
     >
     > - By default, the new cluster is restored to the same region as the source cluster.
     > - If **Dual Region Backup** is enabled in **Backup Setting**, you can also choose to restore the new cluster to the **Secondary Region** configured for dual region backup.
 
-6. In the **Restore** window, you can also make the following changes if necessary:
+5. In the **Restore** window, you can also make the following changes if necessary:
 
     - Set the cluster name.
     - Update the port number of the cluster.
     - Increase node number, vCPU and RAM, and storage for the cluster.
 
-7. Click **Restore**.
+6. Click **Restore**.
 
    The cluster restore process starts and the **Password Settings** dialog box is displayed.
 
-8. In the **Password Settings** dialog box, set the root password to connect to your TiDB Cloud Dedicated cluster, and then click **Save**.
+7. In the **Password Settings** dialog box, set the root password to connect to your TiDB Cloud Dedicated cluster, and then click **Save**.
 
 ### Restore a deleted cluster
 

--- a/tidb-cloud/backup-and-restore.md
+++ b/tidb-cloud/backup-and-restore.md
@@ -302,7 +302,7 @@ To restore your TiDB Cloud Dedicated cluster data from a backup to a new cluster
     > **Note**
     >
     > - By default, the new cluster is restored to the same region as the source cluster.
-    > - If **Dual Region Backup** is enabled in **Backup Setting**, you can also choose to restore the new cluster to the **Secondary Region** configured for dual region backup.
+    > - If [**Dual Region Backup**](/tidb-cloud/backup-and-restore.md#turn-on-dual-region-backup) is enabled in **Backup Setting**, you can also choose to restore the new cluster to the **Secondary Region** configured for dual region backup.
 
 5. In the **Restore** window, you can also make the following changes if necessary:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The Restore From Region option has been removed; the backup source is now fixed to the source cluster's region. The Restore to Region step is renamed to Cloud Provider & Region, and exposes the Secondary Region as an additional target when Dual Region Backup is enabled.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
