### PR TITLE
master: fix minor wording issues in backup-storages and top-sql docs

### DIFF
--- a/br/backup-and-restore-storages.md
+++ b/br/backup-and-restore-storages.md
@@ -154,8 +154,8 @@ You can configure the credentials used to access GCS in the following ways:
 
 If you want TiKV to use GCS WIF or ADC, you need to enable the `gcp_v2` external storage backend. **Starting from v8.5.7, TiKV enables the `gcp_v2` external storage backend by default.** You can configure `gcp_v2` in the following ways:
 
-- full backup and restore: set `[backup].gcp-v2-enable` to `true` in [TiKV Configuration File Descriptions](/tikv-configuration-file.md)
-- log backup: set `[log-backup].gcp-v2-enable` to `true` in [TiKV Configuration File Descriptions](/tikv-configuration-file.md)
+- Full backup and restore: set `[backup].gcp-v2-enable` to `true` in [TiKV Configuration File Descriptions](/tikv-configuration-file.md)
+- Log backup: set `[log-backup].gcp-v2-enable` to `true` in [TiKV Configuration File Descriptions](/tikv-configuration-file.md)
 
 The default values of the preceding two configuration items are both `true`. If you disable `gcp_v2`, TiKV continues to use the legacy GCS implementation. This implementation supports only Service Account JSON and does not support using WIF directly.
 

--- a/dashboard/top-sql.md
+++ b/dashboard/top-sql.md
@@ -121,7 +121,7 @@ The following are the common steps to use Top SQL.
 
         ![Select order by](/media/dashboard/v8.5-top-sql-usage-select-order-by.png)
 
-    > **Note**
+    > **Note:**
     >
     > `By Region`, `Order By Network`, and `Order By Logical IO` are only available when [TiKV Network IO collection (multi-dimensional)](#optional-enable-tikv-network-io-collection-new-in-v857-and-v900) is enabled. If this feature is not enabled but historical data still exists, the page will continue to display historical data and prompt that new data cannot be fully collected.
 


### PR DESCRIPTION
### What is changed, added or deleted?

- `br/backup-and-restore-storages.md`: capitalize first letters of two list items describing GCS configuration (`full` -> `Full`, `log` -> `Log`)
- `dashboard/top-sql.md`: add missing colon after `**Note**` in the admonition about TiKV Network IO collection

### Which TiDB version(s) do your changes apply to?

- [x] master (the latest development version)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/docs/pull/23225/commits/6e4c6d54b7dc76d782eb1a72201b09f10deccac0

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch