### PR TITLE
i18n(ja): fix redundant duplicate API noun after REST interface link

### DIFF
--- a/api/_index.md
+++ b/api/_index.md
@@ -9,7 +9,7 @@ TiDBは、クラスタのクエリと操作、データレプリケーション�
 
 ## TiDB Cloud API (PREVIEW) {#tidb-cloud-api-preview}
 
-[TiDB Cloud API](/api/tidb-cloud-api-overview.md)は[RESTインターフェース](https://en.wikipedia.org/wiki/Representational_state_transfer)APIであり、プロジェクト、クラスタ、バックアップ、リストア、インポート、請求、Data Serviceリソースなど、 TiDB Cloud内の管理オブジェクトをプログラムで管理するためのアクセスを提供します。
+[TiDB Cloud API](/api/tidb-cloud-api-overview.md)は[RESTインターフェース](https://en.wikipedia.org/wiki/Representational_state_transfer)であり、プロジェクト、クラスタ、バックアップ、リストア、インポート、請求、Data Serviceリソースなど、 TiDB Cloud内の管理オブジェクトをプログラムで管理するためのアクセスを提供します。
 
 | API                                       | 説明                                                                           |
 | ----------------------------------------- | ---------------------------------------------------------------------------- |

--- a/api/tidb-cloud-api-overview.md
+++ b/api/tidb-cloud-api-overview.md
@@ -10,7 +10,7 @@ aliases: ['/ja/tidbcloud/api-overview/']
 >
 > TiDB Cloud APIはパブリックプレビューです。
 
-TiDB Cloud APIは[RESTインターフェース](https://en.wikipedia.org/wiki/Representational_state_transfer)APIであり、 TiDB Cloud内の管理オブジェクトをプログラムで管理するためのアクセスを提供します。このAPIを使用すると、プロジェクト、クラスタ、バックアップ、リストア、インポート、請求、[Data Service](https://docs.pingcap.com/tidbcloud/data-service-overview)内のリソースなどのリソースを自動的かつ効率的に管理できます。
+TiDB Cloud APIは[RESTインターフェース](https://en.wikipedia.org/wiki/Representational_state_transfer)であり、 TiDB Cloud内の管理オブジェクトをプログラムで管理するためのアクセスを提供します。このAPIを使用すると、プロジェクト、クラスタ、バックアップ、リストア、インポート、請求、[Data Service](https://docs.pingcap.com/tidbcloud/data-service-overview)内のリソースなどのリソースを自動的かつ効率的に管理できます。
 
 このAPIには以下の機能があります。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

`api/_index.md` and `api/tidb-cloud-api-overview.md` both had a stray trailing `API` immediately after the `[REST interface]` link, producing "...REST interfaceAPIであり" (double "API"). The English source ends at "a REST interface that provides..." with no trailing noun.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch