### PR TITLE
Fix broken external documentation links

### DIFF
--- a/ai/integrations/vector-search-integrate-with-langchain.md
+++ b/ai/integrations/vector-search-integrate-with-langchain.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to integrate [TiDB Vector Search](/ai/concepts/ve
 
 > **Tip**
 >
-> You can view the complete [TiDBVectorStore API reference](https://reference.langchain.com/python/integrations/langchain_community.vectorstores.tidb_vector.TiDBVectorStore/) in LangChain documentation.
+> You can view the complete [`TiDBVectorStore` API reference](https://reference.langchain.com/python/integrations/langchain_community.vectorstores.tidb_vector.TiDBVectorStore/) in LangChain documentation.
 
 ## Prerequisites
 

--- a/ai/integrations/vector-search-integrate-with-langchain.md
+++ b/ai/integrations/vector-search-integrate-with-langchain.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to integrate [TiDB Vector Search](/ai/concepts/ve
 
 > **Tip**
 >
-> You can view the complete [sample code](https://docs.langchain.com/oss/python/integrations/vectorstores/tidb_vector) in LangChain documentation.
+> You can view the complete [TiDBVectorStore API reference](https://reference.langchain.com/python/integrations/langchain_community.vectorstores.tidb_vector.TiDBVectorStore/) in LangChain documentation.
 
 ## Prerequisites
 

--- a/ai/integrations/vector-search-integrate-with-langchain.md
+++ b/ai/integrations/vector-search-integrate-with-langchain.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to integrate [TiDB Vector Search](/ai/concepts/ve
 
 > **Tip**
 >
-> You can view the complete [`TiDBVectorStore` API reference](https://reference.langchain.com/python/integrations/langchain_community.vectorstores.tidb_vector.TiDBVectorStore/) in LangChain documentation.
+> You can view the complete [`TiDBVectorStore` API reference](https://reference.langchain.com/python/langchain-community/vectorstores/tidb_vector/TiDBVectorStore) in LangChain documentation.
 
 ## Prerequisites
 

--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -781,7 +781,7 @@ The key fields of the preceding JSON data are explained as follows:
 
 ### Data type mapping
 
-The data format mapping in the TiCDC Debezium message basically follows the [Debezium data type mapping rules](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types), which is generally consistent with the native message of the Debezium Connector for MySQL. However, for some data types, the following differences exist between TiCDC Debezium and Debezium Connector messages:
+The data format mapping in the TiCDC Debezium message follows the [Debezium data type mapping rules](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types), which is consistent with the native message of the Debezium Connector for MySQL. However, for some data types, the following differences exist between TiCDC Debezium and Debezium Connector messages:
 
 - Currently, TiDB does not support spatial data types, including GEOMETRY, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, and GEOMETRYCOLLECTION.
 

--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -781,7 +781,7 @@ The key fields of the preceding JSON data are explained as follows:
 
 ### Data type mapping
 
-The data format mapping in the TiCDC Debezium message follows the [Debezium data type mapping rules](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types), which is consistent with the native message of the Debezium Connector for MySQL. However, for some data types, the following differences exist between TiCDC Debezium and Debezium Connector messages:
+The TiCDC Debezium message uses the [Debezium data type mapping rules](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types) as its baseline and is generally consistent with the native message of the Debezium Connector for MySQL. However, differences exist for some data types, as described below:
 
 - Currently, TiDB does not support spatial data types, including GEOMETRY, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, and GEOMETRYCOLLECTION.
 


### PR DESCRIPTION
### First-time contributors' checklist

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

Fixes #23161.

- Replaces the removed LangChain TiDB Vector sample page with the current `TiDBVectorStore` API reference.
- Replaces the version-specific Debezium MySQL 2.4 data-type mapping URL with the stable documentation URL.
- Clarifies that the Debezium rules are the mapping baseline while preserving the documented TiCDC differences.

Validation:

- Verified both replacement URLs return HTTP 200.
- Repository external-link, internal-link, Vale, duplicate-file-name, deletion, and CLA checks pass.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): #23161

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch