### PR TITLE
system-variables: mark tidb_merge_partition_stats_concurrency as deprecated

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -4263,6 +4263,10 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 
 ### tidb_merge_partition_stats_concurrency
 
+> **Warning:**
+>
+> Starting from v9.0.0, this variable is deprecated. Merging TopN results of partitioned tables no longer runs concurrently, so this variable has no effect. Setting it to a value other than `1` returns a warning, and reading it always returns `1`, including on clusters upgraded from an earlier version where a different value was persisted.
+
 - Scope: SESSION | GLOBAL
 - Persists to cluster: Yes
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No


### PR DESCRIPTION
Global stats merging no longer runs the TopN merge concurrently, so the variable has no effect. It is kept for backward compatibility: setting it to a value other than 1 returns a warning, and both read paths return 1 unconditionally, so a non-1 value persisted by an earlier TiDB does not survive an upgrade.

### What is changed, added or deleted? (Required)

`tidb_merge_partition_stats_concurrency` is deprecated and does no longer impact anything.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): ref pingcap/tidb#68147

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice for `tidb_merge_partition_stats_concurrency`.
  * Clarified that the setting has no effect starting in v9.0.0.
  * Values other than `1` now produce a warning, while reads always return `1`, including after upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->