### PR TITLE
i18n(ja): remove incorrect or unused dictionary entries from terms-en-ja.md

### DIFF
--- a/resources/terms-en-ja.md
+++ b/resources/terms-en-ja.md
@@ -31,7 +31,6 @@
 | Dedicated | Dedicated | TiDB Cloud plan name, keep in English. |
 | Deploy | デプロイ | Do not translate to 「配備」. |
 | disaster recovery | ディザスタリカバリ | No long vowel mark at end. |
-| Distinct Optimization | クエリの最適化 |  |
 | DM WebUI | DM WebUI | Keep space between DM and WebUI. |
 | Drainer | Drainer | TiDB Binlog component name, keep in English. Do not translate to 「ドレイナー」. |
 | druid | druid | Library name, keep in English. Do not translate to 「ドルイド」. |
@@ -40,7 +39,6 @@
 | Encryption at Rest | 保存時の暗号化 |  |
 | Essential | Essential | TiDB Cloud tier name, keep in English. |
 | EXPLAIN | EXPLAIN | SQL keyword, keep in English. Do not translate to 「説明」. |
-| EXPLAIN Walkthrough | EXPLAIN コマンド |  |
 | experimental | 実験的 |  |
 | Experimental | Experimental | When used as a feature label, keep in English. |
 | Expression index | 式インデックス | Do not translate to 「発見指数」. |
@@ -80,8 +78,6 @@
 | pessimistic | 悲観的 |  |
 | PingCAP | PingCAP | Company name, keep exact capitalization. |
 | Placement rules | 配置ルール |  |
-| Precision Math | 精密計算 |  |
-| Predicates Push Down | Predicate Push Down |  |
 | prepared statement | プリペアドステートメント |  |
 | Prepared Plan Cache | プリペアドプランキャッシュ | Do not translate to 「準備済みプランキャッシュ」. |
 | Primary Cluster | プライマリクラスター |  |
@@ -102,7 +98,6 @@
 | Scale in | スケールイン |  |
 | Scattering | Scattering | Technical term, keep in English. |
 | Secondary Cluster | セカンダリクラスター |  |
-| Secure | セキュリティ |  |
 | Sequence | シーケンス |  |
 | server | サーバー | Use long vowel mark. |
 | single point of failure | 単一障害点 |  |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove five incorrect or unused entries from `resources/terms-en-ja.md`:

- `Distinct Optimization → クエリの最適化`: semantically wrong mapping
- `EXPLAIN Walkthrough → EXPLAIN コマンド`: semantically wrong mapping
- `Precision Math → 精密計算`: suspicious mapping, unused
- `Predicates Push Down → Predicate Push Down`: JA column was English (data entry error)
- `Secure → セキュリティ`: wrong part of speech

These entries were identified during a review of PRs opened against the `i18n-ja-release-8.5` branch. With updated translation tooling, the old mistranslation patterns no longer occur.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch