### PR TITLE
i18n(ja): fix mistranslated section headings in TiDB Cloud docs

### DIFF
--- a/ai/reference/vector-search-functions-and-operators.md
+++ b/ai/reference/vector-search-functions-and-operators.md
@@ -98,7 +98,7 @@ aliases: ['/ja/tidb/stable/vector-search-functions-and-operators/','/ja/tidbclou
 
 `CAST()`使用方法の詳細については、 [ベクトルデータ型 | キャスト](/ai/reference/vector-search-data-types.md#cast)を参照してください。
 
-## 完全な参考文献 {#full-references}
+## 完全なリファレンス {#full-references}
 
 ### VEC_L2_距離 {#vec-l2-distance}
 

--- a/role-based-access-control.md
+++ b/role-based-access-control.md
@@ -352,7 +352,7 @@ SELECT * FROM mysql.default_roles;
 -   `HOST`と`USER`それぞれユーザーのホスト名とユーザー名を示します。
 -   `DEFAULT_ROLE_HOST`と`DEFAULT_ROLE_USER` 、それぞれデフォルト ロールのホスト名とユーザー名を示します。
 
-### 参考文献 {#references}
+### リファレンス {#references}
 
 RBAC、ユーザー管理、権限管理は密接に関連しているため、操作の詳細については次のリソースを参照してください。
 

--- a/tidb-cloud/backup-and-restore-serverless.md
+++ b/tidb-cloud/backup-and-restore-serverless.md
@@ -75,7 +75,7 @@ TiDB Cloudは、 TiDB Cloud StarterまたはEssentialインスタンスのスナ
     -   TiDB Cloud Starterインスタンス：サポートされていません。
     -   TiDB Cloud Essentialインスタンス：バックアップ保持期間内の任意の時点に復元できますが、 TiDB Cloud Essentialインスタンスの作成時刻より前、または現在時刻の1分前より後には復元できません。
 
-### 目的地を復元する {#restore-destination}
+### 復元先 {#restore-destination}
 
 TiDB Cloudは、新しいTiDB Cloud StarterまたはEssentialインスタンスへのデータ復元をサポートしています。
 

--- a/tidb-cloud/premium/backup-and-restore-premium.md
+++ b/tidb-cloud/premium/backup-and-restore-premium.md
@@ -137,7 +137,7 @@ TiDB Cloudは、インスタンスのスナップショット復元と特定時�
 
     -   Premium<CustomContent plan="byoc"> または BYOC</CustomContent> インスタンス：過去7日間の任意の時点に復元できますが、インスタンス作成時刻より前、または現在時刻の1分前より後の時点には復元できません。なお、手動バックアップではPITRはサポートされていません。
 
-### 目的地を復元する {#restore-destination}
+### 復元先 {#restore-destination}
 
 TiDB Cloudは、新しいインスタンスへのデータ復元をサポートしています。
 
@@ -296,7 +296,7 @@ TiDB Cloud Dedicatedクラスターによって生成されたバックアップ
 
 5. バックアップを復元するには、**Restore**をクリックします。
 
-## 参考文献 {#references}
+## リファレンス {#references}
 
 このセクションでは、Amazon S3<CustomContent plan="premium">とAlibaba Cloud OSS</CustomContent>へのアクセス設定方法について説明します。
 

--- a/tidb-cloud/premium/premium-export.md
+++ b/tidb-cloud/premium/premium-export.md
@@ -18,7 +18,7 @@ TiDB Cloudを使用すると、{{{ .premium }}}<CustomContent plan="byoc"> ま�
 > - 現在、この機能はリクエストに応じてのみ利用可能です。この機能をリクエストするには、[TiDB Cloud console](https://tidbcloud.com)の右下隅にある**?**をクリックし、次に**Support Tickets**をクリックして[Help Center](https://tidb.support.pingcap.com/servicedesk/customer/portals)に移動します。チケットを作成し、**Description**フィールドに "Apply for data export for {{{ .premium }}}<CustomContent plan="byoc"> or {{{ .byoc }}}</CustomContent> instance" と入力して、**Submit**をクリックします。
 > - エクスポートの最大サイズは 1 TiB です。この制限を超えるエクスポートは失敗する可能性があります。より多くのデータをエクスポートする場合、またはより高いエクスポート速度をリクエストする場合は、[TiDB Cloudサポート](/tidb-cloud/tidb-cloud-support.md)にお問い合わせください。
 
-## 輸出先 {#export-locations}
+## エクスポート先 {#export-locations}
 
 データを以下の外部ストレージの場所にエクスポートできます。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix three section headings in the Japanese docs that were machine-translated incorrectly. Only the visible heading text is changed; every `{#anchor}` is kept as-is, so existing links are unaffected.

| EN heading | Before (ja) | After (ja) | Note |
|---|---|---|---|
| Restore destination | 目的地を復元する | 復元先 | 目的地 = travel destination; also mis-parsed as a verb |
| References | 参考文献 | リファレンス | 参考文献 = bibliography |
| Export locations | 輸出先 | エクスポート先 | 輸出 = export in the trade/customs sense |

Files:
- `tidb-cloud/backup-and-restore-serverless.md` (Restore destination)
- `tidb-cloud/premium/backup-and-restore-premium.md` (Restore destination, References)
- `role-based-access-control.md` (References)
- `tidb-cloud/premium/premium-export.md` (Export locations)

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (Japanese-only fluency fix; no English source change)
- Other reference link(s): part of the ja `i18n-ja-release-8.5` machine-translation cleanup

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
