### PR TITLE
Document MySQL-compatible dual password support

### DIFF
--- a/mysql-schema/mysql-schema-user.md
+++ b/mysql-schema/mysql-schema-user.md
@@ -83,7 +83,7 @@ The `mysql.user` table contains several fields that can be categorized into thre
     * `authentication_string` and `plugin`: `authentication_string` stores the credentials for the user account. The credentials are interpreted based on the authentication plugin specified in the `plugin` field.
     * `Account_locked`: indicates whether the user account is locked.
     * `Password_reuse_history` and `Password_reuse_time`: used for [Password reuse policy](/password-management.md#password-reuse-policy).
-    * `User_attributes`: provides information about user comments and user attributes.
+    * `User_attributes`: provides information about user comments and user attributes. It also stores the secondary password under `$.additional_password` when [dual passwords](/password-management.md#dual-password-policy) are used.
     * `Token_issuer`: used for the [`tidb_auth_token`](/security-compatibility-with-mysql.md#tidb_auth_token) authentication plugin.
     * `Password_expired`, `Password_last_changed`, and `Password_lifetime`: used for [Password expiration policy](/password-management.md#password-expiration-policy).
 
@@ -102,7 +102,7 @@ The `mysql.user` table contains several fields that can be categorized into thre
     * `authentication_string` and `plugin`: `authentication_string` stores the credentials for the user account. The credentials are interpreted based on the authentication plugin specified in the `plugin` field.
     * `Account_locked`: indicates whether the user account is locked.
     * `Password_reuse_history` and `Password_reuse_time`: used for [Password reuse policy](https://docs.pingcap.com/tidb/stable/password-management#password-reuse-policy).
-    * `User_attributes`: provides information about user comments and user attributes.
+    * `User_attributes`: provides information about user comments and user attributes. It also stores the secondary password under `$.additional_password` when [dual passwords](https://docs.pingcap.com/tidb/stable/password-management#dual-password-policy) are used.
     * `Token_issuer`: used for the [`tidb_auth_token`](https://docs.pingcap.com/tidb/stable/security-compatibility-with-mysql#tidb_auth_token) authentication plugin.
     * `Password_expired`, `Password_last_changed`, and `Password_lifetime`: used for [Password expiration policy](https://docs.pingcap.com/tidb/stable/password-management#password-expiration-policy).
 

--- a/password-management.md
+++ b/password-management.md
@@ -12,6 +12,8 @@ To protect the security of user passwords, TiDB supports the following password 
 - Password reuse policy: prevent users from reusing old passwords.
 - Failed-login tracking and temporary account locking policy: temporarily lock a user account to prevent the same user from trying to log in after multiple login failures caused by wrong passwords.
 
+Starting from v9.0.0, TiDB also supports the dual password policy, which lets applications rotate passwords without downtime. For details, see [Dual password policy](#dual-password-policy).
+
 ## TiDB authentication credential storage
 
 To ensure the authenticity of user identity, TiDB uses passwords as credentials to authenticate users when they log in to the TiDB server.
@@ -357,6 +359,55 @@ ALTER USER 'test'@'localhost'
 > - If you set the password reuse policy multiple times, the last set value takes effect.
 > - The default value of the `PASSWORD HISTORY` and `PASSWORD REUSE INTERVAL` options is 0, which means that the reuse policy is disabled.
 > - When you modify a username, TiDB migrates the corresponding password history in the `mysql.password_history` system table from the original username to the new username.
+
+## Dual password policy
+
+Starting from v9.0.0, TiDB supports the MySQL-compatible [dual password policy](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords), which lets an account hold two valid passwords at the same time: a primary password and a secondary password. When many applications share one account, dual passwords let you rotate the password in phases without any downtime: establish a new primary password while the old password keeps working, migrate the applications one by one, and then discard the old password.
+
+A typical rotation works as follows:
+
+1. Set a new primary password and retain the current password as the secondary password:
+
+    ```sql
+    ALTER USER 'app_user'@'%' IDENTIFIED BY 'new_password' RETAIN CURRENT PASSWORD;
+    ```
+
+    At this point, `app_user` can log in with both `new_password` and the previous password.
+
+2. Update every application to use the new password.
+
+3. After all applications are migrated, discard the secondary password:
+
+    ```sql
+    ALTER USER 'app_user'@'%' DISCARD OLD PASSWORD;
+    ```
+
+    At this point, only `new_password` is valid.
+
+`SET PASSWORD` supports the same clause:
+
+```sql
+SET PASSWORD FOR 'app_user'@'%' = 'new_password' RETAIN CURRENT PASSWORD;
+```
+
+The secondary password is stored in the `User_attributes` column of the `mysql.user` system table and is not displayed in the output of [`SHOW CREATE USER`](/sql-statements/sql-statement-show-create-user.md).
+
+### Required privileges
+
+- Operating on your own account (including the `ALTER USER USER() ...` and `SET PASSWORD ... RETAIN CURRENT PASSWORD` forms) requires the `APPLICATION_PASSWORD_ADMIN` [dynamic privilege](/privilege-management.md#dynamic-privileges). The `CREATE USER` privilege or the `UPDATE` privilege on the `mysql` schema also suffices.
+- Operating on another account requires the normal cross-account authority: the `CREATE USER` privilege (or the `UPDATE` privilege on the `mysql` schema) for `ALTER USER`, and the `SUPER` privilege for `SET PASSWORD`. `APPLICATION_PASSWORD_ADMIN` does not grant authority over other accounts.
+
+### Restrictions
+
+- Dual passwords are only supported for accounts that authenticate with the `mysql_native_password`, `caching_sha2_password`, or `tidb_sm3_password` plugin.
+- `RETAIN CURRENT PASSWORD` requires a non-empty new password. Otherwise, TiDB reports the `ER_CURRENT_PASSWORD_CANNOT_BE_RETAINED` error.
+- `RETAIN CURRENT PASSWORD` requires a non-empty current password. Otherwise, TiDB reports the `ER_SECOND_PASSWORD_CANNOT_BE_EMPTY` error.
+- `RETAIN CURRENT PASSWORD` cannot be combined with a change of the authentication plugin. Otherwise, TiDB reports the `ER_PASSWORD_CANNOT_BE_RETAINED_ON_PLUGIN_CHANGE` error. Changing the authentication plugin without `RETAIN CURRENT PASSWORD` silently removes any existing secondary password.
+- Changing the primary password without `RETAIN CURRENT PASSWORD` leaves an existing secondary password unchanged.
+
+> **Note:**
+>
+> During a rolling upgrade, a retained secondary password authenticates only on TiDB nodes that are already upgraded to a version that supports dual passwords. The new primary password works on all nodes. Complete the cluster upgrade before relying on dual password rotation.
 
 ## Failed-login tracking and temporary account locking policy
 

--- a/password-management.md
+++ b/password-management.md
@@ -362,7 +362,7 @@ ALTER USER 'test'@'localhost'
 
 ## Dual password policy
 
-Starting from v9.0.0, TiDB supports the MySQL-compatible [dual password policy](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords), which lets an account hold two valid passwords at the same time: a primary password and a secondary password. When many applications share one account, dual passwords let you rotate the password in phases without any downtime: establish a new primary password while the old password keeps working, migrate the applications one by one, and then discard the old password.
+Starting from v9.0.0, TiDB supports the MySQL-compatible [dual password policy](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords), which allows an account to hold two valid passwords at the same time: a primary password and a secondary password. When many applications share one account, dual passwords let you rotate the password in phases without any downtime: establish a new primary password while the old password keeps working, migrate the applications one by one, and then discard the old password.
 
 A typical rotation works as follows:
 

--- a/password-management.md
+++ b/password-management.md
@@ -399,7 +399,7 @@ The secondary password is stored in the `User_attributes` column of the `mysql.u
 
 ### Restrictions
 
-- Dual passwords are only supported for accounts that authenticate with the `mysql_native_password`, `caching_sha2_password`, or `tidb_sm3_password` plugin.
+- TiDB only supports dual passwords for accounts that authenticate with the `mysql_native_password`, `caching_sha2_password`, or `tidb_sm3_password` plugin.
 - `RETAIN CURRENT PASSWORD` requires a non-empty new password. Otherwise, TiDB reports the `ER_CURRENT_PASSWORD_CANNOT_BE_RETAINED` error.
 - `RETAIN CURRENT PASSWORD` requires a non-empty current password. Otherwise, TiDB reports the `ER_SECOND_PASSWORD_CANNOT_BE_EMPTY` error.
 - `RETAIN CURRENT PASSWORD` cannot be combined with a change of the authentication plugin. Otherwise, TiDB reports the `ER_PASSWORD_CANNOT_BE_RETAINED_ON_PLUGIN_CHANGE` error. Changing the authentication plugin without `RETAIN CURRENT PASSWORD` silently removes any existing secondary password.

--- a/password-management.md
+++ b/password-management.md
@@ -12,7 +12,7 @@ To protect the security of user passwords, TiDB supports the following password 
 - Password reuse policy: prevent users from reusing old passwords.
 - Failed-login tracking and temporary account locking policy: temporarily lock a user account to prevent the same user from trying to log in after multiple login failures caused by wrong passwords.
 
-Starting from v9.0.0, TiDB also supports the dual password policy, which lets you rotate passwords for applications without downtime. For details, see [Dual password policy](#dual-password-policy).
+Starting from v8.5.7, TiDB also supports the dual password policy, which lets you rotate passwords for applications without downtime. For details, see [Dual password policy](#dual-password-policy).
 
 ## TiDB authentication credential storage
 
@@ -362,7 +362,7 @@ ALTER USER 'test'@'localhost'
 
 ## Dual password policy
 
-Starting from v9.0.0, TiDB supports the MySQL-compatible [dual password policy](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords), which allows an account to hold two valid passwords at the same time: a primary password and a secondary password. When many applications share one account, dual passwords let you rotate the password in phases without any downtime: establish a new primary password while the old password keeps working, migrate the applications one by one, and then discard the old password.
+Starting from v8.5.7, TiDB supports the MySQL-compatible [dual password policy](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords), which allows an account to hold two valid passwords at the same time: a primary password and a secondary password. When many applications share one account, dual passwords let you rotate the password in phases without any downtime: establish a new primary password while the old password keeps working, migrate the applications one by one, and then discard the old password.
 
 A typical rotation works as follows:
 

--- a/password-management.md
+++ b/password-management.md
@@ -402,7 +402,7 @@ TiDB stores the secondary password in the `User_attributes` column of the `mysql
 - TiDB only supports dual passwords for accounts that authenticate with the `mysql_native_password`, `caching_sha2_password`, or `tidb_sm3_password` plugin.
 - `RETAIN CURRENT PASSWORD` requires a non-empty new password. Otherwise, TiDB reports the `ER_CURRENT_PASSWORD_CANNOT_BE_RETAINED` error.
 - `RETAIN CURRENT PASSWORD` requires a non-empty current password. Otherwise, TiDB reports the `ER_SECOND_PASSWORD_CANNOT_BE_EMPTY` error.
-- `RETAIN CURRENT PASSWORD` cannot be combined with a change of the authentication plugin. Otherwise, TiDB reports the `ER_PASSWORD_CANNOT_BE_RETAINED_ON_PLUGIN_CHANGE` error. Changing the authentication plugin without `RETAIN CURRENT PASSWORD` silently removes any existing secondary password.
+- You cannot combine `RETAIN CURRENT PASSWORD` with a change of the authentication plugin. Otherwise, TiDB reports the `ER_PASSWORD_CANNOT_BE_RETAINED_ON_PLUGIN_CHANGE` error. Changing the authentication plugin without `RETAIN CURRENT PASSWORD` silently removes any existing secondary password.
 - Changing the primary password without `RETAIN CURRENT PASSWORD` leaves an existing secondary password unchanged.
 
 > **Note:**

--- a/password-management.md
+++ b/password-management.md
@@ -12,7 +12,7 @@ To protect the security of user passwords, TiDB supports the following password 
 - Password reuse policy: prevent users from reusing old passwords.
 - Failed-login tracking and temporary account locking policy: temporarily lock a user account to prevent the same user from trying to log in after multiple login failures caused by wrong passwords.
 
-Starting from v9.0.0, TiDB also supports the dual password policy, which lets applications rotate passwords without downtime. For details, see [Dual password policy](#dual-password-policy).
+Starting from v9.0.0, TiDB also supports the dual password policy, which lets you rotate passwords for applications without downtime. For details, see [Dual password policy](#dual-password-policy).
 
 ## TiDB authentication credential storage
 

--- a/password-management.md
+++ b/password-management.md
@@ -390,7 +390,7 @@ A typical rotation works as follows:
 SET PASSWORD FOR 'app_user'@'%' = 'new_password' RETAIN CURRENT PASSWORD;
 ```
 
-The secondary password is stored in the `User_attributes` column of the `mysql.user` system table and is not displayed in the output of [`SHOW CREATE USER`](/sql-statements/sql-statement-show-create-user.md).
+TiDB stores the secondary password in the `User_attributes` column of the `mysql.user` system table, and [`SHOW CREATE USER`](/sql-statements/sql-statement-show-create-user.md) does not display it in its output.
 
 ### Required privileges
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -274,6 +274,7 @@ Dynamic privileges include:
 * `SYSTEM_VARIABLES_ADMIN`
 * `ROLE_ADMIN`
 * `CONNECTION_ADMIN`
+* `APPLICATION_PASSWORD_ADMIN` allows privilege owners to use the `RETAIN CURRENT PASSWORD` and `DISCARD OLD PASSWORD` clauses on their own account. For details, see [Dual password policy](/password-management.md#dual-password-policy).
 * `PLACEMENT_ADMIN` allows privilege owners to create, modify, and remove placement policies.
 * `DASHBOARD_CLIENT` allows privilege owners to log in to TiDB Dashboard.
 * `RESTRICTED_TABLES_ADMIN` allows privilege owners to view system tables when SEM is enabled.

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -13,7 +13,6 @@ TiDB supports security features similar to MySQL 5.7, and also supports some sec
 - Column level permissions.
 - These permission attributes: `max_questions` and `max_updated`.
 - Password verification policy, which requires you to verify the current password when you change it.
-- Dual password policy.
 - Random password generation.
 - Multi-factor authentication.
 

--- a/sql-statements/sql-statement-alter-user.md
+++ b/sql-statements/sql-statement-alter-user.md
@@ -87,7 +87,7 @@ ALTER USER 'newuser' IDENTIFIED BY 'newpassword' RETAIN CURRENT PASSWORD;
 Query OK, 0 rows affected (0.02 sec)
 ```
 
-At this point, `newuser` can log in with both the new and the previous password. The secondary password is stored under `$.additional_password` in the `User_attributes` column of the `mysql.user` system table:
+At this point, `newuser` can log in with both the new and the previous password. TiDB stores the secondary password under `$.additional_password` in the `User_attributes` column of the `mysql.user` system table:
 
 ```sql
 SELECT JSON_EXTRACT(User_attributes, '$.additional_password') IS NOT NULL AS has_secondary FROM mysql.user WHERE User = 'newuser';

--- a/sql-statements/sql-statement-alter-user.md
+++ b/sql-statements/sql-statement-alter-user.md
@@ -12,13 +12,16 @@ This statement changes an existing user inside the TiDB privilege system. In the
 
 ```ebnf+diagram
 AlterUserStmt ::=
-    'ALTER' 'USER' IfExists (UserSpecList RequireClauseOpt ConnectionOptions PasswordOption LockOption AttributeOption | 'USER' '(' ')' 'IDENTIFIED' 'BY' AuthString) ResourceGroupNameOption
+    'ALTER' 'USER' IfExists (UserSpecList RequireClauseOpt ConnectionOptions PasswordOption LockOption AttributeOption | 'USER' '(' ')' ('IDENTIFIED' 'BY' AuthString DualPasswordOption | 'DISCARD' 'OLD' 'PASSWORD')) ResourceGroupNameOption
 
 UserSpecList ::=
     UserSpec ( ',' UserSpec )*
 
 UserSpec ::=
-    Username AuthOption
+    Username AuthOption DualPasswordOption
+
+DualPasswordOption ::=
+    ( 'RETAIN' 'CURRENT' 'PASSWORD' | 'DISCARD' 'OLD' 'PASSWORD' )?
 
 Username ::=
     StringName ('@' StringName | singleAtIdentifier)? | 'CURRENT_USER' OptionalBraces
@@ -73,6 +76,41 @@ mysql> SHOW CREATE USER 'newuser';
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 1 row in set (0.00 sec)
 ```
+
+Rotate the password for `newuser` without downtime using [dual passwords](/password-management.md#dual-password-policy): retain the current password as the secondary password while setting a new primary password, and discard it after all applications have switched to the new password. Both statements require the `APPLICATION_PASSWORD_ADMIN` dynamic privilege when operating on your own account.
+
+```sql
+ALTER USER 'newuser' IDENTIFIED BY 'newpassword' RETAIN CURRENT PASSWORD;
+```
+
+```
+Query OK, 0 rows affected (0.02 sec)
+```
+
+At this point, `newuser` can log in with both the new and the previous password. The secondary password is stored under `$.additional_password` in the `User_attributes` column of the `mysql.user` system table:
+
+```sql
+SELECT JSON_EXTRACT(User_attributes, '$.additional_password') IS NOT NULL AS has_secondary FROM mysql.user WHERE User = 'newuser';
+```
+
+```
++---------------+
+| has_secondary |
++---------------+
+|             1 |
++---------------+
+1 row in set (0.00 sec)
+```
+
+```sql
+ALTER USER 'newuser' DISCARD OLD PASSWORD;
+```
+
+```
+Query OK, 0 rows affected (0.02 sec)
+```
+
+After `DISCARD OLD PASSWORD`, only the new password is valid.
 
 Lock the user `newuser`:
 
@@ -216,6 +254,7 @@ SELECT USER, JSON_EXTRACT(User_attributes, "$.resource_group") FROM mysql.user W
 <CustomContent platform="tidb">
 
 * [TiDB User Account Management](/user-account-management.md)
+* [TiDB Password Management](/password-management.md)
 * [Security Compatibility with MySQL](/security-compatibility-with-mysql.md)
 
 </CustomContent>

--- a/sql-statements/sql-statement-set-password.md
+++ b/sql-statements/sql-statement-set-password.md
@@ -55,7 +55,7 @@ mysql> SHOW CREATE USER 'newuser';
 1 row in set (0.00 sec)
 ```
 
-Starting from v9.0.0, `SET PASSWORD ... RETAIN CURRENT PASSWORD` retains the current password as the secondary password while setting the new primary password, so both passwords remain valid during a password rotation. For details, see [Dual password policy](/password-management.md#dual-password-policy).
+Starting from v8.5.7, `SET PASSWORD ... RETAIN CURRENT PASSWORD` retains the current password as the secondary password while setting the new primary password, so both passwords remain valid during a password rotation. For details, see [Dual password policy](/password-management.md#dual-password-policy).
 
 ```sql
 SET PASSWORD FOR 'newuser' = 'newpassword' RETAIN CURRENT PASSWORD;

--- a/sql-statements/sql-statement-set-password.md
+++ b/sql-statements/sql-statement-set-password.md
@@ -12,7 +12,7 @@ This statement changes the user password for a user account in the TiDB system d
 
 ```ebnf+diagram
 SetPasswordStmt ::=
-    "SET" "PASSWORD" ( "FOR" Username )? "=" ( stringLit | "PASSWORD" "(" stringLit ")" )
+    "SET" "PASSWORD" ( "FOR" Username )? "=" ( stringLit | "PASSWORD" "(" stringLit ")" ) ( "RETAIN" "CURRENT" "PASSWORD" )?
 ```
 
 ## Examples
@@ -55,9 +55,21 @@ mysql> SHOW CREATE USER 'newuser';
 1 row in set (0.00 sec)
 ```
 
+Starting from v9.0.0, `SET PASSWORD ... RETAIN CURRENT PASSWORD` retains the current password as the secondary password while setting the new primary password, so both passwords remain valid during a password rotation. For details, see [Dual password policy](/password-management.md#dual-password-policy).
+
+```sql
+SET PASSWORD FOR 'newuser' = 'newpassword' RETAIN CURRENT PASSWORD;
+```
+
+```
+Query OK, 0 rows affected (0.01 sec)
+```
+
+Setting your own password with `RETAIN CURRENT PASSWORD` requires the `APPLICATION_PASSWORD_ADMIN` dynamic privilege. Setting the password of another account requires the `SUPER` privilege.
+
 ## MySQL compatibility
 
-The `SET PASSWORD` statement in TiDB is fully compatible with MySQL. If you find any compatibility differences, [report a bug](https://docs.pingcap.com/tidb/stable/support).
+The `SET PASSWORD` statement in TiDB is fully compatible with MySQL, except that TiDB does not support the `REPLACE 'current_auth_string'` clause for verifying the current password. If you find any compatibility differences, [report a bug](https://docs.pingcap.com/tidb/stable/support).
 
 ## See also
 


### PR DESCRIPTION
### First-time contributors' checklist

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

Documents the MySQL 8.0-compatible **dual password** feature being added in pingcap/tidb#68393 (`ALTER USER ... RETAIN CURRENT PASSWORD` / `DISCARD OLD PASSWORD`, `SET PASSWORD ... RETAIN CURRENT PASSWORD`, and the `APPLICATION_PASSWORD_ADMIN` dynamic privilege).

- `password-management.md`: new **Dual password policy** section — no-downtime rotation walkthrough, storage location (`mysql.user.User_attributes`), required privileges (self vs cross-account), restrictions (capable auth plugins; `ER_CURRENT_PASSWORD_CANNOT_BE_RETAINED`, `ER_SECOND_PASSWORD_CANNOT_BE_EMPTY`, `ER_PASSWORD_CANNOT_BE_RETAINED_ON_PLUGIN_CHANGE`), and a rolling-upgrade note.
- `sql-statements/sql-statement-alter-user.md`: `DualPasswordOption` in the synopsis + rotation example.
- `sql-statements/sql-statement-set-password.md`: `RETAIN CURRENT PASSWORD` in the synopsis + example + privilege note; also notes that the `REPLACE` clause is not supported.
- `privilege-management.md`: `APPLICATION_PASSWORD_ADMIN` added to the dynamic privileges list.
- `security-compatibility-with-mysql.md`: removed "Dual password policy" from the unsupported security features list.

> **Note to reviewers:** pingcap/tidb#68393 (master) and pingcap/tidb#69735 (release-8.5 backport) are both merged; the feature ships in **v8.5.7**, and the version notes say `Starting from v8.5.7`. This PR therefore applies to master **and** the v8.5 docs branch.

### Which TiDB version(s) do your changes apply to? (Required)

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): pingcap/tidb#68393, pingcap/tidb#68028 (parser), [MySQL dual passwords](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [x] Might cause conflicts after applied to another branch

