### PR TITLE
chore: remove v6.1 from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,6 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 - [ ] v7.5 (TiDB 7.5 versions)
 - [ ] v7.1 (TiDB 7.1 versions)
 - [ ] v6.5 (TiDB 6.5 versions)
-- [ ] v6.1 (TiDB 6.1 versions)
 
 ### What is the related PR or file link(s)?
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Currently, we maintain the following versions of TiDB documentation in different
 | [`release-6.4`](https://github.com/pingcap/docs/tree/release-6.4) | 6.4 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-6.3`](https://github.com/pingcap/docs/tree/release-6.3) | 6.3 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-6.2`](https://github.com/pingcap/docs/tree/release-6.2) | 6.2 Development Milestone Release (Archived documentation, no longer updated) |
-| [`release-6.1`](https://github.com/pingcap/docs/tree/release-6.1) | 6.1 LTS (Long-Term Support) version |
+| [`release-6.1`](https://github.com/pingcap/docs/tree/release-6.1) | 6.1 LTS (Long-Term Support) version (Archived documentation, no longer updated) |
 | [`release-6.0`](https://github.com/pingcap/docs/tree/release-6.0) | 6.0 Development Milestone Release (Archived documentation, no longer updated) |
 | [`release-5.4`](https://github.com/pingcap/docs/tree/release-5.4) | 5.4 stable version (Archived documentation, no longer updated) |
 | [`release-5.3`](https://github.com/pingcap/docs/tree/release-5.3) | 5.3 stable version (Archived documentation, no longer updated) |

--- a/TOC-tidb-releases.md
+++ b/TOC-tidb-releases.md
@@ -80,8 +80,6 @@
   - [6.3.0-DMR](/releases/release-6.3.0.md)
 - v6.2
   - [6.2.0-DMR](/releases/release-6.2.0.md)
-- v6.0
-  - [6.0.0-DMR](/releases/release-6.0.0-dmr.md)
 - End of Life Releases
   - v6.1
     - [6.1.7](/releases/release-6.1.7.md)
@@ -92,6 +90,8 @@
     - [6.1.2](/releases/release-6.1.2.md)
     - [6.1.1](/releases/release-6.1.1.md)
     - [6.1.0](/releases/release-6.1.0.md)
+  - v6.0
+    - [6.0.0-DMR](/releases/release-6.0.0-dmr.md)
   - v5.4
     - [5.4.3](/releases/release-5.4.3.md)
     - [5.4.2](/releases/release-5.4.2.md)

--- a/TOC-tidb-releases.md
+++ b/TOC-tidb-releases.md
@@ -80,18 +80,18 @@
   - [6.3.0-DMR](/releases/release-6.3.0.md)
 - v6.2
   - [6.2.0-DMR](/releases/release-6.2.0.md)
-- v6.1
-  - [6.1.7](/releases/release-6.1.7.md)
-  - [6.1.6](/releases/release-6.1.6.md)
-  - [6.1.5](/releases/release-6.1.5.md)
-  - [6.1.4](/releases/release-6.1.4.md)
-  - [6.1.3](/releases/release-6.1.3.md)
-  - [6.1.2](/releases/release-6.1.2.md)
-  - [6.1.1](/releases/release-6.1.1.md)
-  - [6.1.0](/releases/release-6.1.0.md)
 - v6.0
   - [6.0.0-DMR](/releases/release-6.0.0-dmr.md)
 - End of Life Releases
+  - v6.1
+    - [6.1.7](/releases/release-6.1.7.md)
+    - [6.1.6](/releases/release-6.1.6.md)
+    - [6.1.5](/releases/release-6.1.5.md)
+    - [6.1.4](/releases/release-6.1.4.md)
+    - [6.1.3](/releases/release-6.1.3.md)
+    - [6.1.2](/releases/release-6.1.2.md)
+    - [6.1.1](/releases/release-6.1.1.md)
+    - [6.1.0](/releases/release-6.1.0.md)
   - v5.4
     - [5.4.3](/releases/release-5.4.3.md)
     - [5.4.2](/releases/release-5.4.2.md)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Remove the `v6.1` checkbox from the PR template and mark `release-6.1` as archived in `README.md`.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
