### PR TITLE
docs: fix stale external links

### DIFF
--- a/ai/integrations/vector-search-integrate-with-langchain.md
+++ b/ai/integrations/vector-search-integrate-with-langchain.md
@@ -15,7 +15,7 @@ This tutorial demonstrates how to integrate [TiDB Vector Search](/ai/concepts/ve
 
 > **Tip**
 >
-> You can view the complete [sample code](https://docs.langchain.com/oss/python/integrations/vectorstores/tidb_vector) in LangChain documentation.
+> For the complete API, see [`TiDBVectorStore` in the LangChain reference](https://reference.langchain.com/python/langchain-community/vectorstores/tidb_vector/TiDBVectorStore).
 
 ## Prerequisites
 

--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -781,7 +781,7 @@ The key fields of the preceding JSON data are explained as follows:
 
 ### Data type mapping
 
-The data format mapping in the TiCDC Debezium message basically follows the [Debezium data type mapping rules](https://debezium.io/documentation/reference/2.4/connectors/mysql.html#mysql-data-types), which is generally consistent with the native message of the Debezium Connector for MySQL. However, for some data types, the following differences exist between TiCDC Debezium and Debezium Connector messages:
+The data format mapping in the TiCDC Debezium message basically follows the [Debezium data type mapping rules](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types), which is generally consistent with the native message of the Debezium Connector for MySQL. However, for some data types, the following differences exist between TiCDC Debezium and Debezium Connector messages:
 
 - Currently, TiDB does not support spatial data types, including GEOMETRY, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, and GEOMETRYCOLLECTION.
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist

- [ ] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

- Replace the removed LangChain TiDB integration guide with the current `TiDBVectorStore` API reference and update the link text to match its destination.
- Replace the removed Debezium 2.4 data type page with the maintained stable documentation URL.

This addresses the two URLs in #23248 that currently return HTTP 404. The MySQL worklog and WebGraphviz URLs listed in that issue currently return HTTP 200, so this PR leaves them unchanged.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): #23248

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

The Debezium link also exists on `release-8.5` and `release-8.1`, but the LangChain page does not have the same content on those branches. Cherry-picks should apply only the TiCDC link hunk.

### Validation

- `npx --yes markdownlint-cli@0.17.0 ai/integrations/vector-search-integrate-with-langchain.md ticdc/ticdc-debezium.md`
- `git diff --check`
- Both replacement URLs return HTTP 200 after redirects.
