### PR TITLE
explain-joins: reword "create ... on disk" as "spill ... to disk"

### DIFF
--- a/explain-joins.md
+++ b/explain-joins.md
@@ -219,7 +219,7 @@ The `operator info` column in the `EXPLAIN` result table also records other info
 
 ### Runtime Statistics
 
-If [`tidb_mem_quota_query`](/system-variables.md#tidb_mem_quota_query) (default value: 1 GB) is exceeded, and the [`tidb_enable_tmp_storage_on_oom`](/system-variables.md#tidb_enable_tmp_storage_on_oom) value is `ON` (default), TiDB will attempt to use temporary storage, and might create the `Build` operator (used as part of the hash join) on disk. Runtime statistics such as memory usage are recorded in the `execution info` of the `EXPLAIN ANALYZE` result table. The following example shows the output of `EXPLAIN ANALYZE` with a 1 GB (default) and a 500 MB quota for `tidb_mem_quota_query`. At 500 MB, disk is used for temporary storage:
+If [`tidb_mem_quota_query`](/system-variables.md#tidb_mem_quota_query) (default value: 1 GB) is exceeded, and the [`tidb_enable_tmp_storage_on_oom`](/system-variables.md#tidb_enable_tmp_storage_on_oom) value is `ON` (default), TiDB will attempt to use temporary storage, and might spill the `Build` operator (used as part of the hash join) to disk. Runtime statistics such as memory usage are recorded in the `execution info` of the `EXPLAIN ANALYZE` result table. The following example shows the output of `EXPLAIN ANALYZE` with a 1 GB (default) and a 500 MB quota for `tidb_mem_quota_query`. At 500 MB, disk is used for temporary storage:
 
 ```sql
 EXPLAIN ANALYZE SELECT /*+ HASH_JOIN(t1, t2) */ * FROM t1, t2 WHERE t1.id = t2.id;

--- a/explain-joins.md
+++ b/explain-joins.md
@@ -219,7 +219,7 @@ The `operator info` column in the `EXPLAIN` result table also records other info
 
 ### Runtime Statistics
 
-If [`tidb_mem_quota_query`](/system-variables.md#tidb_mem_quota_query) (default value: 1 GB) is exceeded, and the [`tidb_enable_tmp_storage_on_oom`](/system-variables.md#tidb_enable_tmp_storage_on_oom) value is `ON` (default), TiDB will attempt to use temporary storage, and might spill the `Build` operator (used as part of the hash join) to disk. Runtime statistics such as memory usage are recorded in the `execution info` of the `EXPLAIN ANALYZE` result table. The following example shows the output of `EXPLAIN ANALYZE` with a 1 GB (default) and a 500 MB quota for `tidb_mem_quota_query`. At 500 MB, disk is used for temporary storage:
+If [`tidb_mem_quota_query`](/system-variables.md#tidb_mem_quota_query) (default value: 1 GB) is exceeded, and the [`tidb_enable_tmp_storage_on_oom`](/system-variables.md#tidb_enable_tmp_storage_on_oom) value is `ON` (default), TiDB will attempt to use temporary storage and might spill data from the Build side of the hash join to disk. Runtime statistics such as memory usage are recorded in the `execution info` of the `EXPLAIN ANALYZE` result table. The following example shows the output of `EXPLAIN ANALYZE` with a 1 GB (default) and a 500 MB quota for `tidb_mem_quota_query`. At 500 MB, disk is used for temporary storage:
 
 ```sql
 EXPLAIN ANALYZE SELECT /*+ HASH_JOIN(t1, t2) */ * FROM t1, t2 WHERE t1.id = t2.id;


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

In the **Hash Join** section of `explain-joins.md`, one sentence describes the on-disk behavior as:

> TiDB will attempt to use temporary storage, and might **create the `Build` operator (used as part of the hash join) on disk**.

"create the `Build` operator on disk" is confusing — the operator is not created on disk; its data is spilled to temporary storage. Later on the same page, the system-variables section already describes the same behavior with clearer wording:

> TiDB will attempt to **spill the `Build` operator of a hash join to disk** to save memory.

This PR aligns the earlier sentence with that clearer, consistent wording ("spill ... to disk").

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)

### What is the related PR or file link(s)?

N/A — documentation wording clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that when the query memory quota is exceeded and temporary storage on out-of-memory is enabled, the hash join Build operator may spill to disk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->