### PR TITLE
i18n(ja): use English CLI command headings in ticloud reference pages

### DIFF
--- a/tidb-cloud/ticloud-auth-logout.md
+++ b/tidb-cloud/ticloud-auth-logout.md
@@ -3,7 +3,7 @@ title: ticloud auth logout
 summary: ticloud auth logout` のリファレンス。
 ---
 
-# ticloud 認証ログアウト {#ticloud-auth-logout}
+# ticloud auth logout {#ticloud-auth-logout}
 
 TiDB Cloudからログアウトします:
 

--- a/tidb-cloud/ticloud-auth-whoami.md
+++ b/tidb-cloud/ticloud-auth-whoami.md
@@ -3,7 +3,7 @@ title: ticloud auth whoami
 summary: ticloud auth whoami` のリファレンス。
 ---
 
-# ticloud 認証 whoami {#ticloud-auth-whoami}
+# ticloud auth whoami {#ticloud-auth-whoami}
 
 現在のユーザーに関する情報を表示します。
 

--- a/tidb-cloud/ticloud-branch-create.md
+++ b/tidb-cloud/ticloud-branch-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless branch create
 summary: ticloud serverless branch create` のリファレンス。
 ---
 
-# ticloud サーバーレスブランチ作成 {#ticloud-serverless-branch-create}
+# ticloud serverless branch create {#ticloud-serverless-branch-create}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターの[支店](/tidb-cloud/branch-overview.md)作成します。
 

--- a/tidb-cloud/ticloud-branch-delete.md
+++ b/tidb-cloud/ticloud-branch-delete.md
@@ -3,7 +3,7 @@ title: ticloud serverless branch delete
 summary: ticloud serverless branch delete` のリファレンス。
 ---
 
-# ticloud サーバーレスブランチの削除 {#ticloud-serverless-branch-delete}
+# ticloud serverless branch delete {#ticloud-serverless-branch-delete}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターからブランチを削除します。
 

--- a/tidb-cloud/ticloud-branch-describe.md
+++ b/tidb-cloud/ticloud-branch-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless branch describe
 summary: ticloud serverless branch describe` のリファレンス。
 ---
 
-# ticloud サーバーレスブランチの説明 {#ticloud-serverless-branch-describe}
+# ticloud serverless branch describe {#ticloud-serverless-branch-describe}
 
 ブランチに関する情報 (エンドポイント、 [ユーザー名のプレフィックス](/tidb-cloud/select-cluster-tier.md#user-name-prefix) 、使用状況など) を取得します。
 

--- a/tidb-cloud/ticloud-branch-list.md
+++ b/tidb-cloud/ticloud-branch-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless branch list
 summary: ticloud serverless branch list` のリファレンス。
 ---
 
-# ticloud サーバーレス ブランチ リスト {#ticloud-serverless-branch-list}
+# ticloud serverless branch list {#ticloud-serverless-branch-list}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターのすべてのブランチを一覧表示します。
 

--- a/tidb-cloud/ticloud-branch-shell.md
+++ b/tidb-cloud/ticloud-branch-shell.md
@@ -4,7 +4,7 @@ summary: ticloud serverless branch shell` のリファレンス。
 aliases: ['/ja/tidbcloud/ticloud-connect']
 ---
 
-# ticloud サーバーレスブランチシェル {#ticloud-serverless-branch-shell}
+# ticloud serverless branch shell {#ticloud-serverless-branch-shell}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターのブランチに接続します。
 

--- a/tidb-cloud/ticloud-cluster-create.md
+++ b/tidb-cloud/ticloud-cluster-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless create
 summary: ticloud serverless create` のリファレンス。
 ---
 
-# ticloud サーバーレス作成 {#ticloud-serverless-create}
+# ticloud serverless create {#ticloud-serverless-create}
 
 TiDB Cloudクラスターを作成します。
 

--- a/tidb-cloud/ticloud-cluster-delete.md
+++ b/tidb-cloud/ticloud-cluster-delete.md
@@ -3,7 +3,7 @@ title: ticloud serverless cluster delete
 summary: ticloud serverless delete` のリファレンス。
 ---
 
-# ticloud サーバーレス削除 {#ticloud-serverless-delete}
+# ticloud serverless delete {#ticloud-serverless-delete}
 
 プロジェクトからTiDB Cloud Starter またはTiDB Cloud Essential クラスターを削除します。
 

--- a/tidb-cloud/ticloud-cluster-describe.md
+++ b/tidb-cloud/ticloud-cluster-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless cluster describe
 summary: ticloud serverless describe` のリファレンス。
 ---
 
-# ticloud サーバーレスの説明 {#ticloud-serverless-describe}
+# ticloud serverless describe {#ticloud-serverless-describe}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターに関する情報 (クラスター構成やクラスターステータスなど) を取得します。
 

--- a/tidb-cloud/ticloud-cluster-list.md
+++ b/tidb-cloud/ticloud-cluster-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless cluster list
 summary: ticloud serverless list` のリファレンス。
 ---
 
-# ticloud サーバーレス リスト {#ticloud-serverless-list}
+# ticloud serverless list {#ticloud-serverless-list}
 
 プロジェクト内のすべてのTiDB Cloud Starter クラスターとTiDB Cloud Essential クラスターを一覧表示します。
 

--- a/tidb-cloud/ticloud-config-create.md
+++ b/tidb-cloud/ticloud-config-create.md
@@ -3,7 +3,7 @@ title: ticloud config create
 summary: ticloud config create` のリファレンス。
 ---
 
-# ticloud 設定作成 {#ticloud-config-create}
+# ticloud config create {#ticloud-config-create}
 
 ユーザー プロファイル設定を保存する[ユーザープロフィール](/tidb-cloud/cli-reference.md#user-profile)作成します。
 

--- a/tidb-cloud/ticloud-config-delete.md
+++ b/tidb-cloud/ticloud-config-delete.md
@@ -3,7 +3,7 @@ title: ticloud config delete
 summary: ticloud config delete` のリファレンス。
 ---
 
-# ticloud 設定の削除 {#ticloud-config-delete}
+# ticloud config delete {#ticloud-config-delete}
 
 [ユーザープロフィール](/tidb-cloud/cli-reference.md#user-profile)を削除:
 

--- a/tidb-cloud/ticloud-config-describe.md
+++ b/tidb-cloud/ticloud-config-describe.md
@@ -3,7 +3,7 @@ title: ticloud config describe
 summary: ticloud config describe` のリファレンス。
 ---
 
-# ticloud 設定の説明 {#ticloud-config-describe}
+# ticloud config describe {#ticloud-config-describe}
 
 特定の[ユーザープロフィール](/tidb-cloud/cli-reference.md#user-profile)のプロパティ情報を取得します。
 

--- a/tidb-cloud/ticloud-config-edit.md
+++ b/tidb-cloud/ticloud-config-edit.md
@@ -3,7 +3,7 @@ title: ticloud config edit
 summary: ticloud config edit` のリファレンス。
 ---
 
-# ticloud 設定編集 {#ticloud-config-edit}
+# ticloud config edit {#ticloud-config-edit}
 
 macOS または Linux を使用している場合は、デフォルトのテキスト エディターでプロファイル構成ファイルを開くことができます。
 

--- a/tidb-cloud/ticloud-config-list.md
+++ b/tidb-cloud/ticloud-config-list.md
@@ -3,7 +3,7 @@ title: ticloud config list
 summary: ticloud config list` のリファレンス。
 ---
 
-# ticloud 設定リスト {#ticloud-config-list}
+# ticloud config list {#ticloud-config-list}
 
 すべてリスト[ユーザープロファイル](/tidb-cloud/cli-reference.md#user-profile) :
 

--- a/tidb-cloud/ticloud-config-set.md
+++ b/tidb-cloud/ticloud-config-set.md
@@ -3,7 +3,7 @@ title: ticloud config set
 summary: ticloud config set` のリファレンス。
 ---
 
-# ticloud 設定セット {#ticloud-config-set}
+# ticloud config set {#ticloud-config-set}
 
 アクティブ[ユーザープロフィール](/tidb-cloud/cli-reference.md#user-profile)のプロパティを設定します。
 

--- a/tidb-cloud/ticloud-config-use.md
+++ b/tidb-cloud/ticloud-config-use.md
@@ -3,7 +3,7 @@ title: ticloud config use
 summary: ticloud config use` のリファレンス。
 ---
 
-# ticloud 設定の使用 {#ticloud-config-use}
+# ticloud config use {#ticloud-config-use}
 
 指定したプロファイルをアクティブ[ユーザープロフィール](/tidb-cloud/cli-reference.md#user-profile)として設定します。
 

--- a/tidb-cloud/ticloud-import-cancel.md
+++ b/tidb-cloud/ticloud-import-cancel.md
@@ -3,7 +3,7 @@ title: ticloud serverless import cancel
 summary: ticloud serverless import cancel` の参照。
 ---
 
-# ticloud サーバーレスインポートのキャンセル {#ticloud-serverless-import-cancel}
+# ticloud serverless import cancel {#ticloud-serverless-import-cancel}
 
 データインポートタスクをキャンセルします。
 

--- a/tidb-cloud/ticloud-import-describe.md
+++ b/tidb-cloud/ticloud-import-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless import describe
 summary: ticloud serverless import describe` のリファレンス。
 ---
 
-# ticloud サーバーレスインポートの説明 {#ticloud-serverless-import-describe}
+# ticloud serverless import describe {#ticloud-serverless-import-describe}
 
 データ インポート タスクについて説明します。
 

--- a/tidb-cloud/ticloud-import-list.md
+++ b/tidb-cloud/ticloud-import-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless import list
 summary: ticloud serverless import list` のリファレンス。
 ---
 
-# ticloud サーバーレスインポートリスト {#ticloud-serverless-import-list}
+# ticloud serverless import list {#ticloud-serverless-import-list}
 
 データインポートタスクの一覧:
 

--- a/tidb-cloud/ticloud-import-start.md
+++ b/tidb-cloud/ticloud-import-start.md
@@ -4,7 +4,7 @@ summary: ticloud serverless import start` のリファレンス。
 aliases: ['/ja/tidbcloud/ticloud-import-start-local','/ja/tidbcloud/ticloud-import-start-mysql','/ja/tidbcloud/ticloud-import-start-s3']
 ---
 
-# ticloud サーバーレスインポートの開始 {#ticloud-serverless-import-start}
+# ticloud serverless import start {#ticloud-serverless-import-start}
 
 データ インポート タスクを開始します。
 

--- a/tidb-cloud/ticloud-project-list.md
+++ b/tidb-cloud/ticloud-project-list.md
@@ -3,7 +3,7 @@ title: ticloud project list
 summary: ticloud プロジェクト リスト` の参照。
 ---
 
-# ticloud プロジェクトリスト {#ticloud-project-list}
+# ticloud project list {#ticloud-project-list}
 
 アクセス可能なすべてのプロジェクトを一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-config-describe.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-config-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log config describe
 summary: ticloud serverless audit-log config describe` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログ設定の説明 {#ticloud-serverless-audit-log-config-describe}
+# ticloud serverless audit-log config describe {#ticloud-serverless-audit-log-config-describe}
 
 TiDB Cloud Essential クラスターのデータベース監査ログ構成について説明します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-config-update.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-config-update.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log config update
 summary: ticloud serverless audit-log config update` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログ設定の更新 {#ticloud-serverless-audit-log-config-update}
+# ticloud serverless audit-log config update {#ticloud-serverless-audit-log-config-update}
 
 TiDB Cloud Essential クラスターのデータベース監査ログ構成を更新します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-download.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-download.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log download
 summary: ticloud serverless audit-log download` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログのダウンロード {#ticloud-serverless-audit-log-download}
+# ticloud serverless audit-log download {#ticloud-serverless-audit-log-download}
 
 TiDB Cloud Essential クラスターからデータベース監査ログ ファイルをダウンロードします。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-create.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule create
 summary: ticloud serverless audit-log filter-rule create` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールの作成 {#ticloud-serverless-audit-log-filter-rule-create}
+# ticloud serverless audit-log filter-rule create {#ticloud-serverless-audit-log-filter-rule-create}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルールを作成します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-delete.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-delete.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule delete
 summary: ticloud serverless audit-log filter-rule delete` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールの削除 {#ticloud-serverless-audit-log-filter-rule-delete}
+# ticloud serverless audit-log filter-rule delete {#ticloud-serverless-audit-log-filter-rule-delete}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルールを削除します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-describe.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule describe
 summary: ticloud serverless audit-log filter-rule describe` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールの説明 {#ticloud-serverless-audit-log-filter-rule-describe}
+# ticloud serverless audit-log filter-rule describe {#ticloud-serverless-audit-log-filter-rule-describe}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルールについて説明します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-list.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule list
 summary: ticloud serverless audit-log filter-rule list` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールリスト {#ticloud-serverless-audit-log-filter-rule-list}
+# ticloud serverless audit-log filter-rule list {#ticloud-serverless-audit-log-filter-rule-list}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルールを一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-template.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-template.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule template
 summary: ticloud serverless audit-log filter-rule template` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールテンプレート {#ticloud-serverless-audit-log-filter-rule-template}
+# ticloud serverless audit-log filter-rule template {#ticloud-serverless-audit-log-filter-rule-template}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルール テンプレートを表示します。
 

--- a/tidb-cloud/ticloud-serverless-audit-log-filter-rule-update.md
+++ b/tidb-cloud/ticloud-serverless-audit-log-filter-rule-update.md
@@ -3,7 +3,7 @@ title: ticloud serverless audit-log filter-rule update
 summary: ticloud serverless audit-log filter-rule update` のリファレンス。
 ---
 
-# ticloud サーバーレス監査ログフィルタールールの更新 {#ticloud-serverless-audit-log-filter-rule-update}
+# ticloud serverless audit-log filter-rule update {#ticloud-serverless-audit-log-filter-rule-update}
 
 TiDB Cloud Essential クラスターの監査ログ フィルター ルールを更新します。
 

--- a/tidb-cloud/ticloud-serverless-authorized-network-create.md
+++ b/tidb-cloud/ticloud-serverless-authorized-network-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless authorized-network create
 summary: ticloud serverless authorized-network create` のリファレンス。
 ---
 
-# ticloud サーバーレス 承認済みネットワークの作成 {#ticloud-serverless-authorized-network-create}
+# ticloud serverless authorized-network create {#ticloud-serverless-authorized-network-create}
 
 承認済みネットワークを作成します。
 

--- a/tidb-cloud/ticloud-serverless-authorized-network-delete.md
+++ b/tidb-cloud/ticloud-serverless-authorized-network-delete.md
@@ -3,7 +3,7 @@ title: ticloud serverless authorized-network delete
 summary: ticloud serverless authorized-network delete` のリファレンス。
 ---
 
-# ticloud サーバーレス 承認済みネットワークの削除 {#ticloud-serverless-authorized-network-delete}
+# ticloud serverless authorized-network delete {#ticloud-serverless-authorized-network-delete}
 
 承認済みネットワークを削除します。
 

--- a/tidb-cloud/ticloud-serverless-authorized-network-list.md
+++ b/tidb-cloud/ticloud-serverless-authorized-network-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless authorized-network list
 summary: ticloud serverless authorized-network list` のリファレンス。
 ---
 
-# ticloud サーバーレス 承認ネットワーク リスト {#ticloud-serverless-authorized-network-list}
+# ticloud serverless authorized-network list {#ticloud-serverless-authorized-network-list}
 
 承認されたネットワークをすべて一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-authorized-network-update.md
+++ b/tidb-cloud/ticloud-serverless-authorized-network-update.md
@@ -3,7 +3,7 @@ title: ticloud serverless authorized-network update
 summary: ticloud serverless authorized-network update` のリファレンス。
 ---
 
-# ticloud サーバーレス 承認ネットワーク アップデート {#ticloud-serverless-authorized-network-update}
+# ticloud serverless authorized-network update {#ticloud-serverless-authorized-network-update}
 
 承認済みネットワークを更新します。
 

--- a/tidb-cloud/ticloud-serverless-capacity.md
+++ b/tidb-cloud/ticloud-serverless-capacity.md
@@ -3,7 +3,7 @@ title: ticloud serverless capacity
 summary: ticloud serverless capacity` のリファレンス。
 ---
 
-# ticloud サーバーレス容量 {#ticloud-serverless-capacity}
+# ticloud serverless capacity {#ticloud-serverless-capacity}
 
 TiDB Cloudクラスターの容量を、最大および最小のリクエスト容量単位 (RCU) に基づいて設定します。
 

--- a/tidb-cloud/ticloud-serverless-export-cancel.md
+++ b/tidb-cloud/ticloud-serverless-export-cancel.md
@@ -3,7 +3,7 @@ title: ticloud serverless export cancel
 summary: ticloud serverless export cancel` の参照。
 ---
 
-# ticloud サーバーレスエクスポートのキャンセル {#ticloud-serverless-export-cancel}
+# ticloud serverless export cancel {#ticloud-serverless-export-cancel}
 
 データ エクスポート タスクをキャンセルします。
 

--- a/tidb-cloud/ticloud-serverless-export-create.md
+++ b/tidb-cloud/ticloud-serverless-export-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless export create
 summary: ticloud serverless export create` のリファレンス。
 ---
 
-# ticloud サーバーレスエクスポート作成 {#ticloud-serverless-export-create}
+# ticloud serverless export create {#ticloud-serverless-export-create}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターからデータをエクスポートします。
 

--- a/tidb-cloud/ticloud-serverless-export-describe.md
+++ b/tidb-cloud/ticloud-serverless-export-describe.md
@@ -3,7 +3,7 @@ title: ticloud serverless export describe
 summary: ticloud serverless export describe` のリファレンス。
 ---
 
-# ticloud サーバーレスエクスポートの説明 {#ticloud-serverless-export-describe}
+# ticloud serverless export describe {#ticloud-serverless-export-describe}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターのエクスポート情報を取得します。
 

--- a/tidb-cloud/ticloud-serverless-export-download.md
+++ b/tidb-cloud/ticloud-serverless-export-download.md
@@ -3,7 +3,7 @@ title: ticloud serverless export download
 summary: ticloud serverless export download` のリファレンス。
 ---
 
-# ticloud サーバーレスエクスポートのダウンロード {#ticloud-serverless-export-download}
+# ticloud serverless export download {#ticloud-serverless-export-download}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターからエクスポートされたデータをローカルストレージにダウンロードします。
 

--- a/tidb-cloud/ticloud-serverless-export-list.md
+++ b/tidb-cloud/ticloud-serverless-export-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless export list
 summary: ticloud serverless export list` のリファレンス。
 ---
 
-# ticloud サーバーレスエクスポートリスト {#ticloud-serverless-export-list}
+# ticloud serverless export list {#ticloud-serverless-export-list}
 
 TiDB Cloud Starter およびTiDB Cloud Essential クラスターのデータ エクスポート タスクを一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-region.md
+++ b/tidb-cloud/ticloud-serverless-region.md
@@ -4,7 +4,7 @@ summary: ticloud serverless region` のリファレンス。
 aliases: ['/ja/tidbcloud/ticloud-serverless-regions']
 ---
 
-# ticloud サーバーレスリージョン {#ticloud-serverless-region}
+# ticloud serverless region {#ticloud-serverless-region}
 
 TiDB Cloud Starter およびTiDB Cloud Essential で利用可能なすべてのリージョンを一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-shell.md
+++ b/tidb-cloud/ticloud-serverless-shell.md
@@ -4,7 +4,7 @@ summary: ticloud serverless shell` のリファレンス。
 aliases: ['/ja/tidbcloud/ticloud-connect']
 ---
 
-# ticloud サーバーレスシェル {#ticloud-serverless-shell}
+# ticloud serverless shell {#ticloud-serverless-shell}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターに接続します。
 

--- a/tidb-cloud/ticloud-serverless-spending-limit.md
+++ b/tidb-cloud/ticloud-serverless-spending-limit.md
@@ -3,7 +3,7 @@ title: ticloud serverless spending-limit
 summary: ticloud serverless spending-limit` のリファレンス。
 ---
 
-# ticloud サーバーレス支出制限 {#ticloud-serverless-spending-limit}
+# ticloud serverless spending-limit {#ticloud-serverless-spending-limit}
 
 TiDB Cloud Serverless クラスターの月間最大数[支出限度額](/tidb-cloud/manage-serverless-spend-limit.md)設定します。
 

--- a/tidb-cloud/ticloud-serverless-sql-user-create.md
+++ b/tidb-cloud/ticloud-serverless-sql-user-create.md
@@ -3,7 +3,7 @@ title: ticloud serverless sql-user create
 summary: ticloud serverless sql-user create` のリファレンス。
 ---
 
-# ticloud サーバーレス SQL ユーザー作成 {#ticloud-serverless-sql-user-create}
+# ticloud serverless sql-user create {#ticloud-serverless-sql-user-create}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターで SQL ユーザーを作成します。
 

--- a/tidb-cloud/ticloud-serverless-sql-user-delete.md
+++ b/tidb-cloud/ticloud-serverless-sql-user-delete.md
@@ -3,7 +3,7 @@ title: ticloud serverless sql-user delete
 summary: ticloud serverless sql-user delete` のリファレンス。
 ---
 
-# ticloud サーバーレス SQL ユーザー削除 {#ticloud-serverless-sql-user-delete}
+# ticloud serverless sql-user delete {#ticloud-serverless-sql-user-delete}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターから SQL ユーザーを削除します。
 

--- a/tidb-cloud/ticloud-serverless-sql-user-list.md
+++ b/tidb-cloud/ticloud-serverless-sql-user-list.md
@@ -3,7 +3,7 @@ title: ticloud serverless sql-user list
 summary: ticloud serverless sql-user list` のリファレンス。
 ---
 
-# ticloud サーバーレス SQL ユーザーリスト {#ticloud-serverless-sql-user-list}
+# ticloud serverless sql-user list {#ticloud-serverless-sql-user-list}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスター内の SQL ユーザーを一覧表示します。
 

--- a/tidb-cloud/ticloud-serverless-sql-user-update.md
+++ b/tidb-cloud/ticloud-serverless-sql-user-update.md
@@ -3,7 +3,7 @@ title: ticloud serverless sql-user update
 summary: ticloud serverless sql-user update` のリファレンス。
 ---
 
-# ticloud サーバーレス SQL ユーザー更新 {#ticloud-serverless-sql-user-update}
+# ticloud serverless sql-user update {#ticloud-serverless-sql-user-update}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスター内の SQL ユーザーを更新します。
 

--- a/tidb-cloud/ticloud-serverless-update.md
+++ b/tidb-cloud/ticloud-serverless-update.md
@@ -3,7 +3,7 @@ title: ticloud serverless update
 summary: ticloud serverless update` のリファレンス。
 ---
 
-# ticloud サーバーレスアップデート {#ticloud-serverless-update}
+# ticloud serverless update {#ticloud-serverless-update}
 
 TiDB Cloud Starter またはTiDB Cloud Essential クラスターを更新します。
 

--- a/tidb-cloud/ticloud-upgrade.md
+++ b/tidb-cloud/ticloud-upgrade.md
@@ -4,7 +4,7 @@ summary: ticloud アップグレード` のリファレンス。
 aliases: ['/ja/tidbcloud/ticloud-update']
 ---
 
-# ticloud アップグレード {#ticloud-upgrade}
+# ticloud upgrade {#ticloud-upgrade}
 
 TiDB Cloud CLI を最新バージョンにアップグレードします。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Restore English `# ticloud <command>` H1 headings across all 51 TiDB Cloud CLI reference pages under `tidb-cloud/`.

Previously the page H1 was translated into Japanese (for example `# ticloud サーバーレス作成`, `# ticloud 認証ログアウト`, `# ticloud 設定リスト`). This was inconsistent with:

- the `title:` front-matter (which already used the English subcommand),
- the embedded `{#ticloud-...}` anchor IDs,
- the command-line examples shown in the body,
- the rest of the `tiup-*` CLI reference pages in the same repo, which keep English H1s such as `# tiup cluster rename`.

Each page is updated so the H1 matches the literal `ticloud` subcommand shown in the front-matter `title:` and in the code samples, e.g. `# ticloud serverless create {#ticloud-serverless-create}`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
