### PR TITLE
i18n(ja): fix garbled BTREE/HASH/RTREE index-type sentence

### DIFF
--- a/sql-statements/sql-statement-show-indexes.md
+++ b/sql-statements/sql-statement-show-indexes.md
@@ -52,7 +52,7 @@ mysql> SHOW KEYS FROM t1;
 2 rows in set (0.00 sec)
 ```
 
-TiDB `BTREE` `HASH`のインデックス タイプを`RTREE`ますが、無視されることに注意してください。
+TiDB は、MySQL との互換性のために、 `HASH` 、 `BTREE` 、 `RTREE`などのインデックス タイプを構文で受け入れますが、それらを無視することに注意してください。
 
 ## MySQLの互換性 {#mysql-compatibility}
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

`sql-statements/sql-statement-show-indexes.md`: the sentence "TiDB `BTREE` `HASH`のインデックス タイプを`RTREE`ますが、無視されることに注意してください。" was garbled MT output (missing the "accepts ... for compatibility with MySQL" clause entirely, and "`RTREE`ますが" is not valid Japanese).

The English source is: "Note that TiDB accepts index types such as `HASH`, `BTREE` and `RTREE` in syntax for compatibility with MySQL, but ignores them." Three sibling files (`sql-statement-add-index.md`, `sql-statement-create-index.md`, `sql-statement-create-table.md`) contain the closely related sentence "TiDB accepts index types such as `HASH`, `BTREE` and `RTREE` in syntax for compatibility with MySQL, but ignores them." (as a bullet, without the leading "Note that"), already correctly translated as "TiDB は、MySQL との互換性のために、`HASH`、`BTREE`、`RTREE`などのインデックス タイプを構文で受け入れますが、それらを無視します。"

This PR reuses that established core phrasing and appends "...ことに注意してください" (the standard idiom for "Note that", used throughout `sql-statements/*.md`) to fully match this file's own English sentence: "TiDB は、MySQL との互換性のために、`HASH`、`BTREE`、`RTREE`などのインデックス タイプを構文で受け入れますが、それらを無視することに注意してください。"

## Which TiDB version(s) do your changes apply to? (Required)

- [ ] v8.5 (LTS)
- [ ] v8.1 (LTS)
- [ ] v7.5 (LTS)
- [ ] v7.1 (LTS)
- [ ] v6.5 (LTS)
- [ ] v6.1 (LTS)

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Add redirect rules
- [ ] Change the framework or the code logic of the repository