### PR TITLE
i18n(ja): fix broken GCS permission literal in tidb-cloud-auditing.md

### DIFF
--- a/tidb-cloud/tidb-cloud-auditing.md
+++ b/tidb-cloud/tidb-cloud-auditing.md
@@ -151,7 +151,7 @@ TiDB Cloud が監査ログを書き込む宛先として、組織所有の Googl
 2.  [Google Cloud console](https://console.cloud.google.com/)で、 **[IAMと管理]** &gt; **[ロール]**に移動し、ストレージバケット内のオブジェクトに対する次の書き込み専用権限を持つロールが存在するかどうかを確認します。
 
     -   storage.objects.create
-    -   storage.オブジェクト.削除
+    -   storage.objects.delete
 
     はいの場合は、後で使用するためにTiDBクラスターの一致したロールを記録してください。いいえの場合は、 **「IAMと管理」** &gt; **「ロール」** &gt; **「ロールの作成」**に移動して、TiDBクラスターのロールを定義してください。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix a broken code literal in the Japanese `tidb-cloud/tidb-cloud-auditing.md`. In the GCS access permission list, the permission name `storage.objects.delete` had been machine-translated to `storage.オブジェクト.削除`, which is not a valid permission string.

```
     -   storage.objects.create
-    -   storage.オブジェクト.削除
+    -   storage.objects.delete
```

The sibling permission `storage.objects.create` was already correct, and the English source lists exactly `storage.objects.create` / `storage.objects.delete`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (Japanese-only fix; no English source change)
- Other reference link(s): part of the ja `i18n-ja-release-8.5` machine-translation cleanup

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
