### PR TITLE
config: fix heading hierarchy for sub-section levels in tidb-configuration-file.md

### DIFF
--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -660,13 +660,13 @@ Configuration items related to opentracing.
 
 Configuration items related to opentracing.sampler.
 
-### `type`
+#### `type`
 
 + Specifies the type of the opentracing sampler. The string value is case-insensitive.
 + Default value: `"const"`
 + Value options: `"const"`, `"probabilistic"`, `"ratelimiting"`, `"remote"`
 
-### `param`
+#### `param`
 
 + The parameter of the opentracing sampler.
     - For the `const` type, the value can be `0` or `1`, which indicates whether to enable the `const` sampler.
@@ -675,17 +675,17 @@ Configuration items related to opentracing.sampler.
     - For the `remote` type, the parameter specifies the sampling probability, which can be a float number between `0` and `1`.
 + Default value: `1.0`
 
-### `sampling-server-url`
+#### `sampling-server-url`
 
 + The HTTP URL of the jaeger-agent sampling server.
 + Default value: `""`
 
-### `max-operations`
+#### `max-operations`
 
 + The maximum number of operations that the sampler can trace. If an operation is not traced, the default probabilistic sampler is used.
 + Default value: `0`
 
-### `sampling-refresh-interval`
+#### `sampling-refresh-interval`
 
 + Controls the frequency of polling the jaeger-agent sampling policy.
 + Default value: `0`
@@ -694,22 +694,22 @@ Configuration items related to opentracing.sampler.
 
 Configuration items related to opentracing.reporter.
 
-### `queue-size`
+#### `queue-size`
 
 + The queue size with which the reporter records spans in memory.
 + Default value: `0`
 
-### `buffer-flush-interval`
+#### `buffer-flush-interval`
 
 + The interval at which the reporter flushes the spans in memory to the storage.
 + Default value: `0`
 
-### `log-spans`
+#### `log-spans`
 
 + Determines whether to print the log for all submitted spans.
 + Default value: `false`
 
-### `local-agent-host-port`
+#### `local-agent-host-port`
 
 + The address at which the reporter sends spans to the jaeger-agent.
 + Default value: `""`
@@ -814,7 +814,7 @@ Configuration items related to opentracing.reporter.
 
 This section introduces configuration items related to the [Coprocessor Cache](/coprocessor-cache.md) feature.
 
-### `capacity-mb`
+#### `capacity-mb`
 
 - The total size of the cached data. When the cache space is full, old cache entries are evicted. When the value is `0.0`, the Coprocessor Cache feature is disabled.
 - Default value: `1000.0`

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -349,7 +349,7 @@ Configuration items related to log.
 - Unit: second
 - In some user scenarios, TiDB logs might be stored on hot-pluggable or network-attached disks, which might become permanently unavailable. In these cases, TiDB cannot recover automatically from such disaster and the log-writing operations will be permanently blocked. Although the TiDB process might seem to be running, it does not respond to any requests. This configuration item is designed to handle such situations.
 
-## log.file
+### log.file
 
 Configuration items related to log files.
 
@@ -656,7 +656,7 @@ Configuration items related to opentracing.
 + Enables RPC metrics.
 + Default value: `false`
 
-## opentracing.sampler
+### opentracing.sampler
 
 Configuration items related to opentracing.sampler.
 
@@ -690,7 +690,7 @@ Configuration items related to opentracing.sampler.
 + Controls the frequency of polling the jaeger-agent sampling policy.
 + Default value: `0`
 
-## opentracing.reporter
+### opentracing.reporter
 
 Configuration items related to opentracing.reporter.
 
@@ -810,7 +810,7 @@ Configuration items related to opentracing.reporter.
 + Whether to use the new version of the Region replica selector when sending RPC requests to TiKV.
 + Default value: `true`
 
-## tikv-client.copr-cache <span class="version-mark">New in v4.0.0</span>
+### tikv-client.copr-cache <span class="version-mark">New in v4.0.0</span>
 
 This section introduces configuration items related to the [Coprocessor Cache](/coprocessor-cache.md) feature.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix heading hierarchy in tidb-configuration-file.md for sub-section levels that incorrectly used `##` instead of `###`:

- `## log.file` → `### log.file` (child of `## log`)
- `## opentracing.sampler` → `### opentracing.sampler` (child of `## opentracing`)
- `## opentracing.reporter` → `### opentracing.reporter` (child of `## opentracing`)
- `## tikv-client.copr-cache` → `### tikv-client.copr-cache` (child of `## tikv-client`)

These dotted config key names indicate they belong to parent sections, so they should be rendered as sub-headings.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
