### PR TITLE
docs: block cluster pause when PITR or Data Migration is active

### DIFF
--- a/tidb-cloud/pause-or-resume-tidb-cluster.md
+++ b/tidb-cloud/pause-or-resume-tidb-cluster.md
@@ -22,7 +22,7 @@ Comparing with backup and restore, pausing and resuming a cluster takes less tim
 - You cannot pause your cluster when a backup job is going on. You can either wait for the current backup job to be completed or [delete the running backup job](/tidb-cloud/backup-and-restore.md#delete-a-running-backup-job).
 - You cannot pause your cluster if it has any [changefeeds](/tidb-cloud/changefeed-overview.md). You need to [delete the existing changefeeds](/tidb-cloud/changefeed-overview.md#delete-a-changefeed) before pausing the cluster.
 - You cannot pause your cluster when [Point-in-Time Restore (PITR)](/tidb-cloud/backup-and-restore.md#turn-on-point-in-time-restore) is enabled. You need to turn off the **Point-in-time Restore** switch in **Backup Setting** before pausing the cluster.
-- You cannot pause your cluster when a [Data Migration](/tidb-cloud/tidb-cloud-migration-overview.md) job is running. You need to stop the migration job before pausing the cluster.
+- You cannot pause your cluster when a [Data Migration](/tidb-cloud/tidb-cloud-migration-overview.md) job is running. Make sure that no migration job is running before pausing the cluster.
 
 ## Pause a TiDB cluster
 

--- a/tidb-cloud/pause-or-resume-tidb-cluster.md
+++ b/tidb-cloud/pause-or-resume-tidb-cluster.md
@@ -21,6 +21,8 @@ Comparing with backup and restore, pausing and resuming a cluster takes less tim
 - You cannot pause your cluster when a data import task is going on. You can either wait for the import task to be completed or cancel the import task.
 - You cannot pause your cluster when a backup job is going on. You can either wait for the current backup job to be completed or [delete the running backup job](/tidb-cloud/backup-and-restore.md#delete-a-running-backup-job).
 - You cannot pause your cluster if it has any [changefeeds](/tidb-cloud/changefeed-overview.md). You need to [delete the existing changefeeds](/tidb-cloud/changefeed-overview.md#delete-a-changefeed) before pausing the cluster.
+- You cannot pause your cluster when [Point-in-Time Restore (PITR)](/tidb-cloud/backup-and-restore.md#turn-on-point-in-time-restore) is enabled. You need to turn off the **Point-in-time Restore** switch in **Backup Setting** before pausing the cluster.
+- You cannot pause your cluster when a [Data Migration](/tidb-cloud/tidb-cloud-migration-overview.md) job is running. You need to stop the migration job before pausing the cluster.
 
 ## Pause a TiDB cluster
 


### PR DESCRIPTION
### What's changed

Clusters with Point-in-Time Restore (PITR) enabled or a Data Migration job running can no longer be paused directly. The pause request is rejected with a clear error until users explicitly disable PITR / stop the migration job.

### Documentation changes

Adds two new bullets to the **Limitations** section of `tidb-cloud/pause-or-resume-tidb-cluster.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented limitations for pausing TiDB clusters when Point-in-Time Recovery (PITR) is enabled or a Data Migration job is running.
  * Clarified that users must disable PITR and ensure no migration job is active before pausing a cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->