### PR TITLE
i18n(ja): move mid-sentence issue links to the end of release-note bullets

### DIFF
--- a/releases/release-5.0.2.md
+++ b/releases/release-5.0.2.md
@@ -31,10 +31,10 @@ TiDB バージョン: 5.0.2
 
 -   TiKV
 
-    -   BRは、仮想ホストアドレス指定モード[＃10243](https://github.com/tikv/tikv/pull/10243)を使用してS3互換ストレージをサポートするようになりました。
-    -   TiCDCのスキャン速度[＃10151](https://github.com/tikv/tikv/pull/10151)バックプレッシャーをサポート
-    -   TiCDCの初期スキャン[＃10133](https://github.com/tikv/tikv/pull/10133)のメモリ使用量を削減
-    -   悲観的トランザクション[＃10089](https://github.com/tikv/tikv/pull/10089)におけるTiCDCの古い値機能のキャッシュヒット率を改善
+    -   BRは、仮想ホストアドレス指定モードを使用してS3互換ストレージをサポートするようになりました[＃10243](https://github.com/tikv/tikv/pull/10243)
+    -   TiCDCのスキャン速度のバックプレッシャーをサポート[＃10151](https://github.com/tikv/tikv/pull/10151)
+    -   TiCDCの初期スキャンのメモリ使用量を削減[＃10133](https://github.com/tikv/tikv/pull/10133)
+    -   悲観的トランザクションにおけるTiCDCの古い値機能のキャッシュヒット率を改善[＃10089](https://github.com/tikv/tikv/pull/10089)
     -   ホットスポット書き込みがあるときに、リージョンサイズの増加が分割速度を超える問題を軽減するために、リージョンをより均等に分割します[＃9785](https://github.com/tikv/tikv/issues/9785)
 
 -   TiFlash
@@ -47,14 +47,14 @@ TiDB バージョン: 5.0.2
     -   TiCDC
 
         -   テーブルメモリ消費量の監視メトリックを追加する[＃1885](https://github.com/pingcap/tiflow/pull/1885)
-        -   ソート段階[＃1863](https://github.com/pingcap/tiflow/pull/1863)におけるメモリとCPUの使用を最適化する
+        -   ソート段階におけるメモリとCPUの使用を最適化する[＃1863](https://github.com/pingcap/tiflow/pull/1863)
         -   ユーザーの混乱を招く可能性のある不要なログ情報を削除する[＃1759](https://github.com/pingcap/tiflow/pull/1759)
 
     -   Backup & Restore (BR)
 
         -   曖昧なエラーメッセージを明確にする[＃1132](https://github.com/pingcap/br/pull/1132)
-        -   バックアップ[＃1091](https://github.com/pingcap/br/pull/1091)のクラスタ バージョンの確認をサポート
-        -   `mysql`スキーマ[＃1143](https://github.com/pingcap/br/pull/1143) [＃1078](https://github.com/pingcap/br/pull/1078)のシステムテーブルのバックアップと復元をサポート
+        -   バックアップのクラスタ バージョンの確認をサポート[＃1091](https://github.com/pingcap/br/pull/1091)
+        -   `mysql`スキーマのシステムテーブルのバックアップと復元をサポート[＃1143](https://github.com/pingcap/br/pull/1143) [＃1078](https://github.com/pingcap/br/pull/1078)
 
     -   Dumpling
 
@@ -67,31 +67,31 @@ TiDB バージョン: 5.0.2
     -   一部のケースでプレフィックスインデックスとインデックス結合を使用することで発生するpanic問題を修正[＃24547](https://github.com/pingcap/tidb/issues/24547) [＃24716](https://github.com/pingcap/tidb/issues/24716) [＃24717](https://github.com/pingcap/tidb/issues/24717)
     -   `point get`のプリペアドプランキャッシュがトランザクションの`point get`文によって誤って使用される問題を修正しました[＃24741](https://github.com/pingcap/tidb/issues/24741)。
     -   照合順序が`ascii_bin`または`latin1_bin`の場合に間違ったプレフィックスインデックス値を書き込む問題を修正しました[＃24569](https://github.com/pingcap/tidb/issues/24569)
-    -   GCワーカー[＃24591](https://github.com/pingcap/tidb/issues/24591)によって進行中のトランザクションが中断される可能性がある問題を修正
+    -   GCワーカーによって進行中のトランザクションが中断される可能性がある問題を修正[＃24591](https://github.com/pingcap/tidb/issues/24591)
     -   `new-collation`が有効で`new-row-format`無効の場合、クラスター化インデックスでポイントクエリが間違って実行される可能性があるバグを修正しました[＃24541](https://github.com/pingcap/tidb/issues/24541)
-    -   シャッフルハッシュ結合[＃24490](https://github.com/pingcap/tidb/pull/24490)パーティションキーの変換をリファクタリングする
-    -   `HAVING`句[＃24045](https://github.com/pingcap/tidb/issues/24045)を含むクエリのプランを構築するときに発生するpanic問題を修正しました。
+    -   シャッフルハッシュ結合のパーティションキーの変換をリファクタリングする[＃24490](https://github.com/pingcap/tidb/pull/24490)
+    -   `HAVING`句を含むクエリのプランを構築するときに発生するpanic問題を修正しました[＃24045](https://github.com/pingcap/tidb/issues/24045)
     -   列プルーニングの改善により、演算子`Apply`と`Join`結果が間違ってしまう問題を修正しました[＃23887](https://github.com/pingcap/tidb/issues/23887)
     -   非同期コミットからフォールバックしたプライマリロックが解決できないバグを修正[＃24384](https://github.com/pingcap/tidb/issues/24384)
     -   fm-sketch レコードの重複を引き起こす可能性のある統計の GC 問題を修正しました[＃24357](https://github.com/pingcap/tidb/pull/24357)
-    -   悲観的ロックが`ErrKeyExists`エラー[＃23799](https://github.com/pingcap/tidb/issues/23799)を受け取ったときに不要な悲観的ロールバックを回避する
-    -   sql_modeに`ANSI_QUOTES` [＃24429](https://github.com/pingcap/tidb/issues/24429)が含まれている場合に数値リテラルが認識されない問題を修正しました
-    -   `INSERT INTO table PARTITION (<partitions>) ... ON DUPLICATE KEY UPDATE`ような文は、リストされていないパーティション[＃24746](https://github.com/pingcap/tidb/issues/24746)からデータを読み取ることを禁止します。
+    -   悲観的ロックが`ErrKeyExists`エラーを受け取ったときに不要な悲観的ロールバックを回避する[＃23799](https://github.com/pingcap/tidb/issues/23799)
+    -   sql_modeに`ANSI_QUOTES`が含まれている場合に数値リテラルが認識されない問題を修正しました[＃24429](https://github.com/pingcap/tidb/issues/24429)
+    -   `INSERT INTO table PARTITION (<partitions>) ... ON DUPLICATE KEY UPDATE`ような文は、リストされていないパーティションからデータを読み取ることを禁止します[＃24746](https://github.com/pingcap/tidb/issues/24746)
     -   SQL文に`GROUP BY`と`UNION`両方が含まれている場合に発生する可能性のある`index out of range`エラーを修正します[＃24281](https://github.com/pingcap/tidb/issues/24281)
-    -   `CONCAT`関数が照合順序[＃24296](https://github.com/pingcap/tidb/issues/24296)誤って処理する問題を修正しました
-    -   `collation_server`グローバル変数が新しいセッション[＃24156](https://github.com/pingcap/tidb/pull/24156)で有効にならない問題を修正しました
+    -   `CONCAT`関数が照合順序を誤って処理する問題を修正しました[＃24296](https://github.com/pingcap/tidb/issues/24296)
+    -   `collation_server`グローバル変数が新しいセッションで有効にならない問題を修正しました[＃24156](https://github.com/pingcap/tidb/pull/24156)
 
 -   TiKV
 
     -   古い値の読み取りによって引き起こされる TiCDC OOM 問題を修正[＃9996](https://github.com/tikv/tikv/issues/9996) [＃9981](https://github.com/tikv/tikv/issues/9981)
     -   照合順序が`latin1_bin`の場合にクラスター化主キー列のセカンダリインデックスに空の値が含まれる問題を修正しました[＃24548](https://github.com/pingcap/tidb/issues/24548)
-    -   `abort-on-panic`設定を追加すると、panic発生時にTiKVがコアダンプファイルを生成できるようになります。コアダンプ[＃10216](https://github.com/tikv/tikv/pull/10216)を有効にするには、ユーザーは環境を正しく設定する必要があります。
+    -   `abort-on-panic`設定を追加すると、panic発生時にTiKVがコアダンプファイルを生成できるようになります。コアダンプを有効にするには、ユーザーは環境を正しく設定する必要があります[＃10216](https://github.com/tikv/tikv/pull/10216)
     -   TiKVがビジーでないときに発生する`point get`クエリのパフォーマンス回帰の問題を修正しました[＃10046](https://github.com/tikv/tikv/issues/10046)
 
 -   PD
 
     -   ストア数が多い場合にPDリーダーの再選出が遅くなる問題を修正[＃3697](https://github.com/tikv/pd/issues/3697)
-    -   存在しないストア[＃3660](https://github.com/tikv/pd/issues/3660)からエビクト リーダー スケジューラを削除するときに発生するpanic問題を修正しました
+    -   存在しないストアからエビクト リーダー スケジューラを削除するときに発生するpanic問題を修正しました[＃3660](https://github.com/tikv/pd/issues/3660)
     -   オフラインピアがマージされた後に統計が更新されない問題を修正[＃3611](https://github.com/tikv/pd/issues/3611)
 
 -   TiFlash
@@ -110,19 +110,19 @@ TiDB バージョン: 5.0.2
 
     -   TiCDC
 
-        -   Avro出力[＃1712](https://github.com/pingcap/tiflow/pull/1712)でタイムゾーン情報が失われる問題を修正
-        -   Unified Sorter 内の古い一時ファイルのクリーンアップをサポートし、 `sort-dir`ディレクトリ[＃1742](https://github.com/pingcap/tiflow/pull/1742)共有を禁止します。
+        -   Avro出力でタイムゾーン情報が失われる問題を修正[＃1712](https://github.com/pingcap/tiflow/pull/1712)
+        -   Unified Sorter 内の古い一時ファイルのクリーンアップをサポートし、 `sort-dir`ディレクトリの共有を禁止します[＃1742](https://github.com/pingcap/tiflow/pull/1742)
         -   多くの古いリージョンが存在する場合に発生する KV クライアントのデッドロックバグを修正[＃1599](https://github.com/pingcap/tiflow/issues/1599)
-        -   `--cert-allowed-cn`フラグ[＃1697](https://github.com/pingcap/tiflow/pull/1697)の間違ったヘルプ情報を修正
-        -   MySQL [＃1750](https://github.com/pingcap/tiflow/pull/1750)にデータを複製する際に`SUPER`権限を必要とする`explicit_defaults_for_timestamp`の更新を元に戻す
+        -   `--cert-allowed-cn`フラグの間違ったヘルプ情報を修正[＃1697](https://github.com/pingcap/tiflow/pull/1697)
+        -   MySQLにデータを複製する際に`SUPER`権限を必要とする`explicit_defaults_for_timestamp`の更新を元に戻す[＃1750](https://github.com/pingcap/tiflow/pull/1750)
         -   シンクフロー制御をサポートし、メモリオーバーフローのリスクを軽減します[＃1840](https://github.com/pingcap/tiflow/pull/1840)
-        -   テーブル[＃1828](https://github.com/pingcap/tiflow/pull/1828)移動する際にレプリケーションタスクが停止する可能性があるバグを修正
-        -   TiCDC チェンジフィード チェックポイント[＃1759](https://github.com/pingcap/tiflow/pull/1759)の停滞により TiKV GC セーフ ポイントがブロックされる問題を修正しました
+        -   テーブルを移動する際にレプリケーションタスクが停止する可能性があるバグを修正[＃1828](https://github.com/pingcap/tiflow/pull/1828)
+        -   TiCDC チェンジフィード チェックポイントの停滞により TiKV GC セーフ ポイントがブロックされる問題を修正しました[＃1759](https://github.com/pingcap/tiflow/pull/1759)
 
     -   Backup & Restore (BR)
 
         -   ログの復元中に`DELETE`イベントが失われる問題を修正しました[＃1063](https://github.com/pingcap/br/issues/1063)
-        -   BR がTiKV [＃1037](https://github.com/pingcap/br/pull/1037)に無駄な RPC リクエストを大量に送信してしまうバグを修正しました
+        -   BR がTiKVに無駄な RPC リクエストを大量に送信してしまうバグを修正しました[＃1037](https://github.com/pingcap/br/pull/1037)
         -   バックアップ操作が失敗したときにエラーが出力されない問題を修正[＃1043](https://github.com/pingcap/br/pull/1043)
 
     -   TiDB Lightning

--- a/releases/release-5.4.3.md
+++ b/releases/release-5.4.3.md
@@ -13,7 +13,7 @@ TiDB バージョン: 5.4.3
 
 -   TiKV
 
-    -   RocksDB 書き込みストール設定をフロー制御しきい値[＃13467](https://github.com/tikv/tikv/issues/13467)より小さい値に設定できるようになりました。
+    -   RocksDB 書き込みストール設定をフロー制御しきい値より小さい値に設定できるようになりました[＃13467](https://github.com/tikv/tikv/issues/13467)
     -   1つのピアが到達不能になった後にRaftstoreが過剰なメッセージをブロードキャストするのを避けるために`unreachable_backoff`項目の設定をサポートします[＃13054](https://github.com/tikv/tikv/issues/13054)
 
 -   ツール
@@ -30,24 +30,24 @@ TiDB バージョン: 5.4.3
 
 -   TiDB
 
-    -   `SHOW CREATE PLACEMENT POLICY` [＃37526](https://github.com/pingcap/tidb/issues/37526)の誤った出力を修正
+    -   `SHOW CREATE PLACEMENT POLICY`の誤った出力を修正[＃37526](https://github.com/pingcap/tidb/issues/37526)
     -   クラスターのPDノードが交換された後、一部のDDL文が一定期間スタックする可能性がある問題を修正しました[＃33908](https://github.com/pingcap/tidb/issues/33908)
     -   `KILL TIDB`アイドル接続時にすぐに効果を発揮できない問題を修正[＃24031](https://github.com/pingcap/tidb/issues/24031)
-    -   `INFORMSTION_SCHEMA.COLUMNS`システムテーブル[＃36496](https://github.com/pingcap/tidb/issues/36496)をクエリするときに`DATA_TYPE`と`COLUMN_TYPE`列に誤った結果が返される問題を修正しました
+    -   `INFORMSTION_SCHEMA.COLUMNS`システムテーブルをクエリするときに`DATA_TYPE`と`COLUMN_TYPE`列に誤った結果が返される問題を修正しました[＃36496](https://github.com/pingcap/tidb/issues/36496)
     -   TiDB Binlogが有効な場合、 `ALTER SEQUENCE`文を実行するとメタデータ バージョンが間違って発生し、 Drainerが終了する可能性がある問題を修正しました[＃36276](https://github.com/pingcap/tidb/issues/36276)
-    -   `UNION`演算子が予期しない空の結果[＃36903](https://github.com/pingcap/tidb/issues/36903)を返す可能性がある問題を修正しました
-    -   TiFlash [＃37254](https://github.com/pingcap/tidb/issues/37254)のパーティションテーブルでダイナミックモードを有効にしたときに発生する誤った結果を修正しました
-    -   `LIMIT` [＃35638](https://github.com/pingcap/tidb/issues/35638)と併用すると`INL_HASH_JOIN`ハングアップする可能性がある問題を修正
-    -   TiDBが`SHOW WARNINGS`ステートメント[＃31569](https://github.com/pingcap/tidb/issues/31569)を実行するときに`invalid memory address or nil pointer dereference`エラーを返す可能性がある問題を修正しました
-    -   RC分離レベル[＃30872](https://github.com/pingcap/tidb/issues/30872)でステイル読み取りを実行するときに発生する`invalid transaction`エラーを修正
+    -   `UNION`演算子が予期しない空の結果を返す可能性がある問題を修正しました[＃36903](https://github.com/pingcap/tidb/issues/36903)
+    -   TiFlashのパーティションテーブルでダイナミックモードを有効にしたときに発生する誤った結果を修正しました[＃37254](https://github.com/pingcap/tidb/issues/37254)
+    -   `LIMIT`と併用すると`INL_HASH_JOIN`がハングアップする可能性がある問題を修正[＃35638](https://github.com/pingcap/tidb/issues/35638)
+    -   TiDBが`SHOW WARNINGS`ステートメントを実行するときに`invalid memory address or nil pointer dereference`エラーを返す可能性がある問題を修正しました[＃31569](https://github.com/pingcap/tidb/issues/31569)
+    -   RC分離レベルでステイル読み取りを実行するときに発生する`invalid transaction`エラーを修正[＃30872](https://github.com/pingcap/tidb/issues/30872)
     -   DMLエグゼキュータを使用した`EXPLAIN ANALYZE`文がトランザクションコミットが完了する前に結果を返す可能性がある問題を修正しました[＃37373](https://github.com/pingcap/tidb/issues/37373)
     -   TiDB Binlogを有効にして重複した値を挿入すると発生する`data and columnID count not match`エラーの問題を修正しました[＃33608](https://github.com/pingcap/tidb/issues/33608)
     -   静的パーティションプルーニングモードで、テーブルが空の場合に集計条件を含むSQL文が間違った結果を返す可能性がある問題を修正しました[＃35295](https://github.com/pingcap/tidb/issues/35295)
-    -   `UPDATE`文[＃32311](https://github.com/pingcap/tidb/issues/32311)を実行するときに TiDB がpanicする可能性がある問題を修正しました
+    -   `UPDATE`文を実行するときに TiDB がpanicする可能性がある問題を修正しました[＃32311](https://github.com/pingcap/tidb/issues/32311)
     -   `UnionScan`演算子が順序を維持できないために間違ったクエリ結果が発生する問題を修正[＃33175](https://github.com/pingcap/tidb/issues/33175)
-    -   UPDATE文が場合によっては投影を誤って削除し、 `Can't find column`エラー[＃37568](https://github.com/pingcap/tidb/issues/37568)が発生する問題を修正しました。
+    -   UPDATE文が場合によっては投影を誤って削除し、 `Can't find column`エラーが発生する問題を修正しました[＃37568](https://github.com/pingcap/tidb/issues/37568)
     -   パーティションテーブルがインデックスを完全に使用してデータをスキャンできない場合がある問題を修正[＃33966](https://github.com/pingcap/tidb/issues/33966)
-    -   特定のシナリオ[＃37187](https://github.com/pingcap/tidb/issues/37187)予期しないエラーが発生する可能性がある問題を修正しました`EXECUTE`
+    -   特定のシナリオで`EXECUTE`が予期しないエラーが発生する可能性がある問題を修正しました[＃37187](https://github.com/pingcap/tidb/issues/37187)
     -   プリペアドプランキャッシュが有効になっている`BIT`タイプのインデックスを使用すると、TiDBが間違った結果を返す可能性がある問題を修正しました[＃33067](https://github.com/pingcap/tidb/issues/33067)
 
 -   TiKV
@@ -56,7 +56,7 @@ TiDB バージョン: 5.4.3
         -   原因：この問題は、TiKVのバグが原因で発生します。このバグにより、ハートビート要求が失敗した後、TiKVはPDクライアントに再接続するまで、PDクライアントへのハートビート情報の送信を再試行しません。その結果、障害が発生したTiKVノードのリージョン情報が古くなり、TiDBは最新のリージョン情報を取得できず、SQL実行エラーが発生します。
         -   影響を受けるバージョン: v5.3.2 および v5.4.2。この問題は v5.3.3 および v5.4.3 で修正されています。v5.4.2 をご利用の場合は、クラスターを v5.4.3 にアップグレードできます。
         -   回避策: アップグレードに加えて、送信するリージョンハートビートがなくなるまで、リージョンハートビートを PD に送信できない TiKV ノードを再起動することもできます。
-    -   TiKV が Web ID プロバイダーからエラーを取得し、デフォルトのプロバイダー[＃13122](https://github.com/tikv/tikv/issues/13122)にフェイルバックしたときに、権限拒否エラーが発生する問題を修正しました。
+    -   TiKV が Web ID プロバイダーからエラーを取得し、デフォルトのプロバイダーにフェイルバックしたときに、権限拒否エラーが発生する問題を修正しました[＃13122](https://github.com/tikv/tikv/issues/13122)
     -   PDクライアントがデッドロックを引き起こす可能性がある問題を修正[＃13191](https://github.com/tikv/tikv/issues/13191)
     -   Raftstoreがビジー状態の場合にリージョンが重複する可能性がある問題を修正[＃13160](https://github.com/tikv/tikv/issues/13160)
 
@@ -68,9 +68,9 @@ TiDB バージョン: 5.4.3
 
 -   TiFlash
 
-    -   `format`関数が`Data truncated`エラー[＃4891](https://github.com/pingcap/tiflash/issues/4891)を返す可能性がある問題を修正しました
-    -   並列集約[＃5356](https://github.com/pingcap/tiflash/issues/5356)エラーによりTiFlashがクラッシュする可能性がある問題を修正
-    -   `NULL`値[＃5859](https://github.com/pingcap/tiflash/issues/5859)を含む列を持つプライマリインデックスを作成した後に発生するpanicを修正しました
+    -   `format`関数が`Data truncated`エラーを返す可能性がある問題を修正しました[＃4891](https://github.com/pingcap/tiflash/issues/4891)
+    -   並列集約エラーによりTiFlashがクラッシュする可能性がある問題を修正[＃5356](https://github.com/pingcap/tiflash/issues/5356)
+    -   `NULL`値を含む列を持つプライマリインデックスを作成した後に発生するpanicを修正しました[＃5859](https://github.com/pingcap/tiflash/issues/5859)
 
 -   ツール
 
@@ -79,26 +79,26 @@ TiDB バージョン: 5.4.3
         -   `BIGINT`型のAUTO_INCREMENT列が範囲外になる可能性がある問題を修正[＃27937](https://github.com/pingcap/tidb/issues/27937)
         -   重複排除により極端な場合にTiDB Lightning がpanicを起こす可能性がある問題を修正[＃34163](https://github.com/pingcap/tidb/issues/34163)
         -   TiDB Lightning がParquet ファイル内のスラッシュ、数字、または非 ASCII 文字で始まる列をサポートしない問題を修正しました[＃36980](https://github.com/pingcap/tidb/issues/36980)
-        -   TiDBがIPv6ホスト[＃35880](https://github.com/pingcap/tidb/issues/35880)を使用しているときにTiDB LightningがTiDBに接続できない問題を修正しました
+        -   TiDBがIPv6ホストを使用しているときにTiDB LightningがTiDBに接続できない問題を修正しました[＃35880](https://github.com/pingcap/tidb/issues/35880)
 
     -   TiDB Data Migration (DM)
 
-        -   DB Conn [＃3733](https://github.com/pingcap/tiflow/issues/3733)を取得する際に DM ワーカーがスタックする可能性がある問題を修正しました
+        -   DB Connを取得する際に DM ワーカーがスタックする可能性がある問題を修正しました[＃3733](https://github.com/pingcap/tiflow/issues/3733)
         -   DMが`Specified key was too long`エラーを報告する問題を修正しました[＃5315](https://github.com/pingcap/tiflow/issues/5315)
         -   レプリケーション中にlatin1データが破損する可能性がある問題を修正[＃7028](https://github.com/pingcap/tiflow/issues/7028)
-        -   TiDBがIPv6ホスト[＃6249](https://github.com/pingcap/tiflow/issues/6249)を使用しているときにDMが起動に失敗する問題を修正
-        -   `query-status` [＃4811](https://github.com/pingcap/tiflow/issues/4811)で起こりうるデータ競合の問題を修正
-        -   リレーがエラー[＃6193](https://github.com/pingcap/tiflow/issues/6193)に遭遇したときの goroutine リークを修正
+        -   TiDBがIPv6ホストを使用しているときにDMが起動に失敗する問題を修正[＃6249](https://github.com/pingcap/tiflow/issues/6249)
+        -   `query-status`で起こりうるデータ競合の問題を修正[＃4811](https://github.com/pingcap/tiflow/issues/4811)
+        -   リレーがエラーに遭遇したときの goroutine リークを修正[＃6193](https://github.com/pingcap/tiflow/issues/6193)
 
     -   TiCDC
 
-        -   `enable-old-value = false` [＃6198](https://github.com/pingcap/tiflow/issues/6198)を設定すると TiCDC panicする問題を修正
+        -   `enable-old-value = false`を設定すると TiCDC がpanicする問題を修正[＃6198](https://github.com/pingcap/tiflow/issues/6198)
 
     -   Backup & Restore (BR)
 
-        -   外部ストレージ[＃37469](https://github.com/pingcap/tidb/issues/37469)の認証キーに特殊文字が含まれている場合にバックアップと復元が失敗する可能性がある問題を修正しました
+        -   外部ストレージの認証キーに特殊文字が含まれている場合にバックアップと復元が失敗する可能性がある問題を修正しました[＃37469](https://github.com/pingcap/tidb/issues/37469)
         -   復元中に同時実行が大きすぎる設定になっているためにリージョンのバランスが取れていない問題を修正[＃37549](https://github.com/pingcap/tidb/issues/37549)
 
     -   Dumpling
 
-        -   GetDSNがIPv6 [＃36112](https://github.com/pingcap/tidb/issues/36112)をサポートしていない問題を修正
+        -   GetDSNがIPv6をサポートしていない問題を修正[＃36112](https://github.com/pingcap/tidb/issues/36112)

--- a/releases/release-6.6.0.md
+++ b/releases/release-6.6.0.md
@@ -198,11 +198,11 @@ TiDB バージョン: 6.6.0- [DMR](/releases/versioning.md#development-milestone
 
     詳細については、 [ドキュメント](/ticdc/ticdc-sink-to-kafka.md#scale-out-the-load-of-a-single-large-table-to-multiple-ticdc-nodes)を参照してください。
 
--   [GORM](https://github.com/go-gorm/gorm)TiDB 統合テストを追加します。現在、TiDB は GORM によってサポートされるデフォルトのデータベースです。 [#6014](https://github.com/go-gorm/gorm/pull/6014) @[Icemap](https://github.com/Icemap)
+-   [GORM](https://github.com/go-gorm/gorm)がTiDB 統合テストを追加します。現在、TiDB は GORM によってサポートされるデフォルトのデータベースです。 [#6014](https://github.com/go-gorm/gorm/pull/6014) @[Icemap](https://github.com/Icemap)
 
-    -   v1.4.6 では、 [GORM MySQL ドライバー](https://github.com/go-gorm/mysql)TiDB [#104](https://github.com/go-gorm/mysql/pull/104)の`AUTO_RANDOM`属性に適応します
-    -   v1.4.6 では、 [GORM MySQL ドライバー](https://github.com/go-gorm/mysql)は、TiDB に接続する際に、 `Unique`フィールドの`Unique`属性が`AutoMigrate`中に変更できない問題を修正しました。 [#105](https://github.com/go-gorm/mysql/pull/105)
-    -   [GORMドキュメント](https://github.com/go-gorm/gorm.io)TiDB をデフォルトのデータベースとして言及しています [#638](https://github.com/go-gorm/gorm.io/pull/638)
+    -   v1.4.6 では、 [GORM MySQL driver](https://github.com/go-gorm/mysql)はTiDBの`AUTO_RANDOM`属性に適応します [#104](https://github.com/go-gorm/mysql/pull/104)
+    -   v1.4.6 では、 [GORM MySQL driver](https://github.com/go-gorm/mysql)は、TiDB に接続する際に、 `Unique`フィールドの`Unique`属性が`AutoMigrate`中に変更できない問題を修正しました。 [#105](https://github.com/go-gorm/mysql/pull/105)
+    -   [GORMドキュメント](https://github.com/go-gorm/gorm.io)がTiDB をデフォルトのデータベースとして言及しています [#638](https://github.com/go-gorm/gorm.io/pull/638)
 
     詳細については、 [GORMドキュメント](https://gorm.io/docs/index.html)を参照してください。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Follow-up to #23423 (which fixed author-attribution `@[handle]` links). The machine translation also left issue/PR reference links `[#NNNN]` stranded in the **middle** of many release-note bullets, splitting the description, whereas the English source places them at the **end** of the bullet.

Verified 1:1 against the English source and moved the **48 genuine mid-sentence issue links** to the end of their bullets, repairing the particle at the former link site (and in one case relocating a stranded code token `EXECUTE` to its subject position).

**Left unchanged (legitimate inline references, matched to English):** "changes made in [#N]" (`[＃N]で行われた変更`), "see [#N]" (`[#N]を参照`), "comment on [#N]" (`[#N]にコメント`).

**Preserved (verified):** full-width `＃` (count unchanged, 103), author `@[handle]` links (count unchanged, 5907), URLs, indentation. Refs are attached at bullet-end in each file's dominant local style.

**Scope:** 48 changes across 3 files (release-5.0.2, release-5.4.3, release-6.6.0).

### Which TiDB version(s) do your changes apply to? (Required)

<!-- ja translation branch: leave all unchecked -->

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

Follow-up to #23423 (release-note author-link scramble fix).

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch