### PR TITLE
lake: hide python fallback track metrics history

### DIFF
--- a/TOC-tidb-cloud-lake.md
+++ b/TOC-tidb-cloud-lake.md
@@ -18,7 +18,6 @@
 - Administration
   - [AI-Powered Features](/tidb-cloud-lake/guides/ai-powered-features.md)
   - [Manage Costs](/tidb-cloud-lake/guides/manage-costs.md)
-  - [Track Metrics with Prometheus](/tidb-cloud-lake/guides/track-metrics.md)
   - [Monitor Usage](/tidb-cloud-lake/guides/monitor-usage.md)
 - Security
   - [Authenticate with AWS IAM Role](/tidb-cloud-lake/guides/authenticate-with-aws-iam-role.md)

--- a/tidb-cloud-lake/_index.md
+++ b/tidb-cloud-lake/_index.md
@@ -31,9 +31,9 @@ summary: TiDB Cloud Lake is a cloud-native data warehouse service for analytics 
 
 [Connection Overview](https://docs.tidb.io/tidbcloudlake/connection-overview/)
 
-[Connect to TiDB Cloud Lake Using DBeaver](https://docs.tidb.io/tidbcloudlake/connect-using-dbeaver/)
+[Connect Using LakeSQL](https://docs.tidb.io/tidbcloudlake/connect-using-lakesql/)
 
-[Connect to TiDB Cloud Lake Using Golang](https://docs.tidb.io/tidbcloudlake/connect-using-golang/)
+[Connect Using Golang](https://docs.tidb.io/tidbcloudlake/connect-using-golang/)
 
 </LearningPath>
 

--- a/tidb-cloud-lake/_index.md
+++ b/tidb-cloud-lake/_index.md
@@ -27,7 +27,7 @@ summary: TiDB Cloud Lake is a cloud-native data warehouse service for analytics 
 
 </LearningPath>
 
-<LearningPath label="Develop" icon="doc8">
+<LearningPath label="Connect" icon="doc8">
 
 [Connection Overview](https://docs.tidb.io/tidbcloudlake/connection-overview/)
 

--- a/tidb-cloud-lake/guides/connect-using-python.md
+++ b/tidb-cloud-lake/guides/connect-using-python.md
@@ -14,13 +14,12 @@ Choose your preferred approach:
 | Package | Best For | Installation |
 |---------|----------|-------------|
 | **tidbcloudlake-driver** | Direct database operations, async/await | `pip install tidbcloudlake-driver` |
-| **databend-sqlalchemy** | ORM integration, existing SQLAlchemy apps | `pip install databend-sqlalchemy` |
 
 **Connection String**: See [driver overview](/tidb-cloud-lake/guides/driver-overview.md) for DSN format and examples.
 
 ---
 
-## tidbcloudlake-driver (Recommended)
+## tidbcloudlake-driver
 
 ### Features
 
@@ -105,23 +104,6 @@ async def main():
 
 asyncio.run(main())
 ```
-
----
-
-## databend-sqlalchemy
-
-For SQLAlchemy ORM integration:
-
-```python
-from sqlalchemy import create_engine, text
-
-engine = create_engine('<your-dsn>')
-with engine.connect() as conn:
-    result = conn.execute(text("SELECT 1"))
-    print(result.fetchall())
-```
-
----
 
 ## Data Type Mappings
 

--- a/tidb-cloud-lake/guides/connection-overview.md
+++ b/tidb-cloud-lake/guides/connection-overview.md
@@ -5,7 +5,7 @@ summary: TiDB Cloud Lake supports multiple connection methods to suit different 
 
 # Connect to TiDB Cloud Lake
 
-{{{ .lake }}} supports multiple connection methods to suit different use cases. All options below work with both **{{{ .lake }}}** and **self-hosted {{{ .lake }}}**.
+{{{ .lake }}} supports multiple connection methods to suit different use cases.
 
 ## Quick Selection
 

--- a/tidb-cloud-lake/guides/connection-overview.md
+++ b/tidb-cloud-lake/guides/connection-overview.md
@@ -11,7 +11,7 @@ summary: TiDB Cloud Lake supports multiple connection methods to suit different 
 
 | I want to... | Recommended |
 |-------------|-------------|
-| Run SQL queries interactively | **LakeSQL** (CLI) or **DBeaver** (GUI) |
+| Run SQL queries interactively | **LakeSQL** (CLI) |
 | Build an application | Language-specific **Driver** |
 | Create dashboards & reports | **BI/Visualization Tools** |
 

--- a/tidb-cloud-lake/sql/system-history-log-history.md
+++ b/tidb-cloud-lake/sql/system-history-log-history.md
@@ -43,22 +43,3 @@ the `message` field of another log entry might appear as follows:
 ```
 message: [HTTP-QUERY] Preparing to plan SQL query
 ```
-
-## Examples
-
-```sql
-SELECT * FROM system_history.log_history LIMIT 1;
-
-*************************** 1. row ***************************
-   timestamp: 2025-06-03 01:29:49.335455
-        path: databend_common_meta_client::channel_manager: channel_manager.rs:86
-      target: databend_common_meta_client::channel_manager
-   log_level: INFO
-  cluster_id: test_cluster
-     node_id: CkdmtwYXLRMhJIvVzl6i11
-warehouse_id: NULL
-    query_id: NULL
-     message: MetaChannelManager done building RealClient to 127.0.0.1:9191, start handshake
-      fields: {}
-batch_number: 41
-```


### PR DESCRIPTION
This PR removes the SQLAlchemy fallback from the Python guide, hides Track Metrics from the TOC, and trims the system_history.log_history page to keep only the explanatory content above the examples.

Checks:
- `git diff --check`
- Targeted `rg` scans for the removed strings
