### PR TITLE
i18n(ja): restore dropped particles after code spans in two SQL/TiCDC docs

### DIFF
--- a/sql-statements/sql-statement-start-transaction.md
+++ b/sql-statements/sql-statement-start-transaction.md
@@ -40,9 +40,9 @@ Query OK, 0 rows affected (0.01 sec)
 
 ## MySQLとの互換性 {#mysql-compatibility}
 
--   `START TRANSACTION` TiDB内で即座にトランザクションを開始します。これはMySQLとは異なります。MySQLでは`START TRANSACTION`遅延トランザクションを作成します。ただし、TiDBの`START TRANSACTION` MySQLの`START TRANSACTION WITH CONSISTENT SNAPSHOT`に相当します。
+-   `START TRANSACTION`は、TiDB内で即座にトランザクションを開始します。これはMySQLとは異なります。MySQLでは、`START TRANSACTION`は遅延トランザクションを作成します。ただし、TiDBの`START TRANSACTION`は、MySQLの`START TRANSACTION WITH CONSISTENT SNAPSHOT`に相当します。
 
--   ステートメント`START TRANSACTION READ ONLY` MySQL との互換性のために解析されますが、書き込み操作は引き続き許可されます。
+-   ステートメント`START TRANSACTION READ ONLY`は、MySQL との互換性のために解析されますが、書き込み操作は引き続き許可されます。
 
 ## 参照 {#see-also}
 

--- a/ticdc/ticdc-faq.md
+++ b/ticdc/ticdc-faq.md
@@ -351,7 +351,7 @@ mysql root@127.0.0.1:test> show create table test;
 1 row in set
 ```
 
-結果から、レプリケーション前後のテーブルスキーマが不整合になっていることがわかります。これは、TiDBのデフォルト値`explicit_defaults_for_timestamp`がMySQLと異なるためです。詳細は[MySQLとの互換性](/mysql-compatibility.md#default-differences)ご覧ください。
+結果から、レプリケーション前後のテーブルスキーマが不整合になっていることがわかります。これは、TiDBの`explicit_defaults_for_timestamp`のデフォルト値がMySQLと異なるためです。詳細は[MySQLとの互換性](/mysql-compatibility.md#default-differences)をご覧ください。
 
 v5.0.1 または v4.0.13 以降、MySQL へのレプリケーションごとに、TiCDC は上流と下流の間で時刻型の一貫性を保つために、自動的に`explicit_defaults_for_timestamp = ON`設定します。v5.0.1 または v4.0.13 より前のバージョンでは、TiCDC を使用して時刻型データをレプリケーションする際に、不一致な`explicit_defaults_for_timestamp`値によって発生する互換性の問題にご注意ください。
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

- `sql-statements/sql-statement-start-transaction.md`: the `START TRANSACTION` MySQL-compatibility bullet was missing the は particle after every `` `START TRANSACTION` `` code span (3 places), producing a run-on, ungrammatical sentence. Restored particles to match the English source's three clauses (TiDB behavior / MySQL behavior / the `WITH CONSISTENT SNAPSHOT` equivalence). Fixed the same missing-は defect in the adjacent `START TRANSACTION READ ONLY` bullet.
- `ticdc/ticdc-faq.md`:
  - "詳細は[MySQLの互換性](...)ご覧ください" was missing the を particle before the verb. Restored to "...をご覧ください", and also applied `MySQLの互換性` -> `MySQLとの互換性` on this line (matching #23437's term unification, to reduce cross-PR churn).
  - Reordered "TiDBのデフォルト値`explicit_defaults_for_timestamp`がMySQLと異なる" (awkward: reads as "TiDB's default value explicit_defaults_for_timestamp") to "TiDBの`explicit_defaults_for_timestamp`のデフォルト値がMySQLと異なる", matching the English's modifier order: "the default value of `explicit_defaults_for_timestamp` in TiDB".

**Known benign conflict**: this PR and #23437 both touch the same physical line in `ticdc-faq.md` (line-level, not content-level — my version already includes their term change plus additional independent fixes). Standard git line-collision, trivial to resolve on rebase whichever merges second.

## Which TiDB version(s) do your changes apply to? (Required)

- [ ] v8.5 (LTS)
- [ ] v8.1 (LTS)
- [ ] v7.5 (LTS)
- [ ] v7.1 (LTS)
- [ ] v6.5 (LTS)
- [ ] v6.1 (LTS)

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Add redirect rules
- [ ] Change the framework or the code logic of the repository