### PR TITLE
Add more description to AUTO_RANDOM

### DIFF
--- a/auto-random.md
+++ b/auto-random.md
@@ -118,9 +118,10 @@ The structure of an `AUTO_RANDOM` value without a signed bit is as follows:
 |-------------|--------|--------------|
 | `64-R` bits | `S` bits | `R-S` bits |
 
-- Whether a value has a signed bit depends on whether the corresponding column has the `UNSIGNED` attribute.
-- The length of the sign bit is determined by the existence of an `UNSIGNED` attribute. If there is an `UNSIGNED` attribute, the length is `0`. Otherwise, the length is `1`.
+- Whether an `AUTO_RANDOM` column has a signed bit depends on whether the column has the `UNSIGNED` attribute. A column without the `UNSIGNED` attribute has 1 signed bit, and a column with the `UNSIGNED` attribute has no signed bit.
+- Values implicitly allocated to an `AUTO_RANDOM` column are always positive. For columns with a signed bit, the signed bit of implicitly allocated values is always `0`. This rule does not apply to explicitly inserted values.
 - The length of the reserved bits is `64-R`. The reserved bits are always `0`.
+- The auto-increment bits must be at least 27 bits. For signed columns, `R-1-S >= 27` must be satisfied. For unsigned columns, `R-S >= 27` must be satisfied.
 - The content of the shard bits is obtained by calculating the hash value of the starting time of the current transaction. To use a different length of shard bits (such as 10), you can specify `AUTO_RANDOM(10)` when creating the table.
 - The value of the auto-increment bits is stored in the storage engine and allocated sequentially. Each time a new value is allocated, the value is incremented by 1. The auto-increment bits ensure that the values of `AUTO_RANDOM` are unique globally. When the auto-increment bits are exhausted, an error `Failed to read auto-increment value from storage engine` is reported when the value is allocated again.
 - Value range: the maximum number of bits for the final generated value = shard bits + auto-increment bits. The range of a signed column is `[-(2^(R-1))+1, (2^(R-1))-1]`, and the range of an unsigned column is `[0, (2^R)-1]`.

--- a/auto-random.md
+++ b/auto-random.md
@@ -118,7 +118,7 @@ The structure of an `AUTO_RANDOM` value without a signed bit is as follows:
 |-------------|--------|--------------|
 | `64-R` bits | `S` bits | `R-S` bits |
 
-- Whether an `AUTO_RANDOM` column has a signed bit depends on whether the column has the `UNSIGNED` attribute. A column without the `UNSIGNED` attribute has 1 signed bit, and a column with the `UNSIGNED` attribute has no signed bit.
+- Whether an `AUTO_RANDOM` column has a signed bit depends on whether the column has the `UNSIGNED` attribute. A column without the `UNSIGNED` attribute has one signed bit, while a column with the `UNSIGNED` attribute has no signed bit.
 - Values implicitly allocated to an `AUTO_RANDOM` column are always positive. For columns with a signed bit, the signed bit of implicitly allocated values is always `0`. This rule does not apply to explicitly inserted values.
 - The length of the reserved bits is `64-R`. The reserved bits are always `0`.
 - The auto-increment bits must be at least 27 bits. For signed columns, `R-1-S >= 27` must be satisfied. For unsigned columns, `R-S >= 27` must be satisfied.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

close https://github.com/pingcap/docs/issues/23404

Add 2 more descriptions:
- The auto_random value is always positive unless explicitly inserted.
- The auto increment bits must not be less than 27: https://github.com/pingcap/tidb/blob/release-8.5/pkg/meta/autoid/autoid.go#L86

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/21863
- Other reference link(s):

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified signed and unsigned column behavior in `AUTO_RANDOM` bit layouts.
  * Documented that implicitly generated values are always positive with a zero signed bit.
  * Added the minimum 27-bit requirement for auto-increment bits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->