### PR TITLE
i18n(ja): restore the pre_split_regions heading so its anchor resolves

### DIFF
--- a/sql-statements/sql-statement-split-region.md
+++ b/sql-statements/sql-statement-split-region.md
@@ -350,7 +350,7 @@ SPLIT TABLE t1 INDEX idx4 BY ("a", "2000-01-01 00:00:01"), ("b", "2019-04-17 14:
     SPLIT PARTITION TABLE t PARTITION (p1,p2) INDEX idx BETWEEN (0) AND (20000) REGIONS 2;
     ```
 
-## 分割前リージョン {#pre-split-regions}
+## pre_split_regions {#pre_split_regions}
 
 `AUTO_RANDOM`または`SHARD_ROW_ID_BITS`属性を使用してテーブルを作成する場合、テーブル作成直後にテーブルをリージョンに均等に事前分割したい場合は`PRE_SPLIT_REGIONS`オプションを指定することもできます。テーブルの事前分割リージョンの数は`2^(PRE_SPLIT_REGIONS)`です。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

**All nine ja links to `#pre_split_regions` are currently dead.**

The English heading is the identifier itself:

```
EN: ## pre_split_regions
JA: ## 分割前リージョン {#pre-split-regions}
```

Translating the heading changed the anchor from `pre_split_regions` to `pre-split-regions`, while every link in the ja docs still points at `#pre_split_regions`. Restoring the identifier as the heading text — and pinning the anchor explicitly — fixes all nine at once.

`分割前` was also a mistranslation of the feature: `PRE_SPLIT_REGIONS` splits the Regions **in advance**, whereas 「分割前の」 reads as "before splitting".

The same PR also aligns one link's text with its eight siblings:

```
-[分割前のリージョン](/sql-statements/sql-statement-split-region.md#pre_split_regions)
+[`PRE_SPLIT_REGIONS`](/sql-statements/sql-statement-split-region.md#pre_split_regions)
```

Seven of the nine links already read `` [`PRE_SPLIT_REGIONS`] ``; this was the only one rendered as prose.

### How it was checked

- Confirmed `#pre_split_regions` does not exist as an anchor anywhere in the ja file, while nine links target it.
- After the fix, every `sql-statement-split-region.md#…` link in the ja docs resolves to a heading that exists.
- The sub-heading `### pre_split_regionsの例 {#examples-of-pre-split-regions}` was left untouched — nothing links to it, so changing it would be churn.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (Japanese-only fix)
- Other reference link(s): sibling ja PRs #23272 #23273 #23274 #23275 #23291 #23292 #23294 #23295 #23297 #23311 #23315 #23316 #23318 #23320 #23322

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
