### PR TITLE
config: reword primary lease descriptions for clarity

### DIFF
--- a/scheduling-configuration-file.md
+++ b/scheduling-configuration-file.md
@@ -44,7 +44,7 @@ The Scheduling node is used for providing the `scheduling` microservice for PD. 
 
 ### `lease`
 
-- The timeout of the Scheduling Primary Key lease. After the timeout, the system re-elects a Primary.
+- The timeout of the scheduling service's primary lease. After the timeout, the system re-elects a primary.
 - Default value: `3`
 - Unit: seconds
 

--- a/scheduling-configuration-file.md
+++ b/scheduling-configuration-file.md
@@ -44,7 +44,7 @@ The Scheduling node is used for providing the `scheduling` microservice for PD. 
 
 ### `lease`
 
-- The timeout of the scheduling service's primary lease. After the timeout, the system re-elects a primary.
+- The timeout of the Scheduling service's primary lease. After the timeout, the system re-elects a primary.
 - Default value: `3`
 - Unit: seconds
 

--- a/scheduling-configuration-file.md
+++ b/scheduling-configuration-file.md
@@ -44,8 +44,8 @@ The Scheduling node is used for providing the `scheduling` microservice for PD. 
 
 ### `lease`
 
-- The timeout of the Scheduling Primary Key lease. After the timeout, the system re-elects a Primary.
-- Default value: `3`
+- The timeout of the Scheduling service's primary lease. After the timeout, the system re-elects a primary.
+- Default value: `5`
 - Unit: seconds
 
 ## security

--- a/scheduling-configuration-file.md
+++ b/scheduling-configuration-file.md
@@ -45,7 +45,7 @@ The Scheduling node is used for providing the `scheduling` microservice for PD. 
 ### `lease`
 
 - The timeout of the Scheduling service's primary lease. After the timeout, the system re-elects a primary.
-- Default value: `3`
+- Default value: `5`
 - Unit: seconds
 
 ## security

--- a/tso-configuration-file.md
+++ b/tso-configuration-file.md
@@ -44,7 +44,7 @@ The TSO node is used for providing the `tso` microservice for PD. This document 
 
 ### `lease`
 
-- The timeout of the TSO Primary Key lease. After the timeout, the system re-elects a Primary.
+- The timeout of the TSO service's primary lease. After the timeout, the system re-elects a primary.
 - Default value: `3`
 - Unit: seconds
 

--- a/tso-configuration-file.md
+++ b/tso-configuration-file.md
@@ -44,8 +44,8 @@ The TSO node is used for providing the `tso` microservice for PD. This document 
 
 ### `lease`
 
-- The timeout of the TSO Primary Key lease. After the timeout, the system re-elects a Primary.
-- Default value: `3`
+- The timeout of the TSO service's primary lease. After the timeout, the system re-elects a primary.
+- Default value: `5`
 - Unit: seconds
 
 ### `tso-update-physical-interval`

--- a/tso-configuration-file.md
+++ b/tso-configuration-file.md
@@ -45,7 +45,7 @@ The TSO node is used for providing the `tso` microservice for PD. This document 
 ### `lease`
 
 - The timeout of the TSO service's primary lease. After the timeout, the system re-elects a primary.
-- Default value: `3`
+- Default value: `5`
 - Unit: seconds
 
 ### `tso-update-physical-interval`


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Reword the `lease\> description in `scheduling-configuration-file.md` and `tso-configuration-file.md` to avoid confusion with database `PRIMARY KEY` terminology.

**Before:**
> The timeout of the Scheduling Primary Key lease. After the timeout, the system re-elects a Primary.

**After:**
> The timeout of the scheduling service's primary lease. After the timeout, the system re-elects a primary.

Similarly for the TSO configuration file.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- Related simplified Chinese source:
  - https://github.com/pingcap/docs-cn/blob/release-8.5/scheduling-configuration-file.md
  - https://github.com/pingcap/docs-cn/blob/release-8.5/tso-configuration-file.md

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified lease descriptions for the Scheduling and TSO services.
  * Updated terminology for primary leases and re-election behavior.
  * Updated the default lease timeout from 3 to 5 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->