### PR TITLE
lake: update supported regions and editions

### DIFF
--- a/tidb-cloud-lake/guides/editions.md
+++ b/tidb-cloud-lake/guides/editions.md
@@ -94,11 +94,3 @@ The following are feature lists of {{{ .lake }}} among editions:
 |----------|----------|----------|-----------|
 | Streams for tracking table changes. | ✓ | ✓ | ✓ |
 | Tasks for scheduling the execution of SQL statements, often in conjunction with table streams. | ✓ | ✓ | ✓ |
-
-### Customer Support
-
-| Features | Personal | Business | Dedicated |
-|----------|----------|----------|-----------|
-| Logging and tracking support tickets. | ✓ | ✓ | ✓ |
-| 4/7 coverage and 1-hour response window for Severity 1 issues. | ✓ | ✓ | ✓ |
-| **Response to non-severity-1 issues in hours**. | 8h | 4h | 1h |

--- a/tidb-cloud-lake/guides/platforms-regions.md
+++ b/tidb-cloud-lake/guides/platforms-regions.md
@@ -9,10 +9,10 @@ summary: Learn about the supported cloud platforms and regions for TiDB Cloud La
 
 | Platform                     | Region ID      |
 | ---------------------------- | -------------- |
-| AWS US East (Ohio)           | us-east-2      |
 | AWS US West (Oregon)         | us-west-2      |
+| AWS Asia Pacific (Tokyo)     | ap-northeast-1 |
+| AWS US East (N. Virginia)    | us-east-1      |
 | AWS Asia Pacific (Singapore) | ap-southeast-1 |
-| AWS Europe (Frankfurt)       | eu-central-1   |
 
 > **Note:**
 >


### PR DESCRIPTION
## Summary

- Update the TiDB Cloud Lake supported AWS regions list.
- Remove regions that are no longer listed as supported.
- Add Tokyo and N. Virginia to match the current support matrix.

## Checks

- `./scripts/markdownlint tidb-cloud-lake/guides/platforms-regions.md`
- `git diff --check`
