### PR TITLE
i18n(ja): fix broken dashboard URL rendering and duplicated word

### DIFF
--- a/best-practices/tidb-best-practices.md
+++ b/best-practices/tidb-best-practices.md
@@ -195,7 +195,7 @@ TiDB は[Grafana + Prometheus](/tidb-monitoring-framework.md)を使用してシ�
 
 監視に加えて、システムログを表示することもできます。TiDB の 3 つのコンポーネント、tidb-server、tikv-server、および pd-server には、それぞれ`--log-file`パラメータがあります。このパラメータがクラスタの起動時に構成されている場合、ログはパラメータで構成されたファイルに保存され、ログファイルは毎日自動的にアーカイブされます。 `--log-file`パラメータが構成されていない場合、ログは`stderr`に出力されます。
 
-TiDB 4.0 以降、TiDB は使いやすさを向上させるために[TiDB Dashboard](/dashboard/dashboard-intro.md)UI を提供します。 TiDB Dashboardにアクセスするには、ブラウザで[http://${PD_IP}:${PD_PORT}/dashboard](http://$%7BPD_IP%7D:$%7BPD_PORT%7D/dashboard)Dashboardにアクセスします。 TiDB Dashboardは、クラスターのステータスの表示、パフォーマンス分析、トラフィックの視覚化、クラスターの診断、ログ検索などの機能を提供します。
+TiDB 4.0 以降、TiDB は使いやすさを向上させるために[TiDB Dashboard](/dashboard/dashboard-intro.md)UI を提供します。 TiDB Dashboardにアクセスするには、ブラウザで<http://${PD_IP}:${PD_PORT}/dashboard>にアクセスします。 TiDB Dashboardは、クラスターのステータスの表示、パフォーマンス分析、トラフィックの視覚化、クラスターの診断、ログ検索などの機能を提供します。
 
 ### 文書 {#documentation}
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

`best-practices/tidb-best-practices.md`: the TiDB Dashboard URL was rendered as a markdown link with the raw URL as literal link text (`[http://${PD_IP}:${PD_PORT}/dashboard](...)`) instead of an autolink. Because the link text was plain (non-code) text containing two underscores (in `PD_IP` and `PD_PORT`), the renderer interpreted the span between them as markdown emphasis, italicizing part of the URL on the rendered page. Also, the sentence appended a redundant "Dashboard" after the URL ("...dashboard)Dashboardにアクセスします"), duplicating the word.

Restored the English source's safe autolink syntax `<http://${PD_IP}:${PD_PORT}/dashboard>` and removed the duplicated word, matching: "You can access TiDB Dashboard by visiting `<http://${PD_IP}:${PD_PORT}/dashboard>` in your browser."

Verified no conflict with sibling PRs #23440 and #23442, which also touch this file at different lines.

## Which TiDB version(s) do your changes apply to? (Required)

- [ ] v8.5 (LTS)
- [ ] v8.1 (LTS)
- [ ] v7.5 (LTS)
- [ ] v7.1 (LTS)
- [ ] v6.5 (LTS)
- [ ] v6.1 (LTS)

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Add redirect rules
- [ ] Change the framework or the code logic of the repository