### PR TITLE
fix: GitHub casing (Github → GitHub)

### DIFF
--- a/develop/dev-guide-playground-gitpod.md
+++ b/develop/dev-guide-playground-gitpod.md
@@ -22,7 +22,7 @@ Gitpod is an open-source Kubernetes application (GitHub repository address: <htt
 
    - You can configure environment variables in the URL. For example, `https://gitpod.io/#targetFile=spring-jpa-hibernate_Makefile,targetMode=spring-jpa-hibernate/https://github.com/pingcap-inc/tidb-example-java`.
 
-3. Log in and start the workspace using one of the providers listed. For example, `Github`.
+3. Log in and start the workspace using one of the providers listed. For example, `GitHub`.
 
 ## Use the default Gitpod configuration and environment
 

--- a/tidb-cloud/integrate-tidbcloud-with-zapier.md
+++ b/tidb-cloud/integrate-tidbcloud-with-zapier.md
@@ -19,7 +19,7 @@ This guide gives a high-level introduction to the TiDB Cloud app on Zapier and a
 
 [Zap Templates](https://docs.zapier.com/integrations/publish/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
 
-In this section, we will use the **Add new Github global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
+This section uses the **Add new GitHub global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
 
 ### Prerequisites
 
@@ -31,7 +31,7 @@ Before you start, you need:
 
 ### Step 1: Get the template
 
-Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new Github global events to TiDB rows** template and click **Try it**. Then you will enter the editor page.
+Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new GitHub global events to TiDB rows** template and click **Try it**. This opens the editor page.
 
 ### Step 2: Set up the trigger
 

--- a/tidb-cloud/integrate-tidbcloud-with-zapier.md
+++ b/tidb-cloud/integrate-tidbcloud-with-zapier.md
@@ -19,7 +19,7 @@ This guide gives a high-level introduction to the TiDB Cloud app on Zapier and a
 
 [Zap Templates](https://docs.zapier.com/integrations/publish/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
 
-In this section, we will use the **Add new Github global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
+In this section, we will use the **Add new GitHub global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
 
 ### Prerequisites
 
@@ -31,7 +31,7 @@ Before you start, you need:
 
 ### Step 1: Get the template
 
-Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new Github global events to TiDB rows** template and click **Try it**. Then you will enter the editor page.
+Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new GitHub global events to TiDB rows** template and click **Try it**. Then you will enter the editor page.
 
 ### Step 2: Set up the trigger
 

--- a/tidb-cloud/integrate-tidbcloud-with-zapier.md
+++ b/tidb-cloud/integrate-tidbcloud-with-zapier.md
@@ -19,7 +19,7 @@ This guide gives a high-level introduction to the TiDB Cloud app on Zapier and a
 
 [Zap Templates](https://docs.zapier.com/integrations/publish/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
 
-In this section, we will use the **Add new GitHub global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
+This section uses the **Add new GitHub global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
 
 ### Prerequisites
 
@@ -31,7 +31,7 @@ Before you start, you need:
 
 ### Step 1: Get the template
 
-Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new GitHub global events to TiDB rows** template and click **Try it**. Then you will enter the editor page.
+Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new GitHub global events to TiDB rows** template and click **Try it**. This opens the editor page.
 
 ### Step 2: Set up the trigger
 

--- a/tidb-cloud/integrate-tidbcloud-with-zapier.md
+++ b/tidb-cloud/integrate-tidbcloud-with-zapier.md
@@ -19,7 +19,7 @@ This guide gives a high-level introduction to the TiDB Cloud app on Zapier and a
 
 [Zap Templates](https://docs.zapier.com/integrations/publish/zap-templates) are ready made integrations or Zaps with the apps and core fields pre-selected, for publicly available Zapier integrations.
 
-This section uses the **Add new GitHub global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
+This section uses the **Add new Github global events to TiDB rows** template as an example to create a workflow. In this workflow, every time a new global event (any [GitHub event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types) happens from or to you, on any repo) is created from your GitHub account, Zapier adds a new row to your TiDB Cloud cluster.
 
 ### Prerequisites
 
@@ -31,7 +31,7 @@ Before you start, you need:
 
 ### Step 1: Get the template
 
-Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new GitHub global events to TiDB rows** template and click **Try it**. This opens the editor page.
+Go to [TiDB Cloud App on Zapier](https://zapier.com/apps/tidb-cloud/integrations). Choose the **Add new Github global events to TiDB rows** template and click **Try it**. This opens the editor page.
 
 ### Step 2: Set up the trigger
 

--- a/tidb-cloud/releases/release-notes-2023.md
+++ b/tidb-cloud/releases/release-notes-2023.md
@@ -459,7 +459,7 @@ This page lists the release notes of [TiDB Cloud](https://www.pingcap.com/tidb-c
 
 - Support connecting your [Data App](/tidb-cloud/tidb-cloud-glossary.md#data-app) to GitHub.
 
-    By [connecting your Data App to GitHub](/tidb-cloud/data-service-manage-github-connection.md), you can manage all configurations of the Data App as [code files](/tidb-cloud/data-service-app-config-files.md) on Github, which integrates TiDB Cloud Data Service seamlessly with your system architecture and DevOps process.
+    By [connecting your Data App to GitHub](/tidb-cloud/data-service-manage-github-connection.md), you can manage all configurations of the Data App as [code files](/tidb-cloud/data-service-app-config-files.md) on GitHub, which integrates TiDB Cloud Data Service seamlessly with your system architecture and DevOps process.
 
     With this feature, you can easily accomplish the following tasks, which improves the CI/CD experience of developing Data Apps:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix inconsistent GitHub casing (Github → GitHub) in English docs across 3 files:

- `develop/dev-guide-playground-gitpod.md`
- `tidb-cloud/integrate-tidbcloud-with-zapier.md`
- `tidb-cloud/releases/release-notes-2023.md`

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected “GitHub” capitalization across quick-start instructions, Zapier integration guidance, and release notes.
  * Clarified that selecting **Try it** in the Zapier template opens the editor page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->