### PR TITLE
i18n(ja): restore lost code fences in tidb-lightning-distributed-import.md

### DIFF
--- a/tidb-lightning/tidb-lightning-distributed-import.md
+++ b/tidb-lightning/tidb-lightning-distributed-import.md
@@ -18,7 +18,7 @@ TiDB Lightning を使用すると、次のシナリオでデータを並列に�
 >
 > -   並列インポートは、TiDB 内の初期化された空のテーブルのみをサポートし、既存のサービスによって書き込まれたデータを含むテーブルへのデータ移行はサポートしません。そうしないと、データの不整合が発生する可能性があります。
 >
-> -   並列インポートは通常、物理インポートモードで使用されます。`parallel-import = true`設定する必要があります。
+> -   並列インポートは通常、物理インポートモードで使用されます。`parallel-import = true`を設定する必要があります。
 >
 > -   複数のTiDB Lightningインスタンスを使用して同じターゲットにデータをインポートする場合は、一度に1つのバックエンドのみを適用してください。例えば、同じTiDBクラスターに物理インポートモードと論理インポートモードの両方で同時にデータをインポートすることはできません。
 
@@ -39,7 +39,7 @@ TiDB Lightning を使用すると、次のシナリオでデータを並列に�
 
 TiDB Lightningは、生成されたキーバリューデータを、対応するリージョンの各コピーが配置されているTiKVノードにアップロードする必要があるため、インポート速度はターゲットクラスタのサイズによって制限されます。ターゲットTiDBクラスタ内のTiKVインスタンスの数とTiDB Lightningインスタンスの数がn:1（nはリージョンのコピー数）より大きくすることを推奨します。同時に、最適なインポートパフォーマンスを実現するには、以下の要件を満たす必要があります。
 
--   各TiDB Lightningインスタンスを専用マシンにデプロイ。1つのTiDB LightningインスタンスはデフォルトですべてのCPUリソースを消費するため、1台のマシンに複数のインスタンスをデプロイしてもパフォーマンスは向上しません。
+-   各TiDB Lightningインスタンスを専用マシンにデプロイします。1つのTiDB LightningインスタンスはデフォルトですべてのCPUリソースを消費するため、1台のマシンに複数のインスタンスをデプロイしてもパフォーマンスは向上しません。
 -   並列インポートを実行する各TiDB Lightningインスタンスのソースファイルの合計サイズは 5 TiB 未満である必要があります。
 -   TiDB Lightningインスタンスの合計数は 10 未満である必要があります。
 
@@ -84,28 +84,32 @@ Dumpling を使用してデータをエクスポートする方法の詳細に�
 
 構成ファイル`tidb-lightning.toml`を作成し、次のコンテンツを追加します。
 
-    [lightning]
-    status-addr = ":8289"
+```
+[lightning]
+status-addr = ":8289"
 
-    [mydumper]
-    # Specify the path for Dumpling to export data. If Dumpling performs several times and the data belongs to different directories, you can place all the exported data in the same parent directory and specify this parent directory here.
-    data-source-dir = "/path/to/source-dir"
+[mydumper]
+# Specify the path for Dumpling to export data. If Dumpling performs several times and the data belongs to different directories, you can place all the exported data in the same parent directory and specify this parent directory here.
+data-source-dir = "/path/to/source-dir"
 
-    [tikv-importer]
-    # Whether to allow importing data into tables that already have data. The default value is `false`.
-    # When using parallel import, because multiple TiDB Lightning instances import a table at the same time, this configuration item must be set to `true`.
-    parallel-import = true
-    # "local": The default mode. It applies to large dataset import, for example, greater than 1 TiB. However, during the import, downstream TiDB is not available to provide services.
-    # "tidb": You can use this mode for small dataset import, for example, smaller than 1 TiB. During the import, downstream TiDB is available to provide services.
-    backend = "local"
+[tikv-importer]
+# Whether to allow importing data into tables that already have data. The default value is `false`.
+# When using parallel import, because multiple TiDB Lightning instances import a table at the same time, this configuration item must be set to `true`.
+parallel-import = true
+# "local": The default mode. It applies to large dataset import, for example, greater than 1 TiB. However, during the import, downstream TiDB is not available to provide services.
+# "tidb": You can use this mode for small dataset import, for example, smaller than 1 TiB. During the import, downstream TiDB is available to provide services.
+backend = "local"
 
-    # Specify the path for local sorting data.
-    sorted-kv-dir = "/path/to/sorted-dir"
+# Specify the path for local sorting data.
+sorted-kv-dir = "/path/to/sorted-dir"
+```
 
 データソースがAmazon S3やGCSなどの外部ストレージに保存されている場合は、接続用の追加パラメータを設定する必要があります。このような設定にはパラメータを指定できます。例えば、次の例では、データがAmazon S3に保存されていると仮定しています。
 
-    tiup tidb-lightning --tidb-port=4000 --pd-urls=127.0.0.1:2379 --backend=local --sorted-kv-dir=/tmp/sorted-kvs \
-        -d 's3://my-bucket/sql-backup'
+```
+tiup tidb-lightning --tidb-port=4000 --pd-urls=127.0.0.1:2379 --backend=local --sorted-kv-dir=/tmp/sorted-kvs \
+    -d 's3://my-bucket/sql-backup'
+```
 
 詳細なパラメータの説明については、 [外部ストレージサービスのURI形式](/external-storage-uri.md)を参照してください。
 
@@ -147,30 +151,32 @@ TiDB Lightningは、単一テーブルの並列インポートもサポートし
 
 ソースファイルがAmazon S3に保存されており、テーブルファイルが`my_db.my_table.00001.sql` ～ `my_db.my_table.10000.sql` 、合計10,000個のSQLファイルがあると仮定します。インポートを高速化するために2つのTiDB Lightningインスタンスを使用する場合は、設定ファイルに以下の設定を追加する必要があります。
 
-    [[mydumper.files]]
-    # the db schema file
-    pattern = '(?i)^(?:[^/]*/)*my_db-schema-create\.sql'
-    schema = "my_db"
-    type = "schema-schema"
+```
+[[mydumper.files]]
+# the db schema file
+pattern = '(?i)^(?:[^/]*/)*my_db-schema-create\.sql'
+schema = "my_db"
+type = "schema-schema"
 
-    [[mydumper.files]]
-    # the table schema file
-    pattern = '(?i)^(?:[^/]*/)*my_db\.my_table-schema\.sql'
-    schema = "my_db"
-    table = "my_table"
-    type = "table-schema"
+[[mydumper.files]]
+# the table schema file
+pattern = '(?i)^(?:[^/]*/)*my_db\.my_table-schema\.sql'
+schema = "my_db"
+table = "my_table"
+type = "table-schema"
 
-    [[mydumper.files]]
-    # Only import 00001~05000 and ignore other files
-    pattern = '(?i)^(?:[^/]*/)*my_db\.my_table\.(0[0-4][0-9][0-9][0-9]|05000)\.sql'
-    schema = "my_db"
-    table = "my_table"
-    type = "sql"
+[[mydumper.files]]
+# Only import 00001~05000 and ignore other files
+pattern = '(?i)^(?:[^/]*/)*my_db\.my_table\.(0[0-4][0-9][0-9][0-9]|05000)\.sql'
+schema = "my_db"
+table = "my_table"
+type = "sql"
 
-    [tikv-importer]
-    # Whether to allow importing data into tables that already have data. The default value is `false`.
-    # When using parallel import, because multiple TiDB Lightning instances import a table at the same time, this configuration item must be set to `true`.
-    parallel-import = true
+[tikv-importer]
+# Whether to allow importing data into tables that already have data. The default value is `false`.
+# When using parallel import, because multiple TiDB Lightning instances import a table at the same time, this configuration item must be set to `true`.
+parallel-import = true
+```
 
 他のインスタンスの構成を変更して、 `05001 ~ 10000`データ ファイルのみをインポートすることができます。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

Fixed 4 defects found in a full 1:1 comparison against the English source:

- 3 TOML/shell config examples (the `tidb-lightning.toml` example, the `tiup tidb-lightning` external-storage command, and the `[[mydumper.files]]` example) had lost their triple-backtick code fences, present in the English source, degrading to plain indented text and losing syntax highlighting.
- A missing を particle before 設定する必要があります ("`parallel-import = true`設定する必要があります" → "...を設定する必要があります"), inconsistent with a correctly-formed instance of the identical English sentence elsewhere in the same file.
- A truncated sentence missing its verb ending ("...専用マシンにデプロイ。" → "...専用マシンにデプロイします。"), matching the complete-sentence style of the sibling bullets in the same list.

Line count now matches the English source exactly (209/209).

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
