### PR TITLE
cloud: clarify IMPORT INTO wildcard path matching

### DIFF
--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -121,7 +121,21 @@ It specifies the storage location of the data file, which can be an Amazon S3 or
 >
 > If [SEM](/system-variables.md#tidb_enable_enhanced_security) is enabled in the target cluster, the `fileLocation` cannot be specified as a local file path.
 
-In the `fileLocation` parameter, you can specify a single file, or use the `*` and `[]` wildcards to match multiple files for import. Note that the wildcard can only be used in the file name, because it does not match directories or recursively match files in subdirectories. Taking files stored on Amazon S3 as examples, you can configure the parameter as follows:
+In the `fileLocation` parameter, you can specify a single file, or use the `*` and `[]` wildcards to match multiple files for import.
+
+<CustomContent platform="tidb">
+
+The wildcard can only be used in the file name, because it does not match directories or recursively match files in subdirectories.
+
+</CustomContent>
+
+<CustomContent platform="tidb-cloud">
+
+Wildcards can appear in multiple path components, but each wildcard matches only within one `/`-separated component and never crosses `/`. Arbitrary-depth recursive matching is not supported.
+
+</CustomContent>
+
+Taking files stored on Amazon S3 as examples, you can configure the parameter as follows:
 
 - Import a single file: `s3://<bucket-name>/path/to/data/foo.csv`
 - Import all files in a specified path: `s3://<bucket-name>/path/to/data/*`
@@ -129,6 +143,12 @@ In the `fileLocation` parameter, you can specify a single file, or use the `*` a
 - Import all files with the `foo` prefix in a specified path: `s3://<bucket-name>/path/to/data/foo*`
 - Import all files with the `foo` prefix and the `.csv` suffix in a specified path: `s3://<bucket-name>/path/to/data/foo*.csv`
 - Import `1.csv` and `2.csv` in a specified path: `s3://<bucket-name>/path/to/data/[12].csv`
+
+<CustomContent platform="tidb-cloud">
+
+- Import all `.csv` files from matching subdirectories at one fixed directory depth: `s3://<bucket-name>/dir/subdir*/*.csv`
+
+</CustomContent>
 
 ### Format
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR corrects the TiDB Cloud guidance for wildcard paths in `IMPORT INTO`:

- Clarifies that wildcards can appear in multiple fixed-depth path components.
- Explains that a wildcard matches only within one `/`-separated component and does not provide arbitrary-depth recursive matching.
- Adds `s3://<bucket-name>/dir/subdir*/*.csv` as a fixed-depth S3 example.
- Preserves the existing TiDB Self-Managed v8.5 restriction through platform-specific content in the shared SQL reference.

The previous Cloud wording incorrectly limited wildcards to file names. TiDB now supports component-aware patterns such as `dir/subdir*/*.csv`, while still requiring each wildcard to remain within one path component.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (the branch used by the current TiDB Cloud documentation)
- [ ] v8.4
- [ ] v8.3
- [ ] v8.2
- [ ] v8.1
- [ ] v7.5
- [ ] v7.1
- [ ] v6.5

### What is the related PR or file link(s)?

- Other reference links:
  - https://github.com/pingcap/tidb/issues/67471
  - https://github.com/pingcap/tidb/pull/67472

### Validation

- `./scripts/markdownlint sql-statements/sql-statement-import-into.md`
- `python3 scripts/file-format-lint.py sql-statements/sql-statement-import-into.md`
- `python3 scripts/check-manual-line-breaks.py sql-statements/sql-statement-import-into.md`
- Verified the platform filters retain the new wording and example for TiDB Cloud while preserving the existing TiDB Self-Managed v8.5 text.
- Ran `go test -tags=intest,deadlock ./pkg/importsdk -run 'Test(ValidatePattern|GenerateWildcardPath)$' -count=1` in the TiDB repository. The tests verify that the import SDK accepts and generates `dir/subdir*/*.csv`.
- Ran a direct `IMPORT INTO` smoke test against a local TiDB cluster and an S3-compatible MinIO endpoint using `s3://import-smoke/fixture/dir/subdir*/*.csv`. The job finished with four imported rows from two matching directories. Decoy objects in a different directory, one level deeper, with a non-CSV extension, and without the final file component were all excluded.

The direct SQL smoke test validates S3 path matching in the TiDB engine. It does not claim an end-to-end test against a live TiDB Cloud cluster or the Aurora/RDS Parquet workflow.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wildcard behavior for file locations in TiDB and TiDB Cloud.
  * Documented TiDB Cloud support for matching files in subdirectories at a fixed depth.
  * Added an example for selecting `.csv` files within subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->