### PR TITLE
i18n(ja): fix unnatural phrasing and misplaced issue-link

### DIFF
--- a/develop/dev-guide-third-party-tools-compatibility.md
+++ b/develop/dev-guide-third-party-tools-compatibility.md
@@ -19,7 +19,7 @@ aliases: ['/ja/tidb/stable/dev-guide-third-party-tools-compatibility/','/ja/tidb
 >
 > 上記の機能がサポートされていないのは想定された動作であり、このドキュメントには記載されていません。詳細については、 [MySQLの互換性](/mysql-compatibility.md)を参照してください。
 
-このドキュメントに記載されている非互換性の問題は、いくつかの[TiDBでサポートされているサードパーティツール](/develop/dev-guide-third-party-tools-compatibility.md)に見られます。
+このドキュメントに記載されている非互換性の問題は、いくつかの[TiDBでサポートされているサードパーティツール](/develop/dev-guide-third-party-tools-compatibility.md)で発生します。
 
 ## 一般的な非互換性 {#general-incompatibility}
 

--- a/functions-and-operators/encryption-and-compression-functions.md
+++ b/functions-and-operators/encryption-and-compression-functions.md
@@ -381,7 +381,7 @@ SELECT UNCOMPRESSED_LENGTH(0x03000000789C72747206040000FFFF018D00C7);
 
 ## サポートされていない関数 {#unsupported-functions}
 
--   TiDB は、MySQL Enterprise [問題 #2632](https://github.com/pingcap/tidb/issues/2632)でのみ利用可能な関数をサポートしていません。
+-   TiDB は、MySQL Enterpriseでのみ利用可能な関数をサポートしていません[問題 #2632](https://github.com/pingcap/tidb/issues/2632)。
 
 ## MySQLの互換性 {#mysql-compatibility}
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Two small fluency/structure fixes spotted while reviewing nearby files:

- `develop/dev-guide-third-party-tools-compatibility.md`: "...に見られます" (are seen in) read unnaturally for "issues found in some third-party tools". Changed to "...で発生します" (occur in), a more natural verb choice for this subject.
- `functions-and-operators/encryption-and-compression-functions.md`: the GitHub issue link `[問題 #2632]` had been inserted in the middle of the sentence, between "MySQL Enterprise" and "でのみ利用可能な関数", splitting the phrase "functions only available in MySQL Enterprise". Moved the link to the end of the sentence, matching the English source's structure (`... only available in MySQL Enterprise [Issue #2632](...).`).

## Which TiDB version(s) do your changes apply to? (Required)

- [ ] v8.5 (LTS)
- [ ] v8.1 (LTS)
- [ ] v7.5 (LTS)
- [ ] v7.1 (LTS)
- [ ] v6.5 (LTS)
- [ ] v6.1 (LTS)

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Add redirect rules
- [ ] Change the framework or the code logic of the repository