### PR TITLE
dashboard: use "stress test" instead of "pressure test"

### DIFF
--- a/dashboard/dashboard-diagnostics-usage.md
+++ b/dashboard/dashboard-diagnostics-usage.md
@@ -15,7 +15,7 @@ This section demonstrates how to use the comparison diagnostic feature to diagno
 
 ![QPS example](/media/dashboard/dashboard-diagnostics-usage1.png)
 
-The result of a `go-ycsb` pressure test is shown in the image above. You can see that at `2020-03-10 13:24:30`, QPS suddenly began to decrease. After 3 minutes, QPS began to return to normal. You can use diagnostic report of TiDB Dashboard to find out the cause.
+The result of a `go-ycsb` stress test is shown in the image above. You can see that at `2020-03-10 13:24:30`, QPS suddenly began to decrease. After 3 minutes, QPS began to return to normal. You can use diagnostic report of TiDB Dashboard to find out the cause.
 
 Generate a report that compares the system in the following two time ranges:
 
@@ -65,7 +65,7 @@ If a large query has not been executed, the query is not recorded in the slow lo
 
 ![QPS results](/media/dashboard/dashboard-diagnostics-usage3.png)
 
-The result of another `go-ycsb` pressure test is shown in the image above. You can see that at `2020-03-08 01:46:30`, QPS suddenly began to drop and did not recover.
+The result of another `go-ycsb` stress test is shown in the image above. You can see that at `2020-03-08 01:46:30`, QPS suddenly began to drop and did not recover.
 
 Generate a report that compares the system in the following two time ranges:
 
@@ -96,7 +96,7 @@ Because the diagnostics might be wrong, using a comparison report might help DBA
 
 ![QPS results](/media/dashboard/dashboard-diagnostics-usage5.png)
 
-The result of a `go-ycsb` pressure test is shown in the image above. You can see that at `2020-05-22 22:14:00`, QPS suddenly began to decrease. After 3 minutes, QPS began to return to normal. You can use the comparison diagnostic report of TiDB Dashboard to find out the cause.
+The result of a `go-ycsb` stress test is shown in the image above. You can see that at `2020-05-22 22:14:00`, QPS suddenly began to decrease. After 3 minutes, QPS began to return to normal. You can use the comparison diagnostic report of TiDB Dashboard to find out the cause.
 
 Generate a report that compares the system in the following two time ranges:
 
@@ -110,6 +110,6 @@ After generating the comparison report, check the **Max diff item** report. This
 
 From the result above, you can see that the Coprocessor requests in T2 are much more than those in T1. It might be that some large queries appear in T2 that bring more load.
 
-In fact, during the entire time range from T1 to T2, the `go-ycsb` pressure test is running. Then 20 `tpch` queries are running during T2. So it is the `tpch` queries that cause many Coprocessor requests.
+In fact, during the entire time range from T1 to T2, the `go-ycsb` stress test is running. Then 20 `tpch` queries are running during T2. So it is the `tpch` queries that cause many Coprocessor requests.
 
 If such a large query whose execution time exceeds the threshold of slow log is recorded in the slow log. You can check the `Slow Queries In Time Range t2` report to see whether there is any slow query. However, some queries in T1 might become slow queries in T2, because in T2, other loads cause their executions to slow down.

--- a/information-schema/information-schema-metrics-summary.md
+++ b/information-schema/information-schema-metrics-summary.md
@@ -191,4 +191,4 @@ From the query result above, you can get the following information:
 
 From the result above, you can see that the Coprocessor requests in period t2 are much more than those in period t1. This causes TiKV Coprocessor to be overloaded, and the `cop task` has to wait. It might be that some large queries appear in period t2 that bring more load.
 
-In fact, during the entire time period from t1 to t2, the `go-ycsb` pressure test is running. Then 20 `tpch` queries are running during period t2. So it is the `tpch` queries that cause many Coprocessor requests.
+In fact, during the entire time period from t1 to t2, the `go-ycsb` stress test is running. Then 20 `tpch` queries are running during period t2. So it is the `tpch` queries that cause many Coprocessor requests.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

"Pressure test" is not idiomatic English for software performance testing — in software contexts the standard term is **stress test** (or load test); "pressure test" primarily belongs to mechanical/physical engineering (pressure vessels, pipes). Here it reads as a literal rendering of the Chinese `压力测试`, which means "stress test".

This PR renames the 5 `go-ycsb` **pressure test** occurrences to **stress test**, matching the "stress test" wording already used elsewhere in the docs:

- `dashboard/dashboard-diagnostics-usage.md` (4)
- `information-schema/information-schema-metrics-summary.md` (1)

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Other reference link(s): companion to the Japanese `i18n-ja-release-8.5` cleanup (the ja side was renamed 圧力テスト → 負荷テスト).

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated diagnostic usage examples to consistently refer to `go-ycsb` “stress tests” instead of “pressure tests.”
  * Revised the information schema metrics summary to use the same terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->