### PR TITLE
chore: rename AI Markdown translator references

### DIFF
--- a/.github/workflows/sync-doc-pr-zh-to-en.yml
+++ b/.github/workflows/sync-doc-pr-zh-to-en.yml
@@ -40,12 +40,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Checkout ai-pr-translator repository
+      - name: Checkout ai-markdown-translator repository
         uses: actions/checkout@v6
         with:
-          repository: "qiancai/ai-pr-translator"
+          repository: "qiancai/ai-markdown-translator"
           ref: "main"
-          path: "ai-pr-translator"
+          path: "ai-markdown-translator"
           persist-credentials: false
 
       - name: Set up Python
@@ -54,7 +54,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install dependencies
-        run: pip install -r ai-pr-translator/scripts/requirements.txt
+        run: pip install -r ai-markdown-translator/scripts/requirements.txt
 
       - name: Extract PR information
         id: extract_info
@@ -185,7 +185,7 @@ jobs:
           TARGET_REPO_PATH: ${{ github.workspace }}/target_repo
           TERMS_PATH: ${{ github.workspace }}/target_repo/resources/terms.md
         run: |
-          cd ai-pr-translator/scripts
+          cd ai-markdown-translator/scripts
           if python main_workflow.py; then
             echo "sync_success=true" >> $GITHUB_OUTPUT
             echo "✅ Sync script completed successfully"

--- a/.github/workflows/translation-cron.yml
+++ b/.github/workflows/translation-cron.yml
@@ -38,7 +38,7 @@ env:
       ]
     }
   INDEX_FILES: _index.md,ai/_index.md,api/_index.md,best-practices/_index.md,develop/_index.md,releases/_index.md,tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md
-  AI_TRANSLATOR_REPO: qiancai/ai-pr-translator
+  AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
 
 jobs:
@@ -75,11 +75,11 @@ jobs:
           persist-credentials: false
 
       - uses: actions/checkout@v6
-        name: Checkout ai-pr-translator
+        name: Checkout ai-markdown-translator
         with:
           repository: ${{ env.AI_TRANSLATOR_REPO }}
           ref: ${{ env.AI_TRANSLATOR_REF }}
-          path: ai-pr-translator
+          path: ai-markdown-translator
           persist-credentials: false
 
       - uses: actions/setup-python@v6
@@ -87,14 +87,14 @@ jobs:
         with:
           python-version: "3.9"
           cache: pip
-          cache-dependency-path: ai-pr-translator/scripts/requirements.txt
+          cache-dependency-path: ai-markdown-translator/scripts/requirements.txt
 
       - name: Install Python dependencies
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          pip install -r ai-pr-translator/scripts/requirements.txt
+          pip install -r ai-markdown-translator/scripts/requirements.txt
 
       - name: Resolve commit range
         id: commits
@@ -142,7 +142,7 @@ jobs:
           INDEX_FILES: ${{ env.INDEX_FILES }}
         run: |
           set -euo pipefail
-          python ai-pr-translator/scripts/resolve_cloud_source_files.py
+          python ai-markdown-translator/scripts/resolve_cloud_source_files.py
 
       - name: Run commit sync workflow
         id: sync
@@ -174,7 +174,7 @@ jobs:
           FAIL_ON_TRANSLATION_ERROR: "true"
         run: |
           set -euo pipefail
-          cd ai-pr-translator/scripts
+          cd ai-markdown-translator/scripts
           python commit_sync_workflow.py
 
       - name: Post-process translated TOCs
@@ -243,7 +243,7 @@ jobs:
         env:
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
-          FAILURE_REPORT: ${{ github.workspace }}/ai-pr-translator/scripts/temp_output/translation-failures.md
+          FAILURE_REPORT: ${{ github.workspace }}/ai-markdown-translator/scripts/temp_output/translation-failures.md
         run: |
           set -euo pipefail
 
@@ -294,7 +294,7 @@ jobs:
           body: |
             ### What is changed, added or deleted? (Required)
 
-            Translate documentation changes from `pingcap/docs` `${{ env.SOURCE_BRANCH }}` to Japanese via `ai-pr-translator` commit-diff sync.
+            Translate documentation changes from `pingcap/docs` `${{ env.SOURCE_BRANCH }}` to Japanese via `ai-markdown-translator` commit-diff sync.
 
             English commit diff:
 

--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -29,7 +29,7 @@ env:
   CN_CLOUD_BRANCH: i18n-zh-release-8.5
   CLOUD_TOC_FILES: TOC-tidb-cloud.md,TOC-tidb-cloud-starter.md,TOC-tidb-cloud-essential.md,TOC-tidb-cloud-premium.md,TOC-tidb-cloud-releases.md
   CLOUD_INDEX_FILES: tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md
-  AI_TRANSLATOR_REPO: qiancai/ai-pr-translator
+  AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
 
 jobs:
@@ -66,11 +66,11 @@ jobs:
           persist-credentials: false
 
       - uses: actions/checkout@v6
-        name: Checkout ai-pr-translator
+        name: Checkout ai-markdown-translator
         with:
           repository: ${{ env.AI_TRANSLATOR_REPO }}
           ref: ${{ env.AI_TRANSLATOR_REF }}
-          path: ai-pr-translator
+          path: ai-markdown-translator
           persist-credentials: false
 
       - uses: actions/setup-python@v6
@@ -78,14 +78,14 @@ jobs:
         with:
           python-version: "3.9"
           cache: pip
-          cache-dependency-path: ai-pr-translator/scripts/requirements.txt
+          cache-dependency-path: ai-markdown-translator/scripts/requirements.txt
 
       - name: Install Python dependencies
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          pip install -r ai-pr-translator/scripts/requirements.txt
+          pip install -r ai-markdown-translator/scripts/requirements.txt
 
       - name: Resolve commit range
         id: commits
@@ -133,7 +133,7 @@ jobs:
           CLOUD_INDEX_FILES: ${{ env.CLOUD_INDEX_FILES }}
         run: |
           set -euo pipefail
-          python ai-pr-translator/scripts/resolve_cloud_source_files.py
+          python ai-markdown-translator/scripts/resolve_cloud_source_files.py
 
       - name: Run commit sync workflow
         id: sync
@@ -166,7 +166,7 @@ jobs:
           SKIP_TRANSLATING_AI_DOCS_TO_ZH: "true"
         run: |
           set -euo pipefail
-          cd ai-pr-translator/scripts
+          cd ai-markdown-translator/scripts
           python commit_sync_workflow.py
 
       - name: Prepare translated changes
@@ -177,7 +177,7 @@ jobs:
         env:
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
-          FAILURE_REPORT: ${{ github.workspace }}/ai-pr-translator/scripts/temp_output/translation-failures.md
+          FAILURE_REPORT: ${{ github.workspace }}/ai-markdown-translator/scripts/temp_output/translation-failures.md
         run: |
           set -euo pipefail
 
@@ -226,7 +226,7 @@ jobs:
           body: |
             ### What is changed, added or deleted? (Required)
 
-            Translate Cloud documentation changes from `pingcap/docs` `${{ env.SOURCE_BRANCH }}` to Chinese via `ai-pr-translator` commit-diff sync.
+            Translate Cloud documentation changes from `pingcap/docs` `${{ env.SOURCE_BRANCH }}` to Chinese via `ai-markdown-translator` commit-diff sync.
 
             English commit diff:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the GitHub Actions workflows to use the renamed `qiancai/ai-markdown-translator` repository and matching checkout paths.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): https://github.com/qiancai/ai-markdown-translator

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated documentation translation workflows to use the latest Markdown translation tooling.
  * Improved translation dependency installation, source-file resolution, synchronization, and failure reporting.
  * Updated generated pull request descriptions to reflect the revised translation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->