### PR TITLE
i18n(ja): fix reversed --master-addr description in migrate-sql-shards.md

### DIFF
--- a/tidb-cloud/migrate-sql-shards.md
+++ b/tidb-cloud/migrate-sql-shards.md
@@ -138,7 +138,7 @@ Query OK, 0 rows affected (0.17 sec)
 
 ### ステップ4. Amazon S3へのアクセスを設定する {#step-4-configure-amazon-s3-access}
 
-[Amazon S3へのアクセスを設定する](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access)」の手順に従って、ソースデータにアクセスするためのロール ARN を取得します。
+[Amazon S3へのアクセスを設定する](/tidb-cloud/dedicated-external-storage.md#configure-amazon-s3-access)の手順に従って、ソースデータにアクセスするためのロール ARN を取得します。
 
 以下の例では、主要なポリシー設定のみを示しています。Amazon S3 のパスを、ご自身の値に置き換えてください。
 
@@ -285,7 +285,7 @@ Amazon S3へのアクセスを設定した後、 TiDB Cloudコンソールで次
 
     | パラメータ                   | 説明                                                                        |
     | ----------------------- | ------------------------------------------------------------------------- |
-    | `--master-addr`         | `{advertise-addr}`が接続されるクラスタ内の任意のDMマスターノードの`dmctl` 。例：192.168.11.110:9261 |
+    | `--master-addr`         | dmctlが接続するクラスタ内の任意のDMマスターノードの`{advertise-addr}`。例：192.168.11.110:9261 |
     | `operate-source create` | データソースをDMクラスターにロードします。                                                    |
 
     以下は出力例です。
@@ -470,7 +470,7 @@ Starting component `dmctl`: /root/.tiup/components/dmctl/${tidb_version}/dmctl/d
 
 | パラメータ           | 説明                                                                        |
 | --------------- | ------------------------------------------------------------------------- |
-| `--master-addr` | `{advertise-addr}`が接続されるクラスタ内の任意のDMマスターノードの`dmctl` 。例：192.168.11.110:9261 |
+| `--master-addr` | dmctlが接続するクラスタ内の任意のDMマスターノードの`{advertise-addr}`。例：192.168.11.110:9261 |
 | `start-task`    | 移行タスクを開始します。                                                              |
 
 以下は出力例です。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

The `--master-addr` row in two parameter reference tables (identical text at both sites) reversed the subject and object of the English description. English says: "The `{advertise-addr}` of any DM-master node in the cluster where `dmctl` is to be connected" — i.e. `{advertise-addr}` is the DM-master node's address, and `dmctl` is what connects to it. The Japanese instead read as "the `dmctl` of any DM-master node in the cluster to which `{advertise-addr}` connects" — genuinely confusing for a parameter reference a user relies on to fill in a real value. Fixed both occurrences to describe `{advertise-addr}` as the node's address that `dmctl` connects to.

Also fixed a stray unmatched closing bracket `」` after an unrelated link in the "Configure Amazon S3 access" step (no matching opening `「` — the English source has no bracket/quote there at all).

Not touched (already fixed in a separate in-flight PR, #23481): this file's one occurrence of シャードされた→シャーディングされた.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
