### PR TITLE
release-8.5: clarify IMPORT INTO format detection by platform and version

### DIFF
--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -132,7 +132,11 @@ In the `fileLocation` parameter, you can specify a single file, or use the `*` a
 
 ### Format
 
-The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. If not specified, the default format is `CSV`.
+The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. When you specify the `FORMAT` clause, TiDB uses that format regardless of the file extension. If you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.sql`, or `.parquet` file extension. Detection is case-insensitive. For compressed files, TiDB ignores the `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` compression suffix before detecting the data file format. If the remaining file name has no extension or an unrecognized extension, TiDB treats the file as `CSV`.
+
+> **Note:**
+>
+> For wildcard paths, make sure that all matched files use the same data file format. TiDB determines one format for the import job and applies it to every matched file. Files that do not use that format can cause the import to fail. Use separate `IMPORT INTO` statements for different formats.
 
 ### WithOptions
 

--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -115,7 +115,7 @@ It specifies the storage location of the data file, which can be an Amazon S3 or
 
 - Amazon S3 or GCS URI path: for URI configuration details, see [URI Formats of External Storage Services](/external-storage-uri.md).
 
-- TiDB local file path: it must be an absolute path, and the file extension must be `.csv`, `.sql`, or `.parquet`. Make sure that the files corresponding to this path are stored on the TiDB node connected by the current user, and the user has the `FILE` privilege.
+- TiDB local file path: it must be an absolute path, and its final suffix must be `.csv`, `.sql`, `.parquet`, `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` (case-insensitive). Make sure that the files corresponding to this path are stored on the TiDB node connected by the current user, and the user has the `FILE` privilege.
 
 > **Note:**
 >
@@ -138,7 +138,11 @@ The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and 
 
 Starting from v8.5.7, if you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.sql`, or `.parquet` file extension. Detection is case-insensitive. For compressed files, TiDB ignores the `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` compression suffix before detecting the data file format. If the remaining file name has no extension or an unrecognized extension, TiDB treats the file as `CSV`.
 
+For a TiDB local file path, the final suffix validation described above runs before format detection. A local path without a supported final suffix is rejected instead of falling back to `CSV`.
+
 In v8.5.6 and earlier versions, TiDB treats the file as `CSV` when you omit `FORMAT`.
+
+After upgrading to v8.5.7 or later, if an existing import relies on CSV parsing for a file whose name indicates another supported format, specify `FORMAT 'CSV'` to preserve the earlier behavior.
 
 </CustomContent>
 
@@ -150,7 +154,7 @@ If you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.s
 
 > **Note:**
 >
-> For wildcard paths, make sure that all matched files use the same data file format. TiDB determines one format for the import job and applies it to every matched file. Files that do not use that format can cause the import to fail. Use separate `IMPORT INTO` statements for different formats.
+> For wildcard paths, when `FORMAT` is omitted, TiDB detects the format from an arbitrary matched file and applies that format to every matched file. Make sure that all matched files use the same data file format. If any matched file uses another format, the import can fail during parsing. Use separate `IMPORT INTO` statements for different formats.
 
 ### WithOptions
 

--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -132,7 +132,21 @@ In the `fileLocation` parameter, you can specify a single file, or use the `*` a
 
 ### Format
 
-The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. When you specify the `FORMAT` clause, TiDB uses that format regardless of the file extension. If you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.sql`, or `.parquet` file extension. Detection is case-insensitive. For compressed files, TiDB ignores the `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` compression suffix before detecting the data file format. If the remaining file name has no extension or an unrecognized extension, TiDB treats the file as `CSV`.
+The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. When you specify the `FORMAT` clause, TiDB uses that format regardless of the file extension.
+
+<CustomContent platform="tidb">
+
+Starting from v8.5.7, if you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.sql`, or `.parquet` file extension. Detection is case-insensitive. For compressed files, TiDB ignores the `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` compression suffix before detecting the data file format. If the remaining file name has no extension or an unrecognized extension, TiDB treats the file as `CSV`.
+
+In v8.5.6 and earlier versions, TiDB treats the file as `CSV` when you omit `FORMAT`.
+
+</CustomContent>
+
+<CustomContent platform="tidb-cloud">
+
+If you omit `FORMAT`, TiDB automatically detects the format from the `.csv`, `.sql`, or `.parquet` file extension. Detection is case-insensitive. For compressed files, TiDB ignores the `.gz`, `.gzip`, `.zstd`, `.zst`, or `.snappy` compression suffix before detecting the data file format. If the remaining file name has no extension or an unrecognized extension, TiDB treats the file as `CSV`.
+
+</CustomContent>
 
 > **Note:**
 >

--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -132,7 +132,7 @@ In the `fileLocation` parameter, you can specify a single file, or use the `*` a
 
 ### Format
 
-The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. When you specify the `FORMAT` clause, TiDB uses that format regardless of the file extension.
+The `IMPORT INTO` statement supports three data file formats: `CSV`, `SQL`, and `PARQUET`. When you specify the `FORMAT` clause, TiDB uses that format for parsing instead of detecting it from the file extension. For TiDB local file paths, the final suffix validation described above still applies.
 
 <CustomContent platform="tidb">
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

This PR aligns the `IMPORT INTO` format documentation on `release-8.5` with the behavior released in TiDB v8.5.7 and the current TiDB Cloud behavior:

- Explains that an explicit `FORMAT` clause overrides file-extension detection.
- Qualifies automatic format detection as available in TiDB Self-Managed starting from v8.5.7.
- Preserves the v8.5.6-and-earlier behavior in which omitting `FORMAT` uses `CSV`.
- Uses platform-specific content so the TiDB Cloud documentation does not expose a Self-Managed patch-version qualifier.
- Documents case-insensitive detection for `.csv`, `.sql`, and `.parquet` files in the applicable versions and platform.
- Lists the supported compression suffixes ignored during detection.
- Clarifies that a missing or unrecognized extension on external storage falls back to `CSV`, while TiDB local paths require a supported final suffix.
- Explains that wildcard imports use one format for all matched files and avoids claiming that mixed formats fail during precheck.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/tidb/pull/59543
  - https://github.com/pingcap/tidb/pull/63884
  - https://github.com/pingcap/tidb/pull/66058
  - https://github.com/pingcap/docs/pull/21197
  - https://github.com/pingcap/docs/pull/23488

### Validation

- `./scripts/markdownlint sql-statements/sql-statement-import-into.md`
- `python3 scripts/file-format-lint.py sql-statements/sql-statement-import-into.md`
- `python3 scripts/check-manual-line-breaks.py sql-statements/sql-statement-import-into.md`
- `git diff --check`
- Verified that the platform filters retain the v8.5.7 qualifier and earlier-version fallback for TiDB Self-Managed, while TiDB Cloud retains the current automatic-detection wording.
- Local documentation review gate: `APPROVED`, with no findings.
- Ran `go test -tags=intest,deadlock ./pkg/executor/importer -run 'Test(SupportedSuffixForServerDisk|ParseFileType)$' -count=1` against the TiDB v8.5.7 tag.
- Direct smoke test against TiDB v8.5.7 and an S3-compatible MinIO endpoint. This validates the TiDB Self-Managed engine behavior for case-insensitive CSV, SQL, and Parquet detection; `.gz`, `.gzip`, `.zstd`, `.zst`, and `.snappy` suffixes; missing and unrecognized extension fallback; explicit `FORMAT` override; and homogeneous wildcard imports.
- A mixed `.csv` and `.sql` wildcard created an import job and failed while parsing the SQL file as CSV. It did not fail during precheck, and the target table remained empty.
- A live TiDB Cloud cluster was not exercised in this smoke test.

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that format detection is automatic and case-insensitive when `FORMAT` is omitted.
  * Documented support for recognized compression suffixes in local file paths, regardless of letter case.
  * Explained compression-suffix handling, version-specific behavior, and CSV fallback.
  * Added local-path validation guidance for imports.
  * Noted that files matched by wildcards must share the same format and compatible naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
