### PR TITLE
i18n(ja): translate remaining English release-note entries to Japanese

### DIFF
--- a/releases/release-6.1.0.md
+++ b/releases/release-6.1.0.md
@@ -331,7 +331,7 @@ TiDB バージョン: 6.1.0
     -   `EXPLAIN`の出力におけるタスクタイプの表示を改善（MPPタスクタイプを追加） [＃33332](https://github.com/pingcap/tidb/issues/33332)
     -   列のデフォルト値として`rand()`を使用することをサポートします [＃10377](https://github.com/pingcap/tidb/issues/10377)
     -   列のデフォルト値として`uuid()`を使用することをサポートします [＃33870](https://github.com/pingcap/tidb/issues/33870)
-    -   Support modifying the character set of columns from `latin1` to `utf8`/`utf8mb4` [＃34008](https://github.com/pingcap/tidb/issues/34008)
+    -   列の文字セットを`latin1`から`utf8`/`utf8mb4`に変更することをサポートします [＃34008](https://github.com/pingcap/tidb/issues/34008)
 
 -   TiKV
 
@@ -340,7 +340,7 @@ TiDB バージョン: 6.1.0
     -   Raft Engine のメモリ制限設定をサポート [＃12255](https://github.com/tikv/tikv/issues/12255)
     -   TiKVは、破損したSSTファイルを自動的に検出して削除し、製品の可用性を向上させます[＃10578](https://github.com/tikv/tikv/issues/10578)
     -   CDCはRawKV をサポートしています [＃11965](https://github.com/tikv/tikv/issues/11965)
-    -   Support splitting a large snapshot file into multiple files [＃11595](https://github.com/tikv/tikv/issues/11595)
+    -   大きなスナップショットファイルを複数のファイルに分割することをサポートします [＃11595](https://github.com/tikv/tikv/issues/11595)
     -   スナップショットGCがRaftstoreのメッセージループをブロックするのを防ぐために、スナップショットガベージコレクションをRaftstoreからバックグラウンドスレッドに移動します[＃11966](https://github.com/tikv/tikv/issues/11966)
     -   gPRCメッセージの最大メッセージ長（ `max-grpc-send-msg-len` ）と最大バッチサイズ（ `raft-msg-max-batch-size` ） の動的設定をサポート [＃12334](https://github.com/tikv/tikv/issues/12334)
     -   Raft によるオンラインの安全でない復元計画の実行をサポート [＃10483](https://github.com/tikv/tikv/issues/10483)
@@ -387,17 +387,17 @@ TiDB バージョン: 6.1.0
 -   TiKV
 
     -   TiKVインスタンスがオフラインになったときにRaftログの遅延が増加する問題を修正[＃12161](https://github.com/tikv/tikv/issues/12161)
-    -   Fix the issue that TiKV panics and destroys peers unexpectedly because the target Region to be merged is invalid [＃12232](https://github.com/tikv/tikv/issues/12232)
+    -   マージ対象のリージョンが無効なために TiKV がpanicを起こし、予期せずpeerを破棄する問題を修正しました [＃12232](https://github.com/tikv/tikv/issues/12232)
     -   v5.3.1 または v5.4.0 から v6.0.0 以降のバージョンにアップグレードするときに TiKV が`failed to load_latest_options`エラーを報告する問題を修正しました[＃12269](https://github.com/tikv/tikv/issues/12269)
     -   メモリリソースが不足しているときにRaftログを追加することによって発生する OOM の問題を修正しました[#11379](https://github.com/tikv/tikv/issues/11379)
-    -   Fix the issue of TiKV panic caused by the race between destroying peers and batch splitting Regions [＃12368](https://github.com/tikv/tikv/issues/12368)
+    -   peerの破棄とリージョンのバッチ分割の競合により TiKV がpanicを起こす問題を修正しました [＃12368](https://github.com/tikv/tikv/issues/12368)
     -   `stats_monitor`デッドループに陥った後、短時間で TiKVメモリ使用量が急増する問題を修正[＃12416](https://github.com/tikv/tikv/issues/12416)
     -   Follower Read 使用時に TiKV が`invalid store ID 0`エラーを報告する問題を修正しました [＃12478](https://github.com/tikv/tikv/issues/12478)
 
 -   PD
 
     -   `not leader` の間違ったステータスコードを修正 [＃4797](https://github.com/tikv/pd/issues/4797)
-    -   Fix a bug of TSO fallback in some corner cases [＃4884](https://github.com/tikv/pd/issues/4884)
+    -   一部のコーナーケースで TSO がフォールバックするバグを修正しました [＃4884](https://github.com/tikv/pd/issues/4884)
     -   PDリーダー移転後に削除したtombstoneストアが再び表示される問題を修正[＃4941](https://github.com/tikv/pd/issues/4941)
     -   PDリーダー移行後すぐにスケジュールを開始できない問題を修正[＃4769](https://github.com/tikv/pd/issues/4769)
 
@@ -421,7 +421,7 @@ TiDB バージョン: 6.1.0
         -   `start-time`タイムゾーンの問題を修正し、DM の動作をダウンストリーム タイムゾーンの使用からアップストリーム タイムゾーンの使用に変更します[＃5471](https://github.com/pingcap/tiflow/issues/5471)
         -   タスクが自動的に再開された後にDMがより多くのディスクスペースを占有する問題を修正[＃3734](https://github.com/pingcap/tiflow/issues/3734) [＃5344](https://github.com/pingcap/tiflow/issues/5344)
         -   チェックポイントフラッシュにより失敗した行のデータがスキップされる可能性がある問題を修正[＃5279](https://github.com/pingcap/tiflow/issues/5279)
-        -   Fix the issue that in some cases manually executing the filtered DDL in the downstream might cause task resumption failure [＃5272](https://github.com/pingcap/tiflow/issues/5272)
+        -   一部のケースでダウンストリームでフィルタリングされた DDL を手動で実行するとタスクの再開に失敗する可能性がある問題を修正しました [＃5272](https://github.com/pingcap/tiflow/issues/5272)
         -   `case-sensitive: true`が設定されていない場合、大文字テーブルを複製できない問題を修正[＃5255](https://github.com/pingcap/tiflow/issues/5255)
         -   `SHOW CREATE TABLE`ステートメントによって返されるインデックスの先頭に主キーがない場合に発生する DM ワーカーpanicの問題を修正しました。 [＃5159](https://github.com/pingcap/tiflow/issues/5159)
         -   GTID が有効になっているときやタスクが自動的に再開されたときに CPU 使用率が上昇し、大量のログが出力される問題を修正しました[＃5063](https://github.com/pingcap/tiflow/issues/5063)
@@ -434,5 +434,5 @@ TiDB バージョン: 6.1.0
         -   事前チェックでローカルディスクリソースとクラスターの可用性がチェックされない問題を修正[＃34213](https://github.com/pingcap/tidb/issues/34213)
         -   スキーマルーティングが正しくない問題を修正しました [＃33381](https://github.com/pingcap/tidb/issues/33381)
         -   TiDB LightningがパニックになったときにPD構成が正しく復元されない問題を修正[＃31733](https://github.com/pingcap/tidb/issues/31733)
-        -   Fix the issue of Local-backend import failure caused by out-of-bounds data in the `auto_increment` column [＃27937](https://github.com/pingcap/tidb/issues/27937)
-        -   Fix the issue of local backend import failure when the `auto_random` or `auto_increment` column is null [＃34208](https://github.com/pingcap/tidb/issues/34208)
+        -   `auto_increment`列の範囲外のデータによって Local-backend のインポートが失敗する問題を修正しました [＃27937](https://github.com/pingcap/tidb/issues/27937)
+        -   `auto_random`または`auto_increment`列が null の場合に local backend のインポートが失敗する問題を修正しました [＃34208](https://github.com/pingcap/tidb/issues/34208)

--- a/releases/release-6.1.1.md
+++ b/releases/release-6.1.1.md
@@ -49,7 +49,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
 -   PD
 
-    -   Improve the scheduling speed of Balance Region in specific stages [＃4990](https://github.com/tikv/pd/issues/4990) @[bufferflies](https://github.com/bufferflies)
+    -   特定のステージにおける Balance Region のスケジューリング速度を改善します [＃4990](https://github.com/tikv/pd/issues/4990) @[bufferflies](https://github.com/bufferflies)
 
 -   ツール
 
@@ -76,7 +76,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   `SHOW COLUMNS`文を実行するときに TiDB がコプロセッサ要求を送信する可能性があるバグを修正しました。 [＃36496](https://github.com/pingcap/tidb/issues/36496) @[tangenta](https://github.com/tangenta)
     -   TiDBが`SHOW WARNINGS`ステートメントを実行するときに`invalid memory address or nil pointer dereference`エラーを返す可能性があるバグを修正しました [＃31569](https://github.com/pingcap/tidb/issues/31569) @[zyguan](https://github.com/zyguan)
     -   静的パーティションプルーニングモードで、テーブルが空の場合に集計条件を含むSQL文が間違った結果を返す可能性があるバグを修正[＃35295](https://github.com/pingcap/tidb/issues/35295) @[tiancaiamao](https://github.com/tiancaiamao)
-    -   Fix the issue that the Join Reorder operation will mistakenly push down its Outer Join condition [＃37238](https://github.com/pingcap/tidb/issues/37238) @[winoros](https://github.com/winoros)
+    -   Join Reorder 操作がその Outer Join 条件を誤ってプッシュダウンする問題を修正しました [＃37238](https://github.com/pingcap/tidb/issues/37238) @[winoros](https://github.com/winoros)
     -   CTE スキーマハッシュコードが誤って複製され、CTE が複数回参照されると`Can't find column ... in schema ...`エラーが発生する問題を修正しました[＃35404](https://github.com/pingcap/tidb/issues/35404) @[AilinKid](https://github.com/AilinKid)
     -   一部の右外部結合シナリオで結合順序が間違っていると、間違ったクエリ結果が発生する問題を修正しました。 [＃36912](https://github.com/pingcap/tidb/issues/36912) @[winoros](https://github.com/winoros)
     -   EqualAll の場合でTiFlash `firstrow`集計関数の誤って推論された null フラグの問題を修正しました [＃34584](https://github.com/pingcap/tidb/issues/34584) @[fixdb](https://github.com/fixdb)
@@ -89,7 +89,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   TiDB Binlogが有効な場合、 `ALTER SEQUENCE`文を実行するとメタデータ バージョンが間違って発生し、 Drainer が終了する可能性がある問題を修正しました。 [#36276](https://github.com/pingcap/tidb/issues/36276) @[AilinKid](https://github.com/AilinKid)
     -   極端なケースで起動時に誤った TiDB ステータスが表示される問題を修正[＃36791](https://github.com/pingcap/tidb/issues/36791) @[xhebox](https://github.com/xhebox)
     -   TiDB Dashboardでパーティションテーブルの実行計画をクエリするときに発生する可能性のある`UnknownPlanID`問題を修正しました。 [＃35153](https://github.com/pingcap/tidb/issues/35153) @[time-and-fate](https://github.com/time-and-fate)
-    -   Fix the issue that the column list does not work in the LOAD DATA statement [＃35198](https://github.com/pingcap/tidb/issues/35198) @[SpadeA-Tang](https://github.com/SpadeA-Tang)
+    -   LOAD DATA ステートメントでカラムリストが機能しない問題を修正しました [＃35198](https://github.com/pingcap/tidb/issues/35198) @[SpadeA-Tang](https://github.com/SpadeA-Tang)
     -   TiDB Binlogを有効にして重複した値を挿入すると発生する`data and columnID count not match`エラーの問題を修正[＃33608](https://github.com/pingcap/tidb/issues/33608) @[zyguan](https://github.com/zyguan)
     -   `tidb_gc_life_time` の制限を解除 [＃35392](https://github.com/pingcap/tidb/issues/35392) @[TonsnakeLin](https://github.com/TonsnakeLin)
     -   空のフィールド終端文字が使用されている場合の`LOAD DATA`文のデッドループを修正[#33298](https://github.com/pingcap/tidb/issues/33298) @[zyguan](https://github.com/zyguan)
@@ -102,7 +102,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   空の文字列型変換を実行するときに TiKV がパニックになる問題を修正しました [＃12673](https://github.com/tikv/tikv/issues/12673) @[wshwsh12](https://github.com/wshwsh12)
     -   TiKVとPD間のリージョンサイズ設定が一致しない問題を修正 [#12518](https://github.com/tikv/tikv/issues/12518) @[5kbpers](https://github.com/5kbpers)
     -   Raft Engineが有効になっているときに暗号化キーがクリーンアップされない問題を修正[＃12890](https://github.com/tikv/tikv/issues/12890) @[tabokie](https://github.com/tabokie)
-    -   Fix the panic issue that might occur when a peer is being split and destroyed at the same time [#12825](https://github.com/tikv/tikv/issues/12825) @[BusyJay](https://github.com/BusyJay)
+    -   ピアが分割と破棄を同時に行っている場合に発生する可能性があるpanicの問題を修正しました [#12825](https://github.com/tikv/tikv/issues/12825) @[BusyJay](https://github.com/BusyJay)
     -   リージョンマージプロセスでソースピアがスナップショットによってログをキャッチアップするときに発生する可能性のあるpanic問題を修正しました。 [＃12663](https://github.com/tikv/tikv/issues/12663) @[BusyJay](https://github.com/BusyJay)
     -   PDクライアントがエラーに遭遇したときに発生するPDクライアントの頻繁な再接続の問題を修正しました [＃12345](https://github.com/tikv/tikv/issues/12345) @[Connor1996](https://github.com/Connor1996)
     -   Raft Engine で並列リカバリが有効になっている場合に発生する可能性のあるpanicを修正しました [＃13123](https://github.com/tikv/tikv/issues/13123) @[tabokie](https://github.com/tabokie)
@@ -112,7 +112,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   ダッシュボードの`Unified Read Pool CPU`の誤った表現を修正 [＃13086](https://github.com/tikv/tikv/issues/13086) @[glorv](https://github.com/glorv)
     -   リージョンが大きい場合、デフォルトの[`region-split-check-diff`](/tikv-configuration-file.md#region-split-check-diff)バケット サイズよりも大きくなる可能性がある問題を修正しました。 [＃12598](https://github.com/tikv/tikv/issues/12598) @[tonyxuqqi](https://github.com/tonyxuqqi)
     -   スナップショットの適用が中止され、 Raft Engineが有効になっている場合に TiKV がpanicする可能性がある問題を修正[＃12470](https://github.com/tikv/tikv/issues/12470) @[tabokie](https://github.com/tabokie)
-    -   Fix the issue that the PD client might cause deadlocks [＃13191](https://github.com/tikv/tikv/issues/13191) @[bufferflies](https://github.com/bufferflies) [＃12933](https://github.com/tikv/tikv/issues/12933) @[BurtonQin](https://github.com/BurtonQin)
+    -   PD クライアントがデッドロックを引き起こす可能性がある問題を修正しました [＃13191](https://github.com/tikv/tikv/issues/13191) @[bufferflies](https://github.com/bufferflies) [＃12933](https://github.com/tikv/tikv/issues/12933) @[BurtonQin](https://github.com/BurtonQin)
 
 -   PD
 
@@ -128,7 +128,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   一部のエッジケースで不要な CPU 使用率を修正[＃5409](https://github.com/pingcap/tiflash/issues/5409) @[breezewish](https://github.com/breezewish)
     -   IPv6 を使用するクラスターでTiFlash が動作できないバグを修正しました [＃5247](https://github.com/pingcap/tiflash/issues/5247) @[solotzg](https://github.com/solotzg)
     -   並列集約エラーによりTiFlashがクラッシュする可能性があるバグを修正 [#5356](https://github.com/pingcap/tiflash/issues/5356) @[gengliqi](https://github.com/gengliqi)
-    -   Fix a bug that thread resources might leak in case of `MinTSOScheduler` query errors [#5556](https://github.com/pingcap/tiflash/issues/5556) @[windtalker](https://github.com/windtalker)
+    -   `MinTSOScheduler` のクエリエラーが発生した場合にスレッドリソースがリークする可能性があるバグを修正しました [#5556](https://github.com/pingcap/tiflash/issues/5556) @[windtalker](https://github.com/windtalker)
 
 -   ツール
 
@@ -136,7 +136,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
         -   TiDBがIPv6ホストを使用しているときにTiDB LightningがTiDBに接続できない問題を修正しました [#35880](https://github.com/pingcap/tidb/issues/35880) @[D3Hunter](https://github.com/D3Hunter)
         -   再試行メカニズムを追加して`read index not ready`エラーを修正します [#36566](https://github.com/pingcap/tidb/issues/36566) @[D3Hunter](https://github.com/D3Hunter)
-        -   Fix the issue that sensitive information in logs is printed in server mode [＃36374](https://github.com/pingcap/tidb/issues/36374) @[lichunzhu](https://github.com/lichunzhu)
+        -   サーバーモードでログ内の機密情報が出力される問題を修正しました [＃36374](https://github.com/pingcap/tidb/issues/36374) @[lichunzhu](https://github.com/lichunzhu)
         -   TiDB Lightning がParquet ファイル内のスラッシュ、数字、または非 ASCII 文字で始まる列をサポートしない問題を修正[＃36980](https://github.com/pingcap/tidb/issues/36980) @[D3Hunter](https://github.com/D3Hunter)
         -   重複排除により極端な場合にTiDB Lightning がpanicを起こす可能性がある問題を修正[＃34163](https://github.com/pingcap/tidb/issues/34163) @[ForwardStar](https://github.com/ForwardStar)
 
@@ -153,7 +153,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   TiCDC
 
         -   互換性のある最大バージョン番号の誤りを修正 [＃6039](https://github.com/pingcap/tiflow/issues/6039) @[Rustin170506](https://github.com/Rustin170506)
-        -   Fix a bug that may cause the cdc server to panic when it receives an HTTP request before it fully starts [＃5639](https://github.com/pingcap/tiflow/issues/5639) @[asddongmen](https://github.com/asddongmen)
+        -   cdc サーバーが完全に起動する前に HTTP リクエストを受信した場合にpanicを引き起こす可能性があるバグを修正しました [＃5639](https://github.com/pingcap/tiflow/issues/5639) @[asddongmen](https://github.com/asddongmen)
         -   チェンジフィード同期ポイントが有効な場合の DDL シンクpanic問題を修正[＃4934](https://github.com/pingcap/tiflow/issues/4934) @[asddongmen](https://github.com/asddongmen)
         -   同期ポイントが有効な場合に、一部のシナリオでチェンジフィードがスタックする問題を修正[＃6827](https://github.com/pingcap/tiflow/issues/6827) @[hicqu](https://github.com/hicqu)
         -   CDCサーバーの再起動後にchangefeed APIが正常に動作しないバグを修正[＃5837](https://github.com/pingcap/tiflow/issues/5837) @[asddongmen](https://github.com/asddongmen)

--- a/releases/release-6.1.2.md
+++ b/releases/release-6.1.2.md
@@ -39,7 +39,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   データベースレベルの権限が誤ってクリーンアップされる問題を修正[＃38363](https://github.com/pingcap/tidb/issues/38363) @[dveeden](https://github.com/dveeden)
     -   `SHOW CREATE PLACEMENT POLICY`の誤った出力を修正 [#37526](https://github.com/pingcap/tidb/issues/37526) @[xhebox](https://github.com/xhebox)
     -   1つのPDノードがダウンした場合、他のPDノードを再試行しないため、 `information_schema.TIKV_REGION_STATUS`のクエリが失敗する問題を修正しました。 [＃35708](https://github.com/pingcap/tidb/issues/35708) @[tangenta](https://github.com/tangenta)
-    -   Fix the issue that the `UNION` operator might return unexpected empty result [＃36903](https://github.com/pingcap/tidb/issues/36903) @[tiancaiamao](https://github.com/tiancaiamao)
+    -   `UNION`演算子が予期しない空の結果を返す可能性がある問題を修正しました [＃36903](https://github.com/pingcap/tidb/issues/36903) @[tiancaiamao](https://github.com/tiancaiamao)
     -   TiFlash のパーティションテーブルでダイナミックモードを有効にしたときに発生する誤った結果を修正しました [＃37254](https://github.com/pingcap/tidb/issues/37254) @[wshwsh12](https://github.com/wshwsh12)
     -   リージョンがマージされたときにリージョンキャッシュが時間内にクリーンアップされない問題を修正しました [＃37141](https://github.com/pingcap/tidb/issues/37141) @[sticnarf](https://github.com/sticnarf)
     -   KVクライアントが不要なpingメッセージを送信する問題を修正しました [＃36861](https://github.com/pingcap/tidb/issues/36861) @[jackysp](https://github.com/jackysp)
@@ -72,7 +72,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
     -   TiDB Lightning
 
-        -   Fix panic of TiDB Lightning caused by invalid metric counters [＃37338](https://github.com/pingcap/tidb/issues/37338) @[D3Hunter](https://github.com/D3Hunter)
+        -   無効なメトリックカウンターによって発生する TiDB Lightning のpanicを修正しました [＃37338](https://github.com/pingcap/tidb/issues/37338) @[D3Hunter](https://github.com/D3Hunter)
 
     -   TiDB Data Migration (DM)
 

--- a/releases/release-6.1.3.md
+++ b/releases/release-6.1.3.md
@@ -29,7 +29,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
     -   TiCDC
 
-        -   Enable transaction split and disable the safe mode of a changefeed in TiCDC by default to improve performance [＃7505](https://github.com/pingcap/tiflow/issues/7505) @[asddongmen](https://github.com/asddongmen)
+        -   TiCDCでchangefeedのトランザクション分割をデフォルトで有効化し、セーフモードを無効化することでパフォーマンスを向上させます [＃7505](https://github.com/pingcap/tiflow/issues/7505) @[asddongmen](https://github.com/asddongmen)
         -   Kafka プロトコルエンコーダーのパフォーマンスを向上 [#7540](https://github.com/pingcap/tiflow/issues/7540) [＃7532](https://github.com/pingcap/tiflow/issues/7532) [＃7543](https://github.com/pingcap/tiflow/issues/7543) @[sdojjy](https://github.com/sdojjy) @[3AceShowHand](https://github.com/3AceShowHand)
 
 -   その他
@@ -40,7 +40,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
 -   TiDB
 
-    -   Fix the issue that the `grantor` field is missing in the `mysql.tables_priv` table [＃38293](https://github.com/pingcap/tidb/issues/38293) @[CbcWestwolf](https://github.com/CbcWestwolf)
+    -   `mysql.tables_priv`テーブルで`grantor`フィールドが欠落している問題を修正しました [＃38293](https://github.com/pingcap/tidb/issues/38293) @[CbcWestwolf](https://github.com/CbcWestwolf)
     -   結合したテーブルの再配置 によって誤ってプッシュダウンされた条件が破棄されたときに発生する間違ったクエリ結果の問題を修正しました。 [＃38736](https://github.com/pingcap/tidb/issues/38736) @[winoros](https://github.com/winoros)
     -   `get_lock()`で取得したロックが10分以上保持できない問題を修正[＃38706](https://github.com/pingcap/tidb/issues/38706) @[tangenta](https://github.com/tangenta)
     -   AUTO_INCREMENT列がチェック制約で使用できない問題を修正しました [＃38894](https://github.com/pingcap/tidb/issues/38894) @[YangKeao](https://github.com/YangKeao)
@@ -49,7 +49,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   データソース名インジェクションによりデータファイルに無制限にアクセスできる問題を修正 (CVE-2022-3023) [＃38541](https://github.com/pingcap/tidb/issues/38541) @[lance6716](https://github.com/lance6716)
     -   関数`str_to_date`が`NO_ZERO_DATE`モードで間違った結果を返す問題を修正 [#39146](https://github.com/pingcap/tidb/issues/39146) @[mengxin9014](https://github.com/mengxin9014)
     -   バックグラウンドでの統計収集タスクがpanicする可能性がある問題を修正[＃35421](https://github.com/pingcap/tidb/issues/35421) @[lilinghai](https://github.com/lilinghai)
-    -   Fix the issue that in some scenarios the pessimistic lock is incorrectly added to the non-unique secondary index [＃36235](https://github.com/pingcap/tidb/issues/36235) @[ekexium](https://github.com/ekexium)
+    -   一部のシナリオで悲観的ロックが一意でないセカンダリインデックスに誤って追加される問題を修正しました [＃36235](https://github.com/pingcap/tidb/issues/36235) @[ekexium](https://github.com/ekexium)
 
 <!---->
 
@@ -61,11 +61,11 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
 
 -   TiKV
 
-    -   Fix abnormal Region competition caused by expired lease during snapshot acquisition [＃13553](https://github.com/tikv/tikv/issues/13553) @[SpadeA-Tang](https://github.com/SpadeA-Tang)
+    -   スナップショット取得中にリースの有効期限切れによって発生する異常なリージョン競合を修正しました [＃13553](https://github.com/tikv/tikv/issues/13553) @[SpadeA-Tang](https://github.com/SpadeA-Tang)
 
 -   TiFlash
 
-    -   Fix the issue that logical operators return wrong results when the argument type is `UInt8` [＃6127](https://github.com/pingcap/tiflash/issues/6127) @[xzhangxian1008](https://github.com/xzhangxian1008)
+    -   引数の型が`UInt8`の場合に論理演算子が誤った結果を返す問題を修正しました [＃6127](https://github.com/pingcap/tiflash/issues/6127) @[xzhangxian1008](https://github.com/xzhangxian1008)
     -   `CAST(value AS DATETIME)`への間違ったデータ入力によりTiFlash sys CPUの負荷が高くなる問題を修正 [#5097](https://github.com/pingcap/tiflash/issues/5097) @[xzhangxian1008](https://github.com/xzhangxian1008)
     -   書き込み圧力が高すぎるとデルタレイヤーに過剰な列ファイルが生成される可能性がある問題を修正しました。 [＃6361](https://github.com/pingcap/tiflash/issues/6361) @[lidezhu](https://github.com/lidezhu)
     -   TiFlash を再起動した後、デルタレイヤーの列ファイルを圧縮できない問題を修正しました。 [＃6159](https://github.com/pingcap/tiflash/issues/6159) @[lidezhu](https://github.com/lidezhu)
@@ -79,7 +79,7 @@ Quick access: [クイックスタート](https://docs-archive.pingcap.com/tidb/v
     -   TiCDC
 
         -   最初にDDLステートメントを実行し、次に変更フィードを一時停止して再開するシナリオで発生したデータ損失を修正しました [＃7682](https://github.com/pingcap/tiflow/issues/7682) @[asddongmen](https://github.com/asddongmen)
-        -   Fix the issue that the sink component gets stuck if the downstream network is unavailable [#7706](https://github.com/pingcap/tiflow/issues/7706) @[hicqu](https://github.com/hicqu)
+        -   ダウンストリームネットワークが利用できない場合にsinkコンポーネントがスタックする問題を修正しました [#7706](https://github.com/pingcap/tiflow/issues/7706) @[hicqu](https://github.com/hicqu)
 
     -   TiDB Data Migration (DM)
 

--- a/releases/release-6.1.4.md
+++ b/releases/release-6.1.4.md
@@ -21,7 +21,7 @@ TiDB バージョン: 6.1.4
 
 -   TiFlash
 
-    -   Reduce the IOPS by up to 95% and the write amplification by up to 65% for TiFlash instances under high update throughput workloads [＃6460](https://github.com/pingcap/tiflash/issues/6460) @[flowbehappy](https://github.com/flowbehappy)
+    -   高い更新スループットのワークロード下のTiFlashインスタンスにおいて、IOPSを最大95%、書き込み増幅を最大65%削減します [＃6460](https://github.com/pingcap/tiflash/issues/6460) @[flowbehappy](https://github.com/flowbehappy)
 
 -   ツール
 
@@ -60,7 +60,7 @@ TiDB バージョン: 6.1.4
     -   `reset-to-version`コマンドを実行すると tikv-ctl が予期せず終了する問題を修正しました [＃13829](https://github.com/tikv/tikv/issues/13829) @[tabokie](https://github.com/tabokie)
     -   TiKVが誤って`PessimisticLockNotFound`エラーを報告する問題を修正 [＃13425](https://github.com/tikv/tikv/issues/13425) @[sticnarf](https://github.com/sticnarf)
     -   1回の書き込みサイズが2 GiB を超えるとTiKVがpanicになる問題を修正 [＃13848](https://github.com/tikv/tikv/issues/13848) @[YuJuncen](https://github.com/YuJuncen)
-    -   Fix the data inconsistency issue caused by network failure between TiDB and TiKV during the execution of a DML after a failed pessimistic DML [＃14038](https://github.com/tikv/tikv/issues/14038) @[MyonKeminta](https://github.com/MyonKeminta)
+    -   失敗した悲観的DMLの後にDMLを実行する際、TiDBとTiKV間のネットワーク障害によって発生するデータ不整合の問題を修正しました [＃14038](https://github.com/tikv/tikv/issues/14038) @[MyonKeminta](https://github.com/MyonKeminta)
     -   新しい照合順序が有効になっていない場合、 `LIKE`演算子の`_`非 ASCII 文字と一致しない問題を修正[＃13769](https://github.com/tikv/tikv/issues/13769) @[YangKeao](https://github.com/YangKeao) @[tonyxuqqi](https://github.com/tonyxuqqi)
 
 -   TiFlash
@@ -79,11 +79,11 @@ TiDB バージョン: 6.1.4
 
         -   TiCDC が過度に多数のテーブルを複製するとチェックポイントが進めなくなる問題を修正しました [＃8004](https://github.com/pingcap/tiflow/issues/8004) @[asddongmen](https://github.com/asddongmen)
         -   `transaction-atomicity`と`protocol`構成ファイル経由で更新できない問題を修正 [＃7935](https://github.com/pingcap/tiflow/issues/7935) @[CharlesCheung96](https://github.com/CharlesCheung96)
-        -   Fix the issue that TiCDC mistakenly reports an error when the version of TiFlash is later than that of TiCDC [＃7744](https://github.com/pingcap/tiflow/issues/7744) @[overvenus](https://github.com/overvenus)
+        -   TiFlashのバージョンがTiCDCのバージョンより新しい場合にTiCDCが誤ってエラーを報告する問題を修正しました [＃7744](https://github.com/pingcap/tiflow/issues/7744) @[overvenus](https://github.com/overvenus)
         -   TiCDCが大規模なトランザクションを複製するときにOOMが発生する問題を修正 [＃7913](https://github.com/pingcap/tiflow/issues/7913) @[overvenus](https://github.com/overvenus)
         -   TiCDCが大きなトランザクションを分割せずにデータを複製するとコンテキスト期限が超過するバグを修正 [＃7982](https://github.com/pingcap/tiflow/issues/7982) @[Rustin170506](https://github.com/Rustin170506)
         -   `changefeed query`結果のうち`sasl-password`がマスクされない問題を修正しました [＃7182](https://github.com/pingcap/tiflow/issues/7182) @[dveeden](https://github.com/dveeden)
-        -   Fix the issue that data is lost when a user quickly deletes a replication task and then creates another one with the same task name [＃7657](https://github.com/pingcap/tiflow/issues/7657) @[overvenus](https://github.com/overvenus)
+        -   ユーザーがレプリケーションタスクを素早く削除して同じタスク名で別のタスクを作成するとデータが失われる問題を修正しました [＃7657](https://github.com/pingcap/tiflow/issues/7657) @[overvenus](https://github.com/overvenus)
 
     -   TiDB Data Migration (DM)
 

--- a/releases/release-6.1.6.md
+++ b/releases/release-6.1.6.md
@@ -56,7 +56,7 @@ TiDB バージョン: 6.1.6
     -   DDL文の実行中に`PointGet`を使用してテーブルを読み込むSQL文がpanicをスローする可能性がある問題を修正しました。 [＃41622](https://github.com/pingcap/tidb/issues/41622) @[tiancaiamao](https://github.com/tiancaiamao)
     -   トランザクション内で`PointUpdate`を実行した後、TiDB が`SELECT`文に対して誤った結果を返す問題を修正しました。 [＃28011](https://github.com/pingcap/tidb/issues/28011) @[zyguan](https://github.com/zyguan)
     -   メモリリークとパフォーマンスの低下を防ぐため、期限切れのリージョンキャッシュを定期的にクリアします[＃40461](https://github.com/pingcap/tidb/issues/40461) @[sticnarf](https://github.com/sticnarf) @[zyguan](https://github.com/zyguan)
-    -   Fix the issue that `INSERT IGNORE` and `REPLACE` statements do not lock keys that do not modify values [＃42121](https://github.com/pingcap/tidb/issues/42121) @[zyguan](https://github.com/zyguan)
+    -   `INSERT IGNORE` および `REPLACE` ステートメントが値を変更しないキーをロックしない問題を修正しました [＃42121](https://github.com/pingcap/tidb/issues/42121) @[zyguan](https://github.com/zyguan)
 
 -   TiKV
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The machine-translation pipeline **skipped some release-note bullets**, leaving them in English while the surrounding entries are Japanese. This PR translates the **29 remaining English prose bullets** (concentrated in the release-6.1.x notes, plus a few others) into natural Japanese, matching the style of the sibling translated entries (fixes → 「〜問題を修正しました」, features → 「〜をサポートします」, improvements → 「〜を改善します」).

Preserved verbatim: inline code (`...`), issue/PR links `[#NNNN](url)` / `[＃NNNN](url)`, full-width `＃`, and author links `@[handle](url)`. Stray-space author links `@ [handle]` on the touched lines were normalized to `@[handle]`.

**Scope:** 29 bullets across 6 files (release-6.1.0/6.1.1/6.1.2/6.1.3/6.1.4/6.1.6). Pure link-list bullets and product-name-only bullets (e.g. `TiCDC OpenAPI v2`) were intentionally left unchanged. Issue-link count is unchanged (verified).

Note: some of these lines are also touched by the mechanical author-link-spacing PR; per repo maintainer, overlapping conflicts are acceptable and will be rebased.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- ja translation branch: leave all unchecked -->

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

N/A

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch