### PR TITLE
i18n(ja): fix mistranslated config values in filter-binlog-event.md

### DIFF
--- a/filter-binlog-event.md
+++ b/filter-binlog-event.md
@@ -14,7 +14,7 @@ summary: データを移行するときにbinlogイベントをフィルター�
 
 ## コンフィグレーション {#configuration}
 
-binlogイベント フィルターを使用するには、以下に示すように、DM のタスク構成ファイルに`filter`追加します。
+binlogイベント フィルターを使用するには、以下に示すように、DM のタスク構成ファイルに`filter`を追加します。
 
 ```yaml
 filters:
@@ -32,24 +32,24 @@ filters:
 
     | イベント         | カテゴリ | 説明                |
     | ------------ | ---- | ----------------- |
-    | 全て           |      | すべてのイベントを含む       |
-    | すべてのDML      |      | すべてのDMLイベントを含む    |
-    | すべてのDDL      |      | すべてのDDLイベントを含む    |
-    | なし           |      | イベントは含まれません       |
-    | なしDDL        |      | すべてのDDLイベントを除外します |
-    | なし dml       |      | すべてのDMLイベントを除外します |
-    | 入れる          | DML  | DMLイベントを挿入        |
-    | アップデート       | DML  | DMLイベントの更新        |
-    | 消去           | DML  | DMLイベントの削除        |
-    | データベースを作成する  | DDL  | データベースイベントの作成     |
-    | データベースを削除    | DDL  | データベースイベントの削除     |
-    | テーブルを作成する    | DDL  | テーブルイベントの作成       |
-    | インデックスを作成する  | DDL  | インデックスイベントの作成     |
-    | ドロップテーブル     | DDL  | ドロップテーブルイベント      |
-    | テーブルを切り捨てる   | DDL  | テーブル切り捨てイベント      |
-    | テーブルの名前を変更する | DDL  | テーブル名の変更イベント      |
-    | インデックスを削除    | DDL  | インデックス削除イベント      |
-    | テーブルを変更する    | DDL  | テーブル変更イベント        |
+    | all           |      | すべてのイベントを含む       |
+    | all dml      |      | すべてのDMLイベントを含む    |
+    | all ddl      |      | すべてのDDLイベントを含む    |
+    | none           |      | イベントは含まれません       |
+    | none ddl        |      | すべてのDDLイベントを除外します |
+    | none dml       |      | すべてのDMLイベントを除外します |
+    | insert          | DML  | DMLイベントを挿入        |
+    | update       | DML  | DMLイベントの更新        |
+    | delete           | DML  | DMLイベントの削除        |
+    | create database  | DDL  | データベースイベントの作成     |
+    | drop database    | DDL  | データベースイベントの削除     |
+    | create table    | DDL  | テーブルイベントの作成       |
+    | create index  | DDL  | インデックスイベントの作成     |
+    | drop table     | DDL  | ドロップテーブルイベント      |
+    | truncate table   | DDL  | テーブル切り捨てイベント      |
+    | rename table | DDL  | テーブル名の変更イベント      |
+    | drop index    | DDL  | インデックス削除イベント      |
+    | alter table    | DDL  | テーブル変更イベント        |
 
 -   `sql-pattern` : 指定されたDDL SQL文をフィルタリングします。マッチングルールでは正規表現の使用がサポートされています。
 
@@ -65,7 +65,7 @@ filters:
         -   イベントはルール設定と一致します。
         -   sql-pattern が指定されており、イベントの SQL ステートメントが sql-pattern オプションのいずれかと一致します。
 
-    `Do`と`Ignore`両方が設定されている場合、 `Ignore` `Do`よりも優先されます。つまり、 `Ignore`と`Do`両方の条件を満たすイベントは除外されます。
+    `Do`と`Ignore`両方が設定されている場合、 `Ignore`の方が`Do`よりも優先されます。つまり、 `Ignore`と`Do`両方の条件を満たすイベントは除外されます。
 
 ## アプリケーションシナリオ {#application-scenarios}
 
@@ -73,43 +73,49 @@ filters:
 
 ### すべてのシャーディング削除操作を除外する {#filter-out-all-sharding-deletion-operations}
 
-すべての削除操作を除外するには、次に示すように`filter-table-rule`と`filter-schema-rule`設定します。
+すべての削除操作を除外するには、次に示すように`filter-table-rule`と`filter-schema-rule`を設定します。
 
-    filters:
-      filter-table-rule:
-        schema-pattern: "test_*"
-        table-pattern: "t_*"
-        events: ["truncate table", "drop table", "delete"]
-        action: Ignore
-      filter-schema-rule:
-        schema-pattern: "test_*"
-        events: ["drop database"]
-        action: Ignore
+```
+filters:
+  filter-table-rule:
+    schema-pattern: "test_*"
+    table-pattern: "t_*"
+    events: ["truncate table", "drop table", "delete"]
+    action: Ignore
+  filter-schema-rule:
+    schema-pattern: "test_*"
+    events: ["drop database"]
+    action: Ignore
+```
 
 ### シャード化されたスキーマとテーブルのDML操作のみを移行する {#migrate-only-dml-operations-of-sharded-schemas-and-tables}
 
 DML ステートメントのみをレプリケートするには、次に示すように`Binlog event filter rule`を 2 つ設定します。
 
-    filters:
-      do-table-rule:
-        schema-pattern: "test_*"
-        table-pattern: "t_*"
-        events: ["create table", "all dml"]
-        action: Do
-      do-schema-rule:
-        schema-pattern: "test_*"
-        events: ["create database"]
-        action: Do
+```
+filters:
+  do-table-rule:
+    schema-pattern: "test_*"
+    table-pattern: "t_*"
+    events: ["create table", "all dml"]
+    action: Do
+  do-schema-rule:
+    schema-pattern: "test_*"
+    events: ["create database"]
+    action: Do
+```
 
 ### TiDB でサポートされていない SQL ステートメントを除外する {#filter-out-sql-statements-not-supported-by-tidb}
 
-TiDB でサポートされていない SQL ステートメントを除外するには、以下に示すように`filter-procedure-rule`設定します。
+TiDB でサポートされていない SQL ステートメントを除外するには、以下に示すように`filter-procedure-rule`を設定します。
 
-    filters:
-      filter-procedure-rule:
-        schema-pattern: "*"
-        sql-pattern: [".*\\s+DROP\\s+PROCEDURE", ".*\\s+CREATE\\s+PROCEDURE", "ALTER\\s+TABLE[\\s\\S]*ADD\\s+PARTITION", "ALTER\\s+TABLE[\\s\\S]*DROP\\s+PARTITION"]
-        action: Ignore
+```
+filters:
+  filter-procedure-rule:
+    schema-pattern: "*"
+    sql-pattern: [".*\\s+DROP\\s+PROCEDURE", ".*\\s+CREATE\\s+PROCEDURE", "ALTER\\s+TABLE[\\s\\S]*ADD\\s+PARTITION", "ALTER\\s+TABLE[\\s\\S]*DROP\\s+PARTITION"]
+    action: Ignore
+```
 
 > **Warning:**
 >


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

`filter-binlog-event.md`'s `events` config-value table had every entry in the `Event` column translated into Japanese words (e.g. `insert`→入れる, `drop table`→ドロップテーブル [half-translated], `all dml`→すべてのDML, `create database`→データベースを作成する) instead of being kept as the literal config string that a user copies verbatim into a `filter`/`events:` YAML list. This is a config-breaking bug, not just a style issue — a reader following the doc could write the Japanese word into their DM task configuration file and have it silently not match anything. Restored all 18 rows to the literal English value, matching the English source exactly (`Description`/`Category` columns, already correctly translated, are unchanged).

Also fixed, found in the same pass:
- 3 YAML example blocks (the `filter-table-rule`/`filter-schema-rule`, `do-table-rule`/`do-schema-rule`, and `filter-procedure-rule` examples) had lost their ` ``` ` code-fence markers present in the English source, degrading to plain indented text.
- 3 dropped `を` particles before `追加します`/`設定します` (e.g. "`filter`追加します" → "`filter`を追加します").
- A missing comparison particle: "`Ignore` `Do`よりも優先されます" → "`Ignore`の方が`Do`よりも優先されます" (matching "`Ignore` has higher priority over `Do`").

Not touched (already fixed in a separate in-flight PR, #23481): this file's one occurrence of シャード化された→シャーディングされた.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
