### PR TITLE
cloud: document TiDB X foreign key shared locks and lock upgrades

### DIFF
--- a/foreign-key.md
+++ b/foreign-key.md
@@ -183,9 +183,13 @@ By default, in pessimistic transactions, the locking behavior of foreign key che
 
 You can enable the system variable [`tidb_foreign_key_check_in_shared_lock`](/system-variables.md#tidb_foreign_key_check_in_shared_lock-new-in-v856) to let foreign key checks use shared locks. Shared locks allow multiple transactions to perform foreign key checks on the same parent table row simultaneously, thereby reducing lock conflicts and improving the performance of concurrent writes to child tables.
 
+If a pessimistic transaction needs to update or delete a parent table row after a foreign key check has acquired a shared lock on that row, enable [`tidb_enable_shared_lock_upgrade`](/system-variables.md#tidb_enable_shared_lock_upgrade) to let TiDB upgrade the shared lock to an exclusive lock.
+
+Transactions that hold shared locks do not support one-phase commit (1PC) or Async Commit.
+
 > **Warning:**
 >
-> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice. Before setting `tidb_foreign_key_check_in_shared_lock` to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`.
+> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. Before setting `tidb_foreign_key_check_in_shared_lock` to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`.
 
 ## Definition and metadata of foreign keys
 

--- a/foreign-key.md
+++ b/foreign-key.md
@@ -185,7 +185,7 @@ You can enable the system variable [`tidb_foreign_key_check_in_shared_lock`](/sy
 
 If a pessimistic transaction needs to update or delete a parent table row after a foreign key check has acquired a shared lock on that row, enable [`tidb_enable_shared_lock_upgrade`](/system-variables.md#tidb_enable_shared_lock_upgrade) to let TiDB upgrade the shared lock to an exclusive lock.
 
-Transactions that hold shared locks do not support one-phase commit (1PC) or Async Commit.
+Shared locks are not supported in aggressive locking mode or fair locking mode. Transactions that hold shared locks do not support one-phase commit (1PC) or Async Commit.
 
 > **Warning:**
 >

--- a/foreign-key.md
+++ b/foreign-key.md
@@ -183,6 +183,10 @@ By default, in pessimistic transactions, the locking behavior of foreign key che
 
 You can enable the system variable [`tidb_foreign_key_check_in_shared_lock`](/system-variables.md#tidb_foreign_key_check_in_shared_lock-new-in-v856) to let foreign key checks use shared locks. Shared locks allow multiple transactions to perform foreign key checks on the same parent table row simultaneously, thereby reducing lock conflicts and improving the performance of concurrent writes to child tables.
 
+> **Warning:**
+>
+> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice. Before setting `tidb_foreign_key_check_in_shared_lock` to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`.
+
 ## Definition and metadata of foreign keys
 
 To view the definition of a foreign key constraint, execute the [`SHOW CREATE TABLE`](/sql-statements/sql-statement-show-create-table.md) statement:

--- a/system-variables.md
+++ b/system-variables.md
@@ -2785,8 +2785,22 @@ Assume that you have a cluster with 4 TiDB nodes and multiple TiKV nodes. In thi
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
 - Type: Boolean
 - Default value: `OFF`
-- This variable controls whether to enable the feature of upgrading shared locks to exclusive locks. TiDB does not support `SELECT LOCK IN SHARE MODE` by default. When the variable value is `ON`, TiDB tries to upgrade the `SELECT LOCK IN SHARE MODE` statement to `SELECT FOR UPDATE` and add a pessimistic lock. The default value of this variable is `OFF`, which means that the feature of upgrading shared locks to exclusive locks is disabled.
+- This variable controls whether `SELECT ... LOCK IN SHARE MODE` acquires an exclusive pessimistic lock. When the value is `ON`, TiDB executes `SELECT ... LOCK IN SHARE MODE` as `SELECT ... FOR UPDATE`. This behavior acquires an exclusive lock directly rather than upgrading an existing shared lock to an exclusive lock.
 - Enabling this variable takes effect on the `SELECT LOCK IN SHARE MODE` statement, regardless of whether [`tidb_enable_noop_functions`](/system-variables.md#tidb_enable_noop_functions-new-in-v40) is enabled or not.
+
+### tidb_enable_shared_lock_upgrade
+
+> **Warning:**
+>
+> Shared lock upgrade is an experimental feature that can only be enabled on TiDB X. It is not recommended that you enable this feature in production environments.
+
+- Scope: SESSION | GLOBAL
+- Persists to cluster: Yes
+- Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
+- Type: Boolean
+- Default value: `OFF`
+- This variable controls whether a pessimistic transaction can upgrade a shared lock that it already holds to an exclusive lock.
+- Shared lock upgrade is not supported in aggressive locking mode or fair locking mode.
 
 ### tidb_enable_slow_log
 
@@ -3180,7 +3194,7 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 
 > **Warning:**
 >
-> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice. Before setting this variable to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`. When this configuration item is `false`, TiDB rejects attempts to set this variable to `ON`, but an `ON` value that has already been persisted or restored continues to take effect.
+> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. Before setting this variable to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`. When this configuration item is `false`, TiDB rejects attempts to set this variable to `ON`, but an `ON` value that has already been persisted or restored continues to take effect.
 
 - Scope: SESSION | GLOBAL
 - Persists to cluster: Yes

--- a/system-variables.md
+++ b/system-variables.md
@@ -3178,6 +3178,10 @@ For a system upgraded to v5.0 from an earlier version, if you have not modified 
 
 ### tidb_foreign_key_check_in_shared_lock <span class="version-mark">New in v8.5.6</span>
 
+> **Warning:**
+>
+> On TiDB X, using shared locks for foreign key checks is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice. Before setting this variable to `ON`, you must set [`experimental.allow-enable-foreign-key-check-in-shared-lock`](/tidb-configuration-file.md#allow-enable-foreign-key-check-in-shared-lock) to `true`. When this configuration item is `false`, TiDB rejects attempts to set this variable to `ON`, but an `ON` value that has already been persisted or restored continues to take effect.
+
 - Scope: SESSION | GLOBAL
 - Persists to cluster: Yes
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No

--- a/system-variables.md
+++ b/system-variables.md
@@ -2800,7 +2800,6 @@ Assume that you have a cluster with 4 TiDB nodes and multiple TiKV nodes. In thi
 - Type: Boolean
 - Default value: `OFF`
 - This variable controls whether a pessimistic transaction can upgrade a shared lock that it already holds to an exclusive lock.
-- Shared lock upgrade is not supported in aggressive locking mode or fair locking mode.
 
 ### tidb_enable_slow_log
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -1062,6 +1062,15 @@ Configuration items related to the PROXY protocol.
 
 The `experimental` section, introduced in v3.1.0, describes the configurations related to the experimental features of TiDB.
 
+### `allow-enable-foreign-key-check-in-shared-lock`
+
+> **Warning:**
+>
+> This configuration item applies only to TiDB X. Using shared locks for foreign key checks on TiDB X is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice.
+
++ Controls whether SQL users can set [`tidb_foreign_key_check_in_shared_lock`](/system-variables.md#tidb_foreign_key_check_in_shared_lock-new-in-v856) to `ON` in TiDB X. When this configuration item is `false`, TiDB rejects attempts to set the system variable to `ON`. This configuration item does not change an `ON` value that has already been persisted or restored, so the existing behavior is preserved after an upgrade.
++ Default value: `false`
+
 ### `allow-expression-index` <span class="version-mark">New in v4.0.0</span>
 
 + Controls whether an expression index can be created. Since TiDB v5.2.0, if the function in an expression is safe, you can create an expression index directly based on this function without enabling this configuration. If you want to create an expression index based on other functions, you can enable this configuration, but correctness issues might exist. By querying the `tidb_allow_function_for_expression_index` variable, you can get the functions that are safe to be directly used for creating an expression.

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -1066,7 +1066,7 @@ The `experimental` section, introduced in v3.1.0, describes the configurations r
 
 > **Warning:**
 >
-> This configuration item applies only to TiDB X. Using shared locks for foreign key checks on TiDB X is an experimental feature. It is not recommended that you use this feature in production environments. This feature might be changed or removed without prior notice.
+> This configuration item applies only to TiDB X. Using shared locks for foreign key checks on TiDB X is an experimental feature. It is not recommended that you use this feature in production environments.
 
 + Controls whether SQL users can set [`tidb_foreign_key_check_in_shared_lock`](/system-variables.md#tidb_foreign_key_check_in_shared_lock-new-in-v856) to `ON` in TiDB X. When this configuration item is `false`, TiDB rejects attempts to set the system variable to `ON`. This configuration item does not change an `ON` value that has already been persisted or restored, so the existing behavior is preserved after an upgrade.
 + Default value: `false`


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Document the experimental controls and limitations for using shared locks during foreign key checks on TiDB X.

**NOTE**

This change applies only to TiDB X deployments used by TiDB Cloud Premium and Essential v2. It does not apply to TiDB Self-Managed (OP) or other classic TiDB deployments. The shared lock features are experimental and have not reached general availability (GA).

- Explain that TiDB X requires `[experimental].allow-enable-foreign-key-check-in-shared-lock` to be enabled before SQL users can set `tidb_foreign_key_check_in_shared_lock` to `ON`.
- Document that disabling the configuration prevents new SQL-level activation but does not override an `ON` value that has already been persisted or restored.
- Document `tidb_enable_shared_lock_upgrade` for pessimistic transactions that update or delete a parent row after acquiring a shared lock on that row during a foreign key check.
- Distinguish shared lock upgrade from `tidb_enable_shared_lock_promotion` and document shared lock limitations for aggressive locking mode, fair locking mode, one-phase commit, and Async Commit.

The foreign-key shared-lock gate changes were merged into TiDB `master`, while the shared lock upgrade change is tracked in [pingcap/tidb#69559](https://github.com/pingcap/tidb/pull/69559). This documentation PR targets `release-8.5`, which is the source branch for the current TiDB Cloud documentation. The documentation team can decide whether to apply the change to docs `master` during review.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/tidb/pull/69559
  - https://github.com/pingcap/tidb/pull/70328
  - https://github.com/pingcap/tidb/pull/69167
  - https://github.com/pingcap/docs/pull/23458

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added warnings that foreign-key checks with shared locks are experimental on TiDB X and not recommended for production.
  * Documented the configuration prerequisite for enabling this feature, including default behavior and handling of existing enabled values.
  * Clarified shared-lock behavior for pessimistic transactions, including limitations with one-phase and asynchronous commit.
  * Documented shared-lock promotion and the new option for upgrading an existing shared lock to an exclusive lock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
