### PR TITLE
i18n(ja): standardize exchange partition terminology

### DIFF
--- a/releases/release-6.3.0.md
+++ b/releases/release-6.3.0.md
@@ -40,7 +40,7 @@ TiDBバージョン: 6.3.0-DMR
 
     TiDB は[範囲列によるパーティション分割（列リスト）](/partitioned-table.md#range-columns-partitioning)をサポートしています。 `column_list`は単一列に制限されなくなりました。基本的な機能はMySQLと同じです。
 
--   [交換パーティション](/partitioned-table.md#partition-management)が GA になりました [#35996](https://github.com/pingcap/tidb/issues/35996) @[ymkzpx](https://github.com/ymkzpx)
+-   [パーティション交換](/partitioned-table.md#partition-management)が GA になりました [#35996](https://github.com/pingcap/tidb/issues/35996) @[ymkzpx](https://github.com/ymkzpx)
 
 -   TiFlashへのさらに 2 つの[ウィンドウ関数](/tiflash/tiflash-supported-pushdown-calculations.md)のプッシュダウンをサポート [#5579](https://github.com/pingcap/tiflash/issues/5579) @[SeaRise](https://github.com/SeaRise)
 

--- a/releases/release-7.5.6.md
+++ b/releases/release-7.5.6.md
@@ -72,7 +72,7 @@ TiDB バージョン: 7.5.6
     -   ハッシュパーティションテーブルで条件`is null`クエリを実行するとpanic[＃58374](https://github.com/pingcap/tidb/issues/58374) @ [Defined2014](https://github.com/Defined2014)が発生する問題を修正
     -   生成された列[＃58475](https://github.com/pingcap/tidb/issues/58475) @ [joechenrh](https://github.com/joechenrh)を含むパーティション テーブルをクエリするときにエラーが発生する問題を修正しました。
     -   TTLジョブが無視されたり、複数回処理されたりする問題を修正[＃59347](https://github.com/pingcap/tidb/issues/59347) @ [YangKeao](https://github.com/YangKeao)
-    -   パーティション交換の誤った判断により実行エラーが発生する問題を修正[＃59534](https://github.com/pingcap/tidb/issues/59534) @ [mjonss](https://github.com/mjonss)
+    -   パーティション交換での誤った判断により実行エラーが発生する問題を修正[＃59534](https://github.com/pingcap/tidb/issues/59534) @ [mjonss](https://github.com/mjonss)
     -   `tidb_audit_log`変数を複数レベルの相対パスで設定すると、ログディレクトリ[＃58971](https://github.com/pingcap/tidb/issues/58971) @ [lcwangchao](https://github.com/lcwangchao)でエラーが発生する問題を修正しました。
     -   Join の等価条件の両側のデータ型が異なると、 TiFlash [＃59877](https://github.com/pingcap/tidb/issues/59877) @ [yibin87](https://github.com/yibin87)で誤った結果が生じる可能性がある問題を修正しました。
 

--- a/releases/release-7.5.6.md
+++ b/releases/release-7.5.6.md
@@ -72,7 +72,7 @@ TiDB バージョン: 7.5.6
     -   ハッシュパーティションテーブルで条件`is null`クエリを実行するとpanic[＃58374](https://github.com/pingcap/tidb/issues/58374) @ [Defined2014](https://github.com/Defined2014)が発生する問題を修正
     -   生成された列[＃58475](https://github.com/pingcap/tidb/issues/58475) @ [joechenrh](https://github.com/joechenrh)を含むパーティション テーブルをクエリするときにエラーが発生する問題を修正しました。
     -   TTLジョブが無視されたり、複数回処理されたりする問題を修正[＃59347](https://github.com/pingcap/tidb/issues/59347) @ [YangKeao](https://github.com/YangKeao)
-    -   交換パーティションの誤った判断により実行エラーが発生する問題を修正[＃59534](https://github.com/pingcap/tidb/issues/59534) @ [mjonss](https://github.com/mjonss)
+    -   パーティション交換の誤った判断により実行エラーが発生する問題を修正[＃59534](https://github.com/pingcap/tidb/issues/59534) @ [mjonss](https://github.com/mjonss)
     -   `tidb_audit_log`変数を複数レベルの相対パスで設定すると、ログディレクトリ[＃58971](https://github.com/pingcap/tidb/issues/58971) @ [lcwangchao](https://github.com/lcwangchao)でエラーが発生する問題を修正しました。
     -   Join の等価条件の両側のデータ型が異なると、 TiFlash [＃59877](https://github.com/pingcap/tidb/issues/59877) @ [yibin87](https://github.com/yibin87)で誤った結果が生じる可能性がある問題を修正しました。
 

--- a/releases/release-8.5.2.md
+++ b/releases/release-8.5.2.md
@@ -46,7 +46,7 @@ TiDBバージョン：8.5.2
     -   分散ストレージおよびコンピューティングアーキテクチャのTiFlashノードを含むクラスタで`ALTER TABLE ... PLACEMENT POLICY ...`を実行した後、リージョンピアが誤ってTiFlash Compute ノードに追加される可能性がある問題を修正しました [#58633](https://github.com/pingcap/tidb/issues/58633) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   統計ファイルにnull値が含まれている場合、統計の手動読み込みに失敗することがある問題を修正 [#53966](https://github.com/pingcap/tidb/issues/53966) @[King-Dylan](https://github.com/King-Dylan)
     -   TTLジョブが無視されたり、複数回処理されたりする問題を修正 [#59347](https://github.com/pingcap/tidb/issues/59347) @[YangKeao](https://github.com/YangKeao)
-    -   交換パーティションでの誤った判断により実行が失敗する問題を修正 [#59534](https://github.com/pingcap/tidb/issues/59534) @[mjonss](https://github.com/mjonss)
+    -   パーティション交換での誤った判断により実行が失敗する問題を修正 [#59534](https://github.com/pingcap/tidb/issues/59534) @[mjonss](https://github.com/mjonss)
     -   バックグラウンドタスクがタイムアウトした際に、統計情報の例外処理が不適切であるためにメモリ内の統計情報が誤って削除される問題を修正 [#57901](https://github.com/pingcap/tidb/issues/57901) @[hawkingrei](https://github.com/hawkingrei)
     -   Grafana の**Stats Healthy Distribution**パネルのデータが正しくない可能性がある問題を修正 [#57176](https://github.com/pingcap/tidb/issues/57176) @[hawkingrei](https://github.com/hawkingrei)
     -   キャンセルされたTTLタスクが未コミットのセッションをグローバルセッションプールに配置する可能性がある問題を修正 [#58900](https://github.com/pingcap/tidb/issues/58900) @[YangKeao](https://github.com/YangKeao)


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Standardize the Japanese translation of "exchange partition" / "partition exchange".

Consistency rules:
- Feature/concept name: **パーティション交換** (compound noun, matching existing patterns like パーティション管理/パーティション選択)
- SQL command `EXCHANGE PARTITION`: **not translated** (kept as-is)

Changes (3 files):

| File | Before | After |
|---|---|---|
| releases/release-6.3.0.md | `交換パーティション`が GA | `パーティション交換`が GA |
| releases/release-7.5.6.md | `交換パーティション`の誤った判断 | `パーティション交換`の誤った判断 |
| releases/release-8.5.2.md | `交換パーティション`での誤った判断 | `パーティション交換`での誤った判断 |

Unchanged (verified not applicable):
- `EXCHANGE PARTITION` (SQL command): kept as-is ✓
- `MPP ハッシュパーティション交換演算子` (MPP Exchange operator, different concept): not changed ✓
- `パーティション交換` (already correct in global-indexes.md, release-6.5.6.md, release-7.1.2.md, release-7.4.0.md): not changed ✓

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (Japanese-only terminology consistency fix)
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch