### PR TITLE
i18n(ja): fix mistranslated KILL heading and inconsistent high-concurrency term in release notes

### DIFF
--- a/privilege-management.md
+++ b/privilege-management.md
@@ -435,7 +435,7 @@ SELECT * FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE grantee = "'root'@'%'";
 
 `SUPER`の権限が必要です。
 
-### 殺す {#kill}
+### KILL {#kill}
 
 他のユーザーセッションを終了するには、 `SUPER`または`CONNECTION_ADMIN`の権限が必要です。
 

--- a/releases/release-2.1.13.md
+++ b/releases/release-2.1.13.md
@@ -15,7 +15,7 @@ TiDB Ansible バージョン: 2.1.13
 
 -   ホットスポットの問題を軽減するために、列に`AUTO_INCREMENT`属性が含まれている場合に`SHARD_ROW_ID_BITS`を使用して行 ID を分散させる機能を追加します[＃10788](https://github.com/pingcap/tidb/pull/10788)
 -   無効な DDL メタデータの有効期間を最適化して、TiDB クラスタアップグレード後に DDL 操作の通常の実行を回復する速度を向上します。 [＃10789](https://github.com/pingcap/tidb/pull/10789)
--   `execdetails.ExecDetails`ポインタの結果としてコプロセッサーリソースを迅速に解放できないことによって引き起こされる、高同時シナリオでのOOM問題を修正しました。 [＃10833](https://github.com/pingcap/tidb/pull/10833)
+-   `execdetails.ExecDetails`ポインタの結果としてコプロセッサーリソースを迅速に解放できないことによって引き起こされる、高同時実行シナリオでのOOM問題を修正しました。 [＃10833](https://github.com/pingcap/tidb/pull/10833)
 -   統計情報を更新するかどうかを制御する`update-stats`構成項目を追加します[＃10772](https://github.com/pingcap/tidb/pull/10772)
 -   ホットスポット問題を解決するために、リージョンプリスプリットをサポートする次の TiDB 固有の構文を追加します。
 -   `PRE_SPLIT_REGIONS`テーブルオプションを追加する [＃10863](https://github.com/pingcap/tidb/pull/10863)

--- a/releases/release-3.0.0-rc.3.md
+++ b/releases/release-3.0.0-rc.3.md
@@ -39,7 +39,7 @@ TiDB Ansible バージョン: 3.0.0-rc.3
     -   コプロセッサーへの式のプッシュダウンを禁止するブロックリストを追加します。 [＃10791](https://github.com/pingcap/tidb/pull/10791)
     -   クエリがメモリ構成制限を超えたときに`expensive query`ログを出力する機能を追加 [＃10849](https://github.com/pingcap/tidb/pull/10849)
     -   変更されたバインディング実行計画の更新時間を制御する`bind-info-lease`構成項目を追加します。 [＃10727](https://github.com/pingcap/tidb/pull/10727)
-    -   `execdetails.ExecDetails`ポインタの結果としてコプロセッサーリソースを迅速に解放できないことによって引き起こされる、高同時シナリオでのOOM問題を修正しました。 [＃10832](https://github.com/pingcap/tidb/pull/10832)
+    -   `execdetails.ExecDetails`ポインタの結果としてコプロセッサーリソースを迅速に解放できないことによって引き起こされる、高同時実行シナリオでのOOM問題を修正しました。 [＃10832](https://github.com/pingcap/tidb/pull/10832)
     -   `kill`文によって発生するpanic問題を修正[＃10876](https://github.com/pingcap/tidb/pull/10876)
 
 -   サーバ

--- a/releases/release-6.5.10.md
+++ b/releases/release-6.5.10.md
@@ -109,7 +109,7 @@ TiDB バージョン: 6.5.10
     -   空のキー範囲を持つクエリがTiFlashで読み取りタスクを正しく生成できず、 TiFlashクエリがブロックされる可能性がある問題を修正しました。 [＃9108](https://github.com/pingcap/tiflash/issues/9108) @[JinheLin](https://github.com/JinheLin)
     -   `SUBSTRING_INDEX()`関数が一部のコーナーケースでTiFlash のクラッシュを引き起こす可能性がある問題を修正[＃9116](https://github.com/pingcap/tiflash/issues/9116) @[wshwsh12](https://github.com/wshwsh12)
     -   クラスタをv6.5.0より前のバージョンからv6.5.0以降にアップグレードするときに、 TiFlashメタデータが破損してプロセスがpanicになる可能性がある問題を修正しました[＃9039](https://github.com/pingcap/tiflash/issues/9039) @[JaySon-Huang](https://github.com/JaySon-Huang)
-    -   TiFlash が高同時読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
+    -   TiFlash が高同時実行読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
 
 -   ツール
 

--- a/releases/release-7.1.6.md
+++ b/releases/release-7.1.6.md
@@ -240,7 +240,7 @@ TiDB バージョン: 7.1.6
     -   データベース間で`ALTER TABLE ... EXCHANGE PARTITION`を実行した後にTiFlash がスキーマの同期に失敗する可能性がある問題を修正しました [＃7296](https://github.com/pingcap/tiflash/issues/7296) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   データベースが作成直後に削除されるとTiFlash がpanicする可能性がある問題を修正[＃9266](https://github.com/pingcap/tiflash/issues/9266) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   `CAST()`関数を使用して文字列をタイムゾーンまたは無効な文字を含む日付時刻に変換すると、結果が正しくなくなる問題を修正しました[＃8754](https://github.com/pingcap/tiflash/issues/8754) @[solotzg](https://github.com/solotzg)
-    -   TiFlash が高同時読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
+    -   TiFlash が高同時実行読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
     -   `SUBSTRING_INDEX()`関数が一部のコーナーケースでTiFlash のクラッシュを引き起こす可能性がある問題を修正[＃9116](https://github.com/pingcap/tiflash/issues/9116) @[wshwsh12](https://github.com/wshwsh12)
     -   クラスタ内で長期間にわたって頻繁に`EXCHANGE PARTITION`と`DROP TABLE`操作を行うと、 TiFlashテーブル メタデータのレプリケーションが遅くなり、クエリ パフォーマンスが低下する可能性がある問題を修正しました[＃9227](https://github.com/pingcap/tiflash/issues/9227) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   空のキー範囲を持つクエリがTiFlash上で読み取りタスクを正しく生成できず、 TiFlashクエリがブロックされる可能性がある問題を修正しました。 [＃9108](https://github.com/pingcap/tiflash/issues/9108) @[JinheLin](https://github.com/JinheLin)

--- a/releases/release-7.5.2.md
+++ b/releases/release-7.5.2.md
@@ -200,7 +200,7 @@ TiDB バージョン: 7.5.2
     -   チャンクエンコード中に`ENUM`列がTiFlashを引き起こす可能性がある問題を修正しました [＃8674](https://github.com/pingcap/tiflash/issues/8674) @[yibin87](https://github.com/yibin87)
     -   ログの誤った`local_region_num`値を修正 [＃8895](https://github.com/pingcap/tiflash/issues/8895) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   分散ストレージとコンピューティングアーキテクチャで、シャットダウン中にTiFlash がpanicになる可能性がある問題を修正しました。 [＃8837](https://github.com/pingcap/tiflash/issues/8837) @[JaySon-Huang](https://github.com/JaySon-Huang)
-    -   TiFlash が高同時読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
+    -   TiFlash が高同時実行読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
     -   分散ストレージおよびコンピューティングアーキテクチャで、 TiFlashコンピューティングノードの`storage.remote.cache.capacity`構成項目の値を変更した後、Grafanaに表示されるディスク`used_size`メトリックが正しくないという問題を修正しました。 [＃8920](https://github.com/pingcap/tiflash/issues/8920) @[JinheLin](https://github.com/JinheLin)
     -   分散ストレージおよびコンピューティングアーキテクチャで、ネットワーク分離後にクエリが永続的にブロックされる可能性がある問題を修正しました [＃8806](https://github.com/pingcap/tiflash/issues/8806) @[JinheLin](https://github.com/JinheLin)
     -   非厳密モードの`sql_mode` で無効なデフォルト値を持つ列にデータを挿入するとTiFlash がpanicする可能性がある問題を修正しました [＃8803](https://github.com/pingcap/tiflash/issues/8803) @[Lloyd-Pottiger](https://github.com/Lloyd-Pottiger)

--- a/releases/release-8.1.0.md
+++ b/releases/release-8.1.0.md
@@ -242,7 +242,7 @@ TiDB 8.1.0 は長期サポートリリース (LTS) です。
 -   TiFlash
 
     -   非厳密モードの`sql_mode` で無効なデフォルト値を持つ列にデータを挿入するとTiFlash がpanicする可能性がある問題を修正しました [＃8803](https://github.com/pingcap/tiflash/issues/8803) @[Lloyd-Pottiger](https://github.com/Lloyd-Pottiger)
-    -   TiFlash が高同時読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
+    -   TiFlash が高同時実行読み取りシナリオで一時的に誤った結果を返す可能性がある問題を修正[＃8845](https://github.com/pingcap/tiflash/issues/8845) @[JinheLin](https://github.com/JinheLin)
     -   分散ストレージおよびコンピューティングアーキテクチャで、 TiFlashコンピューティングノードの`storage.remote.cache.capacity`構成項目の値を変更した後、Grafanaに表示されるディスク`used_size`メトリックが正しくないという問題を修正しました。 [＃8920](https://github.com/pingcap/tiflash/issues/8920) @[JinheLin](https://github.com/JinheLin)
     -   クラスタをv6.5.0より前のバージョンからv6.5.0以降にアップグレードするときに、 TiFlashメタデータが破損してプロセスがpanicになる可能性がある問題を修正しました[＃9039](https://github.com/pingcap/tiflash/issues/9039) @[JaySon-Huang](https://github.com/JaySon-Huang)
     -   分散ストレージとコンピューティングアーキテクチャで、コンピューティングノードのプロセスが停止するとTiFlash がpanicする可能性がある問題を修正しました[＃8860](https://github.com/pingcap/tiflash/issues/8860) @[guo-shaoge](https://github.com/guo-shaoge)


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- `privilege-management.md`: restore the literal SQL statement name `### KILL {#kill}`, which had been mistranslated as the verb 殺す ("to kill" as in murder). The body text and `sql-statements/sql-statement-kill.md` already use `KILL` as-is, so this heading was the odd one out.
- 6 release notes files (`release-8.1.0.md`, `release-6.5.10.md`, `release-7.1.6.md`, `release-7.5.2.md`, `release-3.0.0-rc.3.md`, `release-2.1.13.md`): fix 高同時読み取りシナリオ/高同時シナリオ to 高同時実行読み取りシナリオ/高同時実行シナリオ. These translate the English "high-concurrency read scenarios" / "high concurrent scenarios", and 高同時実行 (not bare 高同時) is the natural, standard translation for "high concurrency" used everywhere else in the docs.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): #23512

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch