### PR TITLE
sql-statements: document ALTER TABLE COMPRESSION='NONE' behavior

### DIFF
--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -189,7 +189,7 @@ The following major restrictions apply to `ALTER TABLE` in TiDB:
 
 - `ALTER TABLE t CACHE | NOCACHE` is a TiDB extension to MySQL syntax. For details, see [Cached Tables](/cached-tables.md).
 
-- `ALTER TABLE ... COMPRESSION` only accepts `NONE` (case-insensitive) and is a no-op. TiDB accepts this statement only for compatibility (for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute) and does not compress or uncompress any table data. Specifying other values, such as `ZLIB` or `LZ4`, returns the error `This type of ALTER TABLE is currently unsupported` (error code 8200). If you specify an unsupported `COMPRESSION` value together with other options in a single statement, none of the options take effect.
+- `ALTER TABLE ... COMPRESSION` accepts only the string literal `'NONE'` (case-insensitive) and is a no-op. TiDB accepts this statement only for compatibility, for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute. It does not compress or uncompress table data. Other values, such as `'ZLIB'` or `'LZ4'`, return error code 8200 (`This type of ALTER TABLE is currently unsupported`). If you specify an unsupported `COMPRESSION` value together with other options in a single statement, none of the options take effect.
 
 For further restrictions, see [MySQL Compatibility](/mysql-compatibility.md#ddl-operations).
 

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -189,6 +189,8 @@ The following major restrictions apply to `ALTER TABLE` in TiDB:
 
 - `ALTER TABLE t CACHE | NOCACHE` is a TiDB extension to MySQL syntax. For details, see [Cached Tables](/cached-tables.md).
 
+- `ALTER TABLE ... COMPRESSION` only accepts `'NONE'` (case-insensitive) and it is a no-op: the statement is accepted only for compatibility (for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute), and TiDB does not compress or uncompress any table data. Other values such as `'ZLIB'` and `'LZ4'` return the error `This type of ALTER TABLE is currently unsupported` (error code 8200). If an unsupported `COMPRESSION` value is specified together with other options in one statement, none of the options take effect.
+
 For further restrictions, see [MySQL Compatibility](/mysql-compatibility.md#ddl-operations).
 
 ## See also

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -189,7 +189,7 @@ The following major restrictions apply to `ALTER TABLE` in TiDB:
 
 - `ALTER TABLE t CACHE | NOCACHE` is a TiDB extension to MySQL syntax. For details, see [Cached Tables](/cached-tables.md).
 
-- `ALTER TABLE ... COMPRESSION` only accepts `'NONE'` (case-insensitive) and it is a no-op: the statement is accepted only for compatibility (for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute), and TiDB does not compress or uncompress any table data. Other values such as `'ZLIB'` and `'LZ4'` return the error `This type of ALTER TABLE is currently unsupported` (error code 8200). If an unsupported `COMPRESSION` value is specified together with other options in one statement, none of the options take effect.
+- `ALTER TABLE ... COMPRESSION` only accepts `NONE` (case-insensitive) and is a no-op. TiDB accepts this statement only for compatibility (for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute) and does not compress or uncompress any table data. Specifying other values, such as `ZLIB` or `LZ4`, returns the error `This type of ALTER TABLE is currently unsupported` (error code 8200). If you specify an unsupported `COMPRESSION` value together with other options in a single statement, none of the options take effect.
 
 For further restrictions, see [MySQL Compatibility](/mysql-compatibility.md#ddl-operations).
 

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -189,7 +189,7 @@ The following major restrictions apply to `ALTER TABLE` in TiDB:
 
 - `ALTER TABLE t CACHE | NOCACHE` is a TiDB extension to MySQL syntax. For details, see [Cached Tables](/cached-tables.md).
 
-- `ALTER TABLE ... COMPRESSION` accepts only the string literal `'NONE'` (case-insensitive) and is a no-op. TiDB accepts this statement only for compatibility, for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute. It does not compress or uncompress table data. Other values, such as `'ZLIB'` or `'LZ4'`, return error code 8200 (`This type of ALTER TABLE is currently unsupported`). If you specify an unsupported `COMPRESSION` value together with other options in a single statement, none of the options take effect.
+- `ALTER TABLE ... COMPRESSION` accepts only the string literal `'NONE'` (case-insensitive), but has no effect. TiDB accepts this statement only for MySQL compatibility, for example, for tables migrated from MySQL that carry a `COMPRESSION` attribute. It does not compress or uncompress table data. Other values, such as `'ZLIB'` or `'LZ4'`, return error code 8200 (`This type of ALTER TABLE is currently unsupported`). If you specify an unsupported `COMPRESSION` value together with other options in a single statement, none of the options take effect.
 
 For further restrictions, see [MySQL Compatibility](/mysql-compatibility.md#ddl-operations).
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Document the `ALTER TABLE ... COMPRESSION` behavior introduced by pingcap/tidb#62305:

- `ALTER TABLE ... COMPRESSION` only accepts `'NONE'` (case-insensitive) and it is a no-op (metadata-only; TiDB does not compress or uncompress any table data). This allows reverting the `COMPRESSION` attribute for tables migrated from MySQL.
- Other values such as `'ZLIB'` and `'LZ4'` return the error `This type of ALTER TABLE is currently unsupported` (error code 8200).
- If an unsupported `COMPRESSION` value is specified together with other options in one statement, none of the options take effect.

Added one item to the `MySQL compatibility` section of `sql-statements/sql-statement-alter-table.md`.

### Which TiDB version(s) do your changes apply to? (Required)

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): pingcap/tidb#62305

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `ALTER TABLE` MySQL compatibility guidance for the `COMPRESSION` option.
  * Clarified that only `'NONE'` (case-insensitive) is accepted and treated as a no-op; other values return an unsupported-operation error.
  * Documented that when an unsupported `COMPRESSION` value is used alongside other `ALTER TABLE` options in a single statement, none of the other options apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->