### PR TITLE
fix: remove merge conflict artifact in clinic-user-guide-for-tiup.md

### DIFF
--- a/clinic/clinic-user-guide-for-tiup.md
+++ b/clinic/clinic-user-guide-for-tiup.md
@@ -275,7 +275,6 @@ tiup diag upload
     ```bash
     [root@Copy-of-VM-EE-CentOS76-v1 user]# tiup diag upload /home/user/diag-fNTnz5MGhr6
     Starting component `diag`: /root/.tiup/components/diag/v0.7.0/diag upload /home/user/diag-fNTnz5MGhr6
-    >>>>>>>>>>>>>>>>>>>>>>>>>>>>>><>>>>>>>>>
     Completed!
     Download URL: "https://clinic.pingcap.com.cn/portal/#/orgs/4/clusters/XXXX"
     ```


### PR DESCRIPTION
Remove a stray line with conflict markers in clinic-user-guide-for-tiup.md that was left behind from a merge conflict resolution.