### PR TITLE
i18n(ja): restore lost copyable code blocks in migrate-with-more-columns-downstream.md

### DIFF
--- a/migrate-with-more-columns-downstream.md
+++ b/migrate-with-more-columns-downstream.md
@@ -12,9 +12,9 @@ summary: 対応するアップストリーム テーブルよりも多くの列�
 -   [小さなデータセットの MySQL シャードを TiDB に移行してマージする](/migrate-small-mysql-shards-to-tidb.md)
 -   [大規模データセットの MySQL シャードを TiDB に移行およびマージする](/migrate-large-mysql-shards-to-tidb.md)
 
-## DM を使用して、より多くの列を持つ下流の TiDB テーブルにデータを移行します。 {#use-dm-to-migrate-data-to-a-downstream-tidb-table-with-more-columns}
+## DM を使用して、より多くの列を持つ下流の TiDB テーブルにデータを移行します {#use-dm-to-migrate-data-to-a-downstream-tidb-table-with-more-columns}
 
-アップストリームのbinlogを複製する際、DMはダウンストリームの現在のテーブルスキーマを使用してbinlogを解析し、対応するDML文を生成しようとします。アップストリームのバイナリbinlog内のテーブルの列番号がダウンストリームのテーブルスキーマ内の列番号と一致しない場合、次のエラーが発生します。
+アップストリームのbinlogを複製する際、DMはダウンストリームの現在のテーブルスキーマを使用してbinlogを解析し、対応するDML文を生成しようとします。アップストリームのbinlog内のテーブルの列番号がダウンストリームのテーブルスキーマ内の列番号と一致しない場合、次のエラーが発生します。
 
 ```json
 "errors": [
@@ -67,7 +67,11 @@ DM がダウンストリーム テーブル スキーマを使用してアップ
 
 2.  `binlog-schema`コマンドを使用して、データソースから移行するテーブルのテーブルスキーマを設定します。この時点で、データ移行タスクは上記の`Column count doesn't match`エラーにより一時停止状態になっているはずです。
 
-        tiup dmctl --master-addr ${advertise-addr} binlog-schema update -s ${source-id} ${task-name} ${database-name} ${table-name} ${schema-file}
+    {{< copyable "shell-regular" >}}
+
+    ```
+    tiup dmctl --master-addr ${advertise-addr} binlog-schema update -s ${source-id} ${task-name} ${database-name} ${table-name} ${schema-file}
+    ```
 
     このコマンドのパラメータの説明は次のとおりです。
 
@@ -83,12 +87,24 @@ DM がダウンストリーム テーブル スキーマを使用してアップ
 
     例えば：
 
-        tiup dmctl --master-addr 172.16.10.71:8261 binlog-schema update -s mysql-01 task-test -d log -t message log.message.sql
+    {{< copyable "shell-regular" >}}
+
+    ```
+    tiup dmctl --master-addr 172.16.10.71:8261 binlog-schema update -s mysql-01 task-test -d log -t message log.message.sql
+    ```
 
 3.  一時停止状態の移行タスクを再開するには、 `resume-task`コマンドを使用します。
 
-        tiup dmctl --master-addr ${advertise-addr} resume-task ${task-name}
+    {{< copyable "shell-regular" >}}
+
+    ```
+    tiup dmctl --master-addr ${advertise-addr} resume-task ${task-name}
+    ```
 
 4.  `query-status`コマンドを使用して、データ移行タスクが正しく実行されていることを確認します。
 
-        tiup dmctl --master-addr ${advertise-addr} query-status ${task-name}
+    {{< copyable "shell-regular" >}}
+
+    ```
+    tiup dmctl --master-addr ${advertise-addr} query-status ${task-name}
+    ```


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

- 4 `tiup dmctl` shell command examples had lost both their `{{< copyable "shell-regular" >}}` shortcode and their triple-backtick code fence (both present in the English source), degrading to plain 8-space-indented text and losing the copy-button UI affordance. Restored both, matching English exactly. This also brings the file's line count back to parity with English (110/110).
- Removed a redundant "バイナリ" (binary) prefix before "binlog" — "binlog" already means "binary log", and English has no such prefix here ("the upstream binlog", not "the upstream binary binlog").
- Removed a stray trailing `。` on one H2 heading — no other heading in the file has one, matching the English source's unpunctuated heading style.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
