### PR TITLE
master: bump Go requirement to 1.25 in docs

### DIFF
--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -108,8 +108,8 @@ This document describes the software and hardware requirements for deploying and
 
 |  Libraries required for compiling and running TiDB |  Version   |
 |   :---   |   :---   |
-|   Golang  |  1.23 or later |
-|   Rust    |   nightly-2023-12-28 or later  |
+|   Golang  |  1.25 or later |
+|   Rust    |   nightly-2026-01-30 or later  |
 |  GCC      |   7.x      |
 |  LLVM     |  17.0 or later  |
 

--- a/pd-control.md
+++ b/pd-control.md
@@ -33,7 +33,7 @@ To obtain `pd-ctl` of the latest version, download the TiDB server installation 
 
 ### Compile from source code
 
-1. [Go](https://golang.org/) 1.23 or later is required because the Go modules are used.
+1. [Go](https://golang.org/) 1.25 or later is required because the Go modules are used.
 2. In the root directory of the [PD project](https://github.com/pingcap/pd), use the `make` or `make pd-ctl` command to compile and generate `bin/pd-ctl`.
 
 ## Usage

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -10,7 +10,7 @@ PD Recover is a disaster recovery tool of PD, used to recover the PD cluster whi
 
 ## Compile from source code
 
-+ [Go](https://golang.org/) 1.23 or later is required because the Go modules are used.
++ [Go](https://golang.org/) 1.25 or later is required because the Go modules are used.
 + In the root directory of the [PD project](https://github.com/pingcap/pd), use the `make pd-recover` command to compile and generate `bin/pd-recover`.
 
 > **Note:**

--- a/tidb-control.md
+++ b/tidb-control.md
@@ -26,7 +26,7 @@ After installing TiUP, you can use `tiup ctl:v<CLUSTER_VERSION> tidb` command to
 
 ### Compile from source code
 
-- Compilation environment requirement: [Go](https://golang.org/) 1.23 or later
+- Compilation environment requirement: [Go](https://golang.org/) 1.25 or later
 - Compilation procedures: Go to the root directory of the [TiDB Control project](https://github.com/pingcap/tidb-ctl), use the `make` command to compile, and generate `tidb-ctl`.
 - Compilation documentation: you can find the help files in the `doc` directory; if the help files are lost or you want to update them, use the `make doc` command to generate the help files.
 


### PR DESCRIPTION


<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
Update documentation to reflect the new Go toolchain requirement. 

Changed Go version from 1.23 to 1.25 in hardware-and-software-requirements.md, pd-control.md, pd-recover.md, and tidb-control.md so build/compile instructions and dependency lists are consistent with the current supported Go version.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/21737
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
