### PR TITLE
i18n(ja): restore English information_schema table names in inbound links

### DIFF
--- a/dashboard/dashboard-diagnostics-report.md
+++ b/dashboard/dashboard-diagnostics-report.md
@@ -61,7 +61,7 @@ summary: TiDB Dashboard診断レポートでは、基本情報、診断情報、
 
 #### クラスタトポロジ情報 {#cluster-topology-info}
 
-表`Cluster Info`はクラスタトポロジ情報を示しています。この表の情報はTiDB [情報スキーマ.クラスタ情報](/information-schema/information-schema-cluster-info.md)システムテーブルから取得されています。
+表`Cluster Info`はクラスタトポロジ情報を示しています。この表の情報はTiDB [information_schema.cluster_info](/information-schema/information-schema-cluster-info.md)システムテーブルから取得されています。
 
 ![Cluster info](/media/dashboard/dashboard-diagnostics-cluster-info.png)
 
@@ -77,7 +77,7 @@ summary: TiDB Dashboard診断レポートでは、基本情報、診断情報、
 
 ### 診断情報 {#diagnostic-information}
 
-TiDBには自動診断結果が組み込まれています。各フィールドの説明については、 [情報スキーマ.検査結果](/information-schema/information-schema-inspection-result.md)システムテーブルを参照してください。
+TiDBには自動診断結果が組み込まれています。各フィールドの説明については、 [information_schema.inspection-result](/information-schema/information-schema-inspection-result.md)システムテーブルを参照してください。
 
 ### ロード情報 {#load-info}
 

--- a/releases/release-8.4.0.md
+++ b/releases/release-8.4.0.md
@@ -166,7 +166,7 @@ TiDB バージョン: 8.4.0
     [TiDB Dashboard](/dashboard/dashboard-intro.md)の[Top SQLページ](/dashboard/top-sql.md)CPU 使用率の高い SQL ステートメントを表示します。バージョン 8.4.0 以降、TiDB はシステム テーブルに CPU 使用時間情報を追加し、セッションや SQL の他のメトリックと並べて表示することで、CPU 使用率の高い操作をさまざまな視点から簡単に把握できるようにしました。この情報は、インスタンスの CPU スパイクやクラスタ内の読み書きホットスポットなどのシナリオで、問題の原因を迅速に特定するのに役立ちます。
 
     -   [ステートメントサマリーテーブル](/statement-summary-tables.md)には`AVG_TIDB_CPU_TIME`と`AVG_TIKV_CPU_TIME`が追加され、過去の個々の SQL ステートメントによって消費された平均 CPU 時間が表示されます。
-    -   [情報スキーマ.プロセスリスト](/information-schema/information-schema-processlist.md)テーブルには、 `TIDB_CPU`と`TIKV_CPU`が追加され、現在セッションで実行されている SQL ステートメントの累積 CPU 消費量が表示されます。
+    -   [INFORMATION_SCHEMA.PROCESSLIST](/information-schema/information-schema-processlist.md)テーブルには、 `TIDB_CPU`と`TIKV_CPU`が追加され、現在セッションで実行されている SQL ステートメントの累積 CPU 消費量が表示されます。
     -   [スロークエリログ](/analyze-slow-queries.md)には`Tidb_cpu_time`フィールドと`Tikv_cpu_time`フィールドが追加され、キャプチャされた SQL ステートメントによって消費された CPU 時間が表示されます。
 
     デフォルトでは、TiKV が消費する CPU 時間が表示されます。TiDB が消費する CPU 時間を収集すると追加のオーバーヘッド (約 8%) が発生するため、TiDB が消費する CPU 時間は、 [Top SQL](/dashboard/top-sql.md)が有効になっている場合にのみ実際の値が表示されます。それ以外の場合は、常に`0`と表示されます。

--- a/sql-statements/sql-statement-admin-show-ddl.md
+++ b/sql-statements/sql-statement-admin-show-ddl.md
@@ -252,4 +252,4 @@ DDL履歴ジョブキュー内の任意の結果範囲から、 `job_id`に対�
 -   [`ADMIN PAUSE DDL`](/sql-statements/sql-statement-admin-pause-ddl.md)
 -   [`ADMIN RESUME DDL`](/sql-statements/sql-statement-admin-resume-ddl.md)
 -   [`ADMIN ALTER DDL`](/sql-statements/sql-statement-admin-alter-ddl.md)
--   [情報スキーマ.DDL_JOBS](/information-schema/information-schema-ddl-jobs.md)
+-   [INFORMATION_SCHEMA.DDL_JOBS](/information-schema/information-schema-ddl-jobs.md)

--- a/sql-statements/sql-statement-kill.md
+++ b/sql-statements/sql-statement-kill.md
@@ -79,4 +79,4 @@ Global Kill 機能が有効になっていない場合、または v6.1.0 より
 ## 参照 {#see-also}
 
 -   [SHOW [FULL] PROCESSLIST](/sql-statements/sql-statement-show-processlist.md)
--   [クラスタープロセスリスト](/information-schema/information-schema-processlist.md#cluster_processlist)
+-   [CLUSTER_PROCESSLIST](/information-schema/information-schema-processlist.md#cluster_processlist)

--- a/system-variable-reference.md
+++ b/system-variable-reference.md
@@ -20,9 +20,9 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [AUTO_RANDOM](/auto-random.md)
 -   [データの挿入](/develop/dev-guide-insert-data.md)
--   [セッション変数](/information-schema/information-schema-session-variables.md)
+-   [SESSION_VARIABLES](/information-schema/information-schema-session-variables.md)
 -   [システム変数](/system-variables.md#allow_auto_random_explicit_insert-new-in-v403)
--   [変数情報](/information-schema/information-schema-variables-info.md)
+-   [VARIABLES_INFO](/information-schema/information-schema-variables-info.md)
 
 ### authentication_ldap_sasl_auth_method_name
 
@@ -172,9 +172,9 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 -   [AUTO_RANDOM](/auto-random.md)
 -   [双方向レプリケーション](/ticdc/ticdc-bidirectional-replication.md)
 -   [エラーコードとトラブルシューティング](/error-codes.md)
--   [セッション変数](/information-schema/information-schema-session-variables.md)
+-   [SESSION_VARIABLES](/information-schema/information-schema-session-variables.md)
 -   [システム変数](/system-variables.md#auto_increment_increment)
--   [変数情報](/information-schema/information-schema-variables-info.md)
+-   [VARIABLES_INFO](/information-schema/information-schema-variables-info.md)
 -   [TiDB 7.1.6 リリースノート](/releases/release-7.1.6.md)
 -   [TiDB 6.5.10 リリースノート](/releases/release-6.5.10.md)
 -   [TiDB 3.0.9 リリースノート](/releases/release-3.0.9.md)
@@ -187,9 +187,9 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 -   [AUTO_RANDOM](/auto-random.md)
 -   [双方向レプリケーション](/ticdc/ticdc-bidirectional-replication.md)
 -   [エラーコードとトラブルシューティング](/error-codes.md)
--   [セッション変数](/information-schema/information-schema-session-variables.md)
+-   [SESSION_VARIABLES](/information-schema/information-schema-session-variables.md)
 -   [システム変数](/system-variables.md#auto_increment_offset)
--   [変数情報](/information-schema/information-schema-variables-info.md)
+-   [VARIABLES_INFO](/information-schema/information-schema-variables-info.md)
 -   [TiDB 7.1.6 リリースノート](/releases/release-7.1.6.md)
 -   [TiDB 6.5.10 リリースノート](/releases/release-6.5.10.md)
 -   [TiDB 3.0.9 リリースノート](/releases/release-3.0.9.md)
@@ -219,7 +219,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 -   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_client)
 -   [Dumplingを使用してデータをエクスポートする](/dumpling-overview.md)
--   [ビュー](/information-schema/information-schema-views.md)
+-   [VIEWS](/information-schema/information-schema-views.md)
 -   [ビュー](/views.md)
 -   [ビュー](/develop/dev-guide-use-views.md)
 
@@ -269,7 +269,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 -   [SQLに関するよくある質問](/faq/sql-faq.md)
 -   [文字列関数](/functions-and-operators/string-functions.md)
 -   [システム変数](/system-variables.md#collation_connection)
--   [ビュー](/information-schema/information-schema-views.md)
+-   [VIEWS](/information-schema/information-schema-views.md)
 -   [ビュー](/views.md)
 -   [ビュー](/develop/dev-guide-use-views.md)
 
@@ -1309,7 +1309,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [統計入門](/statistics.md)
 -   [SHOW [GLOBAL|SESSION] VARIABLES](/sql-statements/sql-statement-show-variables.md)
--   [スロークエリ](/information-schema/information-schema-slow-query.md)
+-   [SLOW_QUERY](/information-schema/information-schema-slow-query.md)
 -   [SQLに関するよくある質問](/faq/sql-faq.md)
 -   [システム変数](/system-variables.md#tidb_distsql_scan_concurrency)
 -   [TiDB ベストプラクティス](/best-practices/tidb-best-practices.md)
@@ -3669,8 +3669,8 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [インポート先](/sql-statements/sql-statement-import-into.md)
 -   [TiDB Cloudで制限されたSQL機能](https://docs.pingcap.com/tidbcloud/limited-sql-features)
--   [メモリ使用量](/information-schema/information-schema-memory-usage.md)
--   [メモリ使用量オペレーション履歴](/information-schema/information-schema-memory-usage-ops-history.md)
+-   [MEMORY_USAGE](/information-schema/information-schema-memory-usage.md)
+-   [MEMORY_USAGE_OPS_HISTORY](/information-schema/information-schema-memory-usage-ops-history.md)
 -   [システム変数](/system-variables.md#tidb_server_memory_limit-new-in-v640)
 -   [TiDBコンフィグレーションファイル](/tidb-configuration-file.md)
 -   [TiDB メモリ制御](/configure-memory-usage.md)
@@ -3980,7 +3980,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 -   [CREATE [GLOBAL|SESSION] BINDING](/sql-statements/sql-statement-create-binding.md)
 -   [TiDB Cloudで制限されたSQL機能](https://docs.pingcap.com/tidbcloud/limited-sql-features)
 -   [SHOW [GLOBAL|SESSION] VARIABLES](/sql-statements/sql-statement-show-variables.md)
--   [スロークエリ](/information-schema/information-schema-slow-query.md)
+-   [SLOW_QUERY](/information-schema/information-schema-slow-query.md)
 -   [TiDB Dashboardのスロークエリページ](/dashboard/dashboard-slow-query.md)
 -   [ステートメントサマリーテーブル](/statement-summary-tables.md)
 -   [システム変数](/system-variables.md#tidb_stmt_summary_max_sql_length-new-in-v40)

--- a/system-variable-reference.md
+++ b/system-variable-reference.md
@@ -216,7 +216,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [文字セットと照合順序](/character-set-and-collation.md)
 -   [GBK](/character-set-gbk.md)
--   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
+-   [SET [NAMES|CHARACTER SET]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_client)
 -   [Dumplingを使用してデータをエクスポートする](/dumpling-overview.md)
 -   [VIEWS](/information-schema/information-schema-views.md)
@@ -229,7 +229,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [文字セットと照合順序](/character-set-and-collation.md)
 -   [GBK](/character-set-gbk.md)
--   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
+-   [SET [NAMES|CHARACTER SET]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_connection)
 -   [Dumplingを使用してデータをエクスポートする](/dumpling-overview.md)
 
@@ -238,7 +238,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 参照先:
 
 -   [文字セットと照合順序](/character-set-and-collation.md)
--   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
+-   [SET [NAMES|CHARACTER SET]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_database)
 
 ### character_set_results
@@ -246,7 +246,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 参照先:
 
 -   [文字セットと照合順序](/character-set-and-collation.md)
--   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
+-   [SET [NAMES|CHARACTER SET]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_results)
 -   [TiDB 8.5.4 リリースノート](/releases/release-8.5.4.md)
 -   [TiDB 6.2.0 リリースノート](/releases/release-6.2.0.md)
@@ -257,7 +257,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 参照先:
 
 -   [文字セットと照合順序](/character-set-and-collation.md)
--   [SET [名前|文字セット]](/sql-statements/sql-statement-set-names.md)
+-   [SET [NAMES|CHARACTER SET]](/sql-statements/sql-statement-set-names.md)
 -   [システム変数](/system-variables.md#character_set_server)
 -   [TiDB 5.3 リリースノート](/releases/release-5.3.0.md)
 

--- a/system-variable-reference.md
+++ b/system-variable-reference.md
@@ -869,7 +869,7 @@ summary: すべての TiDB システム変数とドキュメント内の参照�
 
 -   [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
 -   [統計入門](/statistics.md)
--   [分析ステータスを表示](/sql-statements/sql-statement-show-analyze-status.md)
+-   [SHOW ANALYZE STATUS](/sql-statements/sql-statement-show-analyze-status.md)
 -   [システム変数](/system-variables.md#tidb_analyze_version-new-in-v510)
 -   [TiDB メモリ制御](/configure-memory-usage.md)
 -   [TiDB OOM の問題のトラブルシューティング](/troubleshoot-tidb-oom.md)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

Several pages link to `information_schema` tables using a translated Japanese descriptive phrase instead of the literal English table name that the English source uses, which breaks the table-citation convention followed elsewhere in the corpus (e.g. `information-schema/*.md` H1 headings, restored in #23474 and #23468).

- `system-variable-reference.md`: 12 "See also" list entries translated the target table name into Japanese (セッション変数→SESSION_VARIABLES, 変数情報→VARIABLES_INFO, ビュー→VIEWS ×2, スロークエリ→SLOW_QUERY ×2, メモリ使用量→MEMORY_USAGE, メモリ使用量オペレーション履歴→MEMORY_USAGE_OPS_HISTORY), while the English source uses the literal all-caps table name as link text in every case.
- `dashboard/dashboard-diagnostics-report.md`: 2 inline references translated both halves of the English source's `information_schema.<table>` dotted notation into Japanese (情報スキーマ.クラスタ情報→`information_schema.cluster_info`, 情報スキーマ.検査結果→`information_schema.inspection-result`), restored to match the English literal text exactly.
- 3 more sites found by a follow-up corpus-wide sweep for the same pattern: `releases/release-8.4.0.md` (情報スキーマ.プロセスリスト→`INFORMATION_SCHEMA.PROCESSLIST`), `sql-statements/sql-statement-admin-show-ddl.md` (情報スキーマ.DDL_JOBS→`INFORMATION_SCHEMA.DDL_JOBS`), `sql-statements/sql-statement-kill.md` (クラスタープロセスリスト→`CLUSTER_PROCESSLIST`).
- `system-variable-reference.md`: 5 more "See also" entries translated the two bracket alternatives of the `SET [NAMES|CHARACTER SET]` SQL statement name into Japanese (`SET [名前|文字セット]`), even though the linked page's own title keeps the statement name literal in English. Restored to `SET [NAMES|CHARACTER SET]`.

Sites intentionally left unchanged after checking against the English source (not part of this defect):
- `basic-features.md` and `releases/release-6.2.0.md`'s "ロックビュー" (Lock View) — the English source itself uses "Lock View" as a feature name here, not the literal `DATA_LOCK_WAITS` table name, so the Japanese translation is correct.
- `information-schema/information-schema-inspection-rules.md`'s internal "[検査結果]" link — the English source itself uses natural-language lowercase "inspection result" here (not the literal table name), so the Japanese translation is correct.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
