### PR TITLE
workflows: configure translation product and manual scope

### DIFF
--- a/.github/workflows/sync-doc-pr-zh-to-en.yml
+++ b/.github/workflows/sync-doc-pr-zh-to-en.yml
@@ -27,6 +27,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  PRODUCT: TiDB
+
 jobs:
   sync-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-doc-pr-zh-to-en.yml
+++ b/.github/workflows/sync-doc-pr-zh-to-en.yml
@@ -13,15 +13,6 @@ on:
         required: true
         type: string
         default: ''
-      ai_provider:
-        description: 'AI Provider to use for translation'
-        required: false
-        type: choice
-        options:
-          - deepseek
-          - gemini
-          - azure
-        default: 'azure'
 
 permissions:
   contents: write
@@ -178,13 +169,11 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEEPSEEK_API_TOKEN: ${{ secrets.DEEPSEEK_API_TOKEN }}
-          GEMINI_API_TOKEN: ${{ secrets.GEMINI_API_TOKEN }}
           AZURE_OPENAI_KEY: ${{ secrets.AZURE_OPENAI_KEY }}
           OPENAI_BASE_URL: ${{ secrets.AZURE_OPENAI_BASE_URL }}
           SOURCE_PR_URL: ${{ github.event.inputs.source_pr_url }}
           TARGET_PR_URL: ${{ github.event.inputs.target_pr_url }}
-          AI_PROVIDER: ${{ github.event.inputs.ai_provider }}
+          AI_PROVIDER: azure
           TARGET_REPO_PATH: ${{ github.workspace }}/target_repo
           TERMS_PATH: ${{ github.workspace }}/target_repo/resources/terms.md
         run: |
@@ -206,7 +195,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_PR_URL: ${{ github.event.inputs.source_pr_url }}
           TARGET_PR_URL: ${{ github.event.inputs.target_pr_url }}
-          AI_PROVIDER: ${{ github.event.inputs.ai_provider }}
           TARGET_BRANCH: ${{ steps.target_branch.outputs.target_branch }}
           TARGET_BASE_BRANCH: ${{ steps.target_branch.outputs.base_branch }}
         run: |
@@ -255,8 +243,8 @@ jobs:
             echo "Base ref ${BASE_REF} not found in cloned fork. Skipping placeholder cleanup."
           fi
 
-          if ! printf "Auto-sync: Update English docs from Chinese PR\n\nSynced from: %s\nTarget PR: %s\nAI Provider: %s\n\nCo-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
-            "$SOURCE_PR_URL" "$TARGET_PR_URL" "$AI_PROVIDER" | git commit -F -; then
+          if ! printf "Auto-sync: Update English docs from Chinese PR\n\nSynced from: %s\nTarget PR: %s\n\nCo-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
+            "$SOURCE_PR_URL" "$TARGET_PR_URL" | git commit -F -; then
             echo "push_success=false" >> $GITHUB_OUTPUT
             echo "Failed to create a commit for the translated changes."
             exit 1

--- a/.github/workflows/translation-cron.yml
+++ b/.github/workflows/translation-cron.yml
@@ -1,6 +1,7 @@
 name: Translation Cron JA
 
 concurrency:
+  # Do not manually dispatch this workflow while a scheduled run is in progress.
   group: translation-ja-${{ github.event_name }}
   cancel-in-progress: true
 
@@ -10,12 +11,20 @@ on:
     - cron: "30 16 * * 3"
   workflow_dispatch:
     inputs:
-      file_names:
-        description: "Specify file names to translate (comma-separated list)"
+      translation_scope:
+        description: "Choose whether to translate all updated files or only specified files"
         required: true
+        type: choice
+        default: Translate all updated files
+        options:
+          - Translate all updated files
+          - Translate only specified files
+      file_names:
+        description: "Required for specified files: paths to translate (comma-separated)"
+        required: false
         type: string
       source_files_translation_mode:
-        description: "Translate specified files incrementally or as full files"
+        description: "For specified files only: translate incrementally or as full files"
         required: true
         type: choice
         default: incremental
@@ -24,6 +33,7 @@ on:
           - full
 
 env:
+  PRODUCT: TiDB
   SOURCE_REPO: pingcap/docs
   SOURCE_BRANCH: release-8.5
   TERMS_BRANCH: master
@@ -40,6 +50,8 @@ env:
   INDEX_FILES: _index.md,ai/_index.md,api/_index.md,best-practices/_index.md,develop/_index.md,releases/_index.md,tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md
   AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
+  # Manual all-updated runs use the same global cursor behavior as scheduled runs.
+  COMMIT_SYNC_RUN_TYPE: ${{ (github.event_name == 'schedule' || inputs.translation_scope == 'Translate all updated files') && 'schedule' || 'workflow_dispatch' }}
 
 jobs:
   translate-ja:
@@ -51,6 +63,34 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Validate manual inputs
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          TRANSLATION_SCOPE: ${{ inputs.translation_scope }}
+          INPUT_FILE_NAMES: ${{ inputs.file_names }}
+          SOURCE_FILES_TRANSLATION_MODE: ${{ inputs.source_files_translation_mode }}
+        run: |
+          set -euo pipefail
+          case "${TRANSLATION_SCOPE}" in
+            "Translate all updated files")
+              if [ -n "${INPUT_FILE_NAMES//[[:space:]]/}" ]; then
+                echo "file_names must be empty when translation_scope is 'Translate all updated files'." >&2
+                exit 1
+              fi
+              if [ "${SOURCE_FILES_TRANSLATION_MODE}" != "incremental" ]; then
+                echo "source_files_translation_mode must be 'incremental' when translation_scope is 'Translate all updated files'." >&2
+                exit 1
+              fi
+              ;;
+            "Translate only specified files")
+              if [ -z "${INPUT_FILE_NAMES//[[:space:]]/}" ]; then
+                echo "file_names is required when translation_scope is 'Translate only specified files'." >&2
+                exit 1
+              fi
+              ;;
+          esac
+
       - uses: actions/checkout@v6
         name: Checkout docs target branch
         with:
@@ -134,7 +174,7 @@ jobs:
         id: source_files
         shell: bash
         env:
-          INPUT_FILE_NAMES: ${{ inputs.file_names || '' }}
+          INPUT_FILE_NAMES: ${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.file_names || '' }}
           BASE_REF: ${{ steps.commits.outputs.base_ref }}
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           DOCS_SOURCE_PATH: ${{ github.workspace }}/docs-source
@@ -160,7 +200,7 @@ jobs:
           SOURCE_HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           SOURCE_FOLDER: ""
           SOURCE_FILES: ${{ steps.source_files.outputs.files }}
-          SOURCE_FILES_TRANSLATION_MODE: ${{ inputs.source_files_translation_mode || 'incremental' }}
+          SOURCE_FILES_TRANSLATION_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.source_files_translation_mode || 'incremental' }}
           SOURCE_LANGUAGE: English
           TARGET_LANGUAGE: Japanese
           TOC_FILES: ${{ env.TOC_FILES }}
@@ -252,7 +292,7 @@ jobs:
               echo "failure_summary<<EOF"
               cat "${FAILURE_REPORT}"
               echo
-              echo "> Before merging this PR, manually translate the failed files above or rerun this workflow with workflow_dispatch and file_names set to those paths."
+              echo "> Before merging this PR, manually translate the failed files above or rerun this workflow with translation_scope set to 'Translate only specified files' and file_names set to those paths."
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
           fi
@@ -263,11 +303,11 @@ jobs:
           fi
 
           # Intentionally advance the cursor even on partial sync failure.
-          # Most files are translated successfully; failed files are listed in the PR body so reviewers can manually translate or re-run them via workflow_dispatch with file_names. Do NOT gate this on sync outcome.
-          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+          # Most files are translated successfully; failed files are listed in the PR body so reviewers can manually translate or rerun them with the specified-files scope and file_names. Do NOT gate this on sync outcome.
+          if [ "${COMMIT_SYNC_RUN_TYPE}" = "schedule" ]; then
             python -c 'import json, os; from pathlib import Path; Path("latest_translation_commit.json").write_text(json.dumps({"target": os.environ["SOURCE_BRANCH"], "sha": os.environ["HEAD_REF"]}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
           else
-            echo "Skipping latest_translation_commit.json update for ${GITHUB_EVENT_NAME} run."
+            echo "Skipping latest_translation_commit.json update for ${COMMIT_SYNC_RUN_TYPE} run."
           fi
 
           echo "has_changes=true" >> "${GITHUB_OUTPUT}"
@@ -310,6 +350,7 @@ jobs:
             - Source branch: `${{ env.SOURCE_BRANCH }}`
             - TOCs: `${{ env.TOC_FILES }}`
             - Source files: `${{ steps.source_files.outputs.files }}`
+            - Source files translation mode: `${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.source_files_translation_mode || 'incremental' }}`
             - Sync outcome: `${{ steps.sync.outcome }}`
 
             ${{ steps.changes.outputs.failure_summary }}

--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: "0 9 * * 3" # Runs at 17:00 every Wednesday (Beijing time, UTC+8)
+    - cron: "0 7 * * 3" # Runs at 15:00 every Wednesday (Beijing time, UTC+8)
   workflow_dispatch:
     inputs:
       translation_scope:

--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -1,6 +1,7 @@
 name: Sync TiDB Cloud Docs from EN to ZH
 
 concurrency:
+  # Do not manually dispatch this workflow while a scheduled run is in progress.
   group: translation-zh-cloud-${{ github.event_name }}
   cancel-in-progress: true
 
@@ -9,12 +10,20 @@ on:
     - cron: "0 9 * * 3" # Runs at 17:00 every Wednesday (Beijing time, UTC+8)
   workflow_dispatch:
     inputs:
-      file_names:
-        description: "Specify Cloud files to translate (comma-separated list)"
+      translation_scope:
+        description: "Choose whether to translate all updated files or only specified files"
         required: true
+        type: choice
+        default: Translate all updated files
+        options:
+          - Translate all updated files
+          - Translate only specified files
+      file_names:
+        description: "Required for specified files: Cloud paths to translate (comma-separated)"
+        required: false
         type: string
       source_files_translation_mode:
-        description: "Translate specified files incrementally or as full files"
+        description: "For specified files only: translate incrementally or as full files"
         required: true
         type: choice
         default: incremental
@@ -23,6 +32,7 @@ on:
           - full
 
 env:
+  PRODUCT: TiDB
   SOURCE_REPO: pingcap/docs
   SOURCE_BRANCH: release-8.5
   TERMS_BRANCH: master
@@ -31,6 +41,8 @@ env:
   CLOUD_INDEX_FILES: tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md
   AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
+  # Manual all-updated runs use the same global cursor behavior as scheduled runs.
+  COMMIT_SYNC_RUN_TYPE: ${{ (github.event_name == 'schedule' || inputs.translation_scope == 'Translate all updated files') && 'schedule' || 'workflow_dispatch' }}
 
 jobs:
   translate:
@@ -42,6 +54,34 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Validate manual inputs
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          TRANSLATION_SCOPE: ${{ inputs.translation_scope }}
+          INPUT_FILE_NAMES: ${{ inputs.file_names }}
+          SOURCE_FILES_TRANSLATION_MODE: ${{ inputs.source_files_translation_mode }}
+        run: |
+          set -euo pipefail
+          case "${TRANSLATION_SCOPE}" in
+            "Translate all updated files")
+              if [ -n "${INPUT_FILE_NAMES//[[:space:]]/}" ]; then
+                echo "file_names must be empty when translation_scope is 'Translate all updated files'." >&2
+                exit 1
+              fi
+              if [ "${SOURCE_FILES_TRANSLATION_MODE}" != "incremental" ]; then
+                echo "source_files_translation_mode must be 'incremental' when translation_scope is 'Translate all updated files'." >&2
+                exit 1
+              fi
+              ;;
+            "Translate only specified files")
+              if [ -z "${INPUT_FILE_NAMES//[[:space:]]/}" ]; then
+                echo "file_names is required when translation_scope is 'Translate only specified files'." >&2
+                exit 1
+              fi
+              ;;
+          esac
+
       - uses: actions/checkout@v6
         name: Checkout docs target branch
         with:
@@ -125,7 +165,7 @@ jobs:
         id: source_files
         shell: bash
         env:
-          INPUT_FILE_NAMES: ${{ inputs.file_names || '' }}
+          INPUT_FILE_NAMES: ${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.file_names || '' }}
           BASE_REF: ${{ steps.commits.outputs.base_ref }}
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           DOCS_SOURCE_PATH: ${{ github.workspace }}/docs-source
@@ -151,7 +191,7 @@ jobs:
           SOURCE_HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           SOURCE_FOLDER: ""
           SOURCE_FILES: ${{ steps.source_files.outputs.files }}
-          SOURCE_FILES_TRANSLATION_MODE: ${{ inputs.source_files_translation_mode || 'incremental' }}
+          SOURCE_FILES_TRANSLATION_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.source_files_translation_mode || 'incremental' }}
           SOURCE_LANGUAGE: English
           TARGET_LANGUAGE: Chinese
           IGNORE_RESOURCE_CARD_SECTION: "Yes"
@@ -186,7 +226,7 @@ jobs:
               echo "failure_summary<<EOF"
               cat "${FAILURE_REPORT}"
               echo
-              echo "> Before merging this PR, manually translate the failed files above or rerun this workflow with workflow_dispatch and file_names set to those paths."
+              echo "> Before merging this PR, manually translate the failed files above or rerun this workflow with translation_scope set to 'Translate only specified files' and file_names set to those paths."
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
           fi
@@ -196,10 +236,10 @@ jobs:
             exit 0
           fi
 
-          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+          if [ "${COMMIT_SYNC_RUN_TYPE}" = "schedule" ]; then
             python -c 'import json, os; from pathlib import Path; Path("latest_translation_commit.json").write_text(json.dumps({"target": os.environ["SOURCE_BRANCH"], "sha": os.environ["HEAD_REF"]}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")'
           else
-            echo "Skipping latest_translation_commit.json update for ${GITHUB_EVENT_NAME} run."
+            echo "Skipping latest_translation_commit.json update for ${COMMIT_SYNC_RUN_TYPE} run."
           fi
 
           echo "has_changes=true" >> "${GITHUB_OUTPUT}"
@@ -242,6 +282,7 @@ jobs:
             - Source branch: `${{ env.SOURCE_BRANCH }}`
             - Cloud TOCs: `${{ env.CLOUD_TOC_FILES }}`
             - Source files: `${{ steps.source_files.outputs.files }}`
+            - Source files translation mode: `${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.source_files_translation_mode || 'incremental' }}`
             - Sync outcome: `${{ steps.sync.outcome }}`
 
             ${{ steps.changes.outputs.failure_summary }}


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR updates the workflows that use `ai-markdown-translator`:

- Explicitly sets `PRODUCT: TiDB` in the PR sync, Japanese translation, and Cloud Chinese translation workflows.
- Keeps Azure as the only translation provider and removes unused provider inputs and credentials.
- Removes provider details from Git commit messages generated by the PR sync workflow.
- Adds a `translation_scope` input to the Japanese and Cloud Chinese workflows, with options to translate all updated files or only specified files.
- Validates manual input combinations. All-updated runs use an empty file filter and incremental mode, while specified-file runs require `file_names` and support incremental or full-file translation.
- Treats manual all-updated runs like scheduled runs for commit-sync and global cursor updates, while specified-file runs do not advance the global cursor.
- Updates retry guidance and PR metadata to reflect the selected-file workflow.

These changes make the product context explicit instead of relying on a translator fallback, which keeps the workflows compatible as `ai-markdown-translator` becomes product-agnostic. Using one supported provider removes misleading choices and unused secrets, while provider-neutral commit messages keep generated history focused on documentation changes. The new manual scopes let maintainers either retry selected files or process the complete outstanding commit range without waiting for the next schedule. Input validation prevents conflicting options, and schedule-equivalent cursor handling avoids translating the same source range again in the next scheduled run.

Validation:

- `actionlint` passed for the Japanese and Cloud Chinese workflows.
- GitHub Actions structure validation passed for the PR sync workflow.
- YAML and workflow-dispatch semantic checks passed for all-updated and specified-file modes.
- All 13 `resolve_cloud_source_files` unit tests passed.
- `git diff --check` passed.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): [docs-cn AI translation workflow](https://github.com/pingcap/docs-cn/blob/master/.github/workflows/sync-ai-docs-en-to-zh.yml)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation runs can now target all updated files or selected files during manual execution.
  * Added validation for file selections and translation modes.
  * Scheduled and manual translation runs now use appropriate synchronization behavior.
* **Bug Fixes**
  * Improved translation failure guidance and pull request metadata.
  * Standardized documentation translation through the Azure translation provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->