### PR TITLE
sql: remove unnecessary 'copy' from FLUSH PRIVILEGES description

### DIFF
--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -5,7 +5,7 @@ summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 
 # FLUSH PRIVILEGES
 
-The statement `FLUSH PRIVILEGES` instructs TiDB to reload the in-memory copy of privileges from the privilege tables. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
+The statement `FLUSH PRIVILEGES` instructs TiDB to reload the grant tables into memory. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
 
 ## Synopsis
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -5,7 +5,7 @@ summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 
 # FLUSH PRIVILEGES
 
-The statement `FLUSH PRIVILEGES` instructs TiDB to reload the grant tables into memory. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
+The `FLUSH PRIVILEGES` statement refreshes the in-memory privilege cache of TiDB from the privilege tables. You must execute this statement after manually editing privilege tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
 
 ## Synopsis
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -5,7 +5,7 @@ summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 
 # FLUSH PRIVILEGES
 
-The statement `FLUSH PRIVILEGES` instructs TiDB to reload the grant tables into memory. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
+The statement `FLUSH PRIVILEGES` instructs TiDB to reload the privileges from the grant tables. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
 
 ## Synopsis
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -5,7 +5,7 @@ summary: An overview of the usage of FLUSH PRIVILEGES for the TiDB database.
 
 # FLUSH PRIVILEGES
 
-The statement `FLUSH PRIVILEGES` instructs TiDB to reload the privileges from the grant tables. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
+The statement `FLUSH PRIVILEGES` instructs TiDB to reload the grant tables into memory. You must execute this statement after manually editing tables such as `mysql.user`. However, executing this statement is not necessary after using privilege statements like `GRANT` or `REVOKE`. To execute this statement, the `RELOAD` privilege is required.
 
 ## Synopsis
 

--- a/sql-statements/sql-statement-overview.md
+++ b/sql-statements/sql-statement-overview.md
@@ -278,7 +278,7 @@ TiDB uses SQL statements that aim to follow ISO/IEC SQL standards, with extensio
 | [`CREATE USER`](/sql-statements/sql-statement-create-user.md) | Creates a new user. |
 | [`DROP ROLE`](/sql-statements/sql-statement-drop-role.md) | Drops an existing role. |
 | [`DROP USER`](/sql-statements/sql-statement-drop-user.md) | Drops an existing user. |
-| [`FLUSH PRIVILEGES`](/sql-statements/sql-statement-flush-privileges.md) | Reloads the in-memory copy of privileges from the privilege tables. |
+| [`FLUSH PRIVILEGES`](/sql-statements/sql-statement-flush-privileges.md) | Reloads the grant tables into memory. |
 | [`GRANT <privileges>`](/sql-statements/sql-statement-grant-privileges.md) | Grants privileges. |
 | [`GRANT <role>`](/sql-statements/sql-statement-grant-role.md) | Grants a role. |
 | [`RENAME USER`](/sql-statements/sql-statement-rename-user.md) | Renames an existing user. |

--- a/sql-statements/sql-statement-overview.md
+++ b/sql-statements/sql-statement-overview.md
@@ -278,7 +278,7 @@ TiDB uses SQL statements that aim to follow ISO/IEC SQL standards, with extensio
 | [`CREATE USER`](/sql-statements/sql-statement-create-user.md) | Creates a new user. |
 | [`DROP ROLE`](/sql-statements/sql-statement-drop-role.md) | Drops an existing role. |
 | [`DROP USER`](/sql-statements/sql-statement-drop-user.md) | Drops an existing user. |
-| [`FLUSH PRIVILEGES`](/sql-statements/sql-statement-flush-privileges.md) | Reloads the grant tables into memory. |
+| [`FLUSH PRIVILEGES`](/sql-statements/sql-statement-flush-privileges.md) | Refreshes the in-memory privilege cache from the privilege tables. |
 | [`GRANT <privileges>`](/sql-statements/sql-statement-grant-privileges.md) | Grants privileges. |
 | [`GRANT <role>`](/sql-statements/sql-statement-grant-role.md) | Grants a role. |
 | [`RENAME USER`](/sql-statements/sql-statement-rename-user.md) | Renames an existing user. |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Align the `FLUSH PRIVILEGES` description with MySQL documentation. Changed:

- `reload the in-memory copy of privileges from the privilege tables`
- `reload the grant tables into memory`

MySQL's own documentation at https://dev.mysql.com/doc/refman/8.4/en/privilege-changes.html uses `reload the grant tables` without `copy`. TiDB documentation should follow the same concise style.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- Other reference link(s): https://dev.mysql.com/doc/refman/8.4/en/privilege-changes.html

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `FLUSH PRIVILEGES` reloads grant tables into memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->