### PR TITLE
v8.5.7: add max-ts configuration docs for v8.5.7

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -636,6 +636,33 @@ Configuration items related to the I/O rate limiter.
 + Value options: `"read-only"`, `"write-only"`, and `"all-io"`
 + Default value: `"write-only"`
 
+## storage.max-ts
+
+Configuration items related to `max-ts`.
+
+`max-ts` is the maximum read timestamp known to the current TiKV node. It ensures linearizability and transaction concurrency control semantics for async commit and one-phase commit (1PC) transactions.
+
+### `action-on-invalid-update` <span class="version-mark">New in v8.5.7</span>
+
++ Determines how TiKV handles invalid `max-ts` update requests. If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and [`max-drift`](#max-drift-new-in-v857)**, TiKV considers it an invalid `max-ts` update request. Invalid `max-ts` update requests might break the linearizability and transaction concurrency control semantics of the TiDB cluster.
++ Value options:
+    + `"panic"`: TiKV panics. If the PD TSO cached in TiKV is not updated in time, TiKV uses an approximate method for validation, in which case invalid requests do not cause TiKV panic.
+    + `"error"`: TiKV returns an error and stops processing the request.
+    + `"log"`: TiKV prints an error log but still processes the request.
++ Default value: `"panic"`
+
+### `cache-sync-interval` <span class="version-mark">New in v8.5.7</span>
+
++ Controls the interval at which TiKV updates its local PD TSO cache. TiKV periodically retrieves the latest timestamp from PD and caches it locally to check the validity of `max-ts`.
++ Default value: `"15s"`
+
+### `max-drift` <span class="version-mark">New in v8.5.7</span>
+
++ Specifies the maximum time by which the timestamp of a read or write request can exceed the PD TSO cached in TiKV.
++ If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and `max-drift`**, TiKV considers it an invalid `max-ts` update request and handles it according to the [`action-on-invalid-update`](#action-on-invalid-update-new-in-v857) configuration.
++ Default value: `"60s"`
++ It is recommended to set this value to at least three times the value of [`cache-sync-interval`](#cache-sync-interval-new-in-v857).
+
 ## pd
 
 ### `enable-forwarding` <span class="version-mark">New in v5.0.0</span>

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -649,7 +649,7 @@ Configuration items related to `max-ts`.
     + `"panic"`: TiKV panics. If the PD TSO cached in TiKV is not updated in time, TiKV uses an approximate method for validation, in which case invalid requests do not cause TiKV panic.
     + `"error"`: TiKV returns an error and stops processing the request.
     + `"log"`: TiKV prints an error log but still processes the request.
-+ Default value: `"panic"`
++ Default value: `"error"`
 
 ### `cache-sync-interval` <span class="version-mark">New in v8.5.7</span>
 
@@ -661,7 +661,7 @@ Configuration items related to `max-ts`.
 + Specifies the maximum time by which the timestamp of a read or write request can exceed the PD TSO cached in TiKV.
 + If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and `max-drift`**, TiKV considers it an invalid `max-ts` update request and handles it according to the [`action-on-invalid-update`](#action-on-invalid-update-new-in-v857) configuration.
 + Default value: `"60s"`
-+ This value must be greater than [`cache-sync-interval`](#cache-sync-interval-introduced-in-v857). Otherwise, TiKV fails configuration validation and cannot start.
++ This value must be greater than [`cache-sync-interval`](#cache-sync-interval-new-in-v857). Otherwise, TiKV fails configuration validation and cannot start.
 + It is recommended to set this value to at least three times the value of [`cache-sync-interval`](#cache-sync-interval-new-in-v857).
 
 ## pd

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -661,6 +661,7 @@ Configuration items related to `max-ts`.
 + Specifies the maximum time by which the timestamp of a read or write request can exceed the PD TSO cached in TiKV.
 + If a read or write request uses a timestamp that exceeds **the sum of the PD TSO cached in TiKV and `max-drift`**, TiKV considers it an invalid `max-ts` update request and handles it according to the [`action-on-invalid-update`](#action-on-invalid-update-new-in-v857) configuration.
 + Default value: `"60s"`
++ This value must be greater than [`cache-sync-interval`](#cache-sync-interval-introduced-in-v857). Otherwise, TiKV fails configuration validation and cannot start.
 + It is recommended to set this value to at least three times the value of [`cache-sync-interval`](#cache-sync-interval-new-in-v857).
 
 ## pd


### PR DESCRIPTION
This PR is translated from: https://github.com/pingcap/docs-cn/pull/21745

### What is changed, added or deleted? (Required)

cherry-pick from https://github.com/pingcap/docs-cn/pull/19380 with default value changes

Document the TiKV `storage.max-ts` configuration section for v8.5.7 on the release-8.5 branch, including:

- `action-on-invalid-update`
- `cache-sync-interval`
- `max-drift`

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)

### What is the related PR or file link(s)?

- TiKV PR: https://github.com/tikv/tikv/pull/19756
- Issue: https://github.com/tikv/tikv/issues/19755

### Do your changes match any of the following descriptions?

- [x] Configuration changes
- [ ] API changes
- [ ] SQL syntax changes
- [ ] Error code changes
- [ ] Others
