### PR TITLE
i18n(ja): unify katakana embedding term to its translated form

### DIFF
--- a/ai/concepts/vector-search-overview.md
+++ b/ai/concepts/vector-search-overview.md
@@ -29,7 +29,7 @@ aliases: ['/ja/tidb/stable/vector-search-overview/','/ja/tidb/dev/vector-search-
 
 ベクトル埋め込みは機械学習において不可欠であり、意味的類似性検索の基盤となる。
 
-TiDB は、ベクトル埋め込みのストレージと検索を最適化するように設計された[ベクトルデータ型](/ai/reference/vector-search-data-types.md)と[ベクトル検索インデックス](/ai/reference/vector-search-index.md)を導入し、AI アプリケーションでの使用を強化します。ベクトル エンベディングを TiDB に保存し、ベクトル検索クエリを実行して、これらのデータ タイプを使用して最も関連性の高いデータを見つけることができます。
+TiDB は、ベクトル埋め込みのストレージと検索を最適化するように設計された[ベクトルデータ型](/ai/reference/vector-search-data-types.md)と[ベクトル検索インデックス](/ai/reference/vector-search-index.md)を導入し、AI アプリケーションでの使用を強化します。ベクトル埋め込みを TiDB に保存し、ベクトル検索クエリを実行して、これらのデータ タイプを使用して最も関連性の高いデータを見つけることができます。
 
 ### 埋め込みモデル {#embedding-model}
 

--- a/ai/examples/vector-search-with-pytidb.md
+++ b/ai/examples/vector-search-with-pytidb.md
@@ -7,7 +7,7 @@ summary: ベクトル埋め込みを用いたセマンティック検索を実�
 
 この例では、TiDBとローカル埋め込みモデルを使用してセマンティック検索アプリケーションを構築する方法を示します。ベクトル検索を使用して、キーワードだけでなく意味に基づいて類似アイテムを検索します。
 
-このアプリケーションは、ローカル エンベディング生成に[Ollama](https://ollama.com/download)、Web UI に[Streamlit](https://streamlit.io/)、および RAG パイプラインを構築するために[`pytidb`](https://github.com/pingcap/pytidb) (TiDB 用の公式 Python SDK) を使用します。
+このアプリケーションは、ローカル埋め込み生成に[Ollama](https://ollama.com/download)、Web UI に[Streamlit](https://streamlit.io/)、および RAG パイプラインを構築するために[`pytidb`](https://github.com/pingcap/pytidb) (TiDB 用の公式 Python SDK) を使用します。
 
 <p align="center"><img width="700" alt="ベクトル埋め込みを用いた意味検索" src="https://docs-download.pingcap.com/media/images/docs/ai/semantic-search-with-vector-embeddings.png" /><p align="center"><i>ベクトル埋め込みを用いた意味検索</i></p></p>
 

--- a/ai/integrations/vector-search-auto-embedding-nvidia-nim.md
+++ b/ai/integrations/vector-search-auto-embedding-nvidia-nim.md
@@ -4,7 +4,7 @@ summary: TiDB CloudでNVIDIA NIM埋め込みモデルを使用する方法を学
 aliases: ['/ja/tidbcloud/vector-search-auto-embedding-nvidia-nim/']
 ---
 
-# NVIDIA NIM エンベディング {#nvidia-nim-embeddings}
+# NVIDIA NIM 埋め込み {#nvidia-nim-embeddings}
 
 このドキュメントでは、TiDB CloudでNVIDIA NIM埋め込みモデルを[自動埋め込み](/ai/integrations/vector-search-auto-embedding-overview.md)で使用して、テキストクエリによるセマンティック検索を実行する方法について説明します。
 

--- a/ai/integrations/vector-search-auto-embedding-overview.md
+++ b/ai/integrations/vector-search-auto-embedding-overview.md
@@ -123,7 +123,7 @@ TiDB Cloudがサポートする以下の推論サービスを通じて、オー�
 | 埋め込みモデル    | 文書                                                                                | TiDB Cloud <sup>1</sup>がホストしています | BYOK <sup>2</sup> | サポートされているモデルの例                     |
 | ---------- | --------------------------------------------------------------------------------- | -------------------------------- | ----------------- | ---------------------------------- |
 | Hugging Face 推論  | [Hugging Face Embeddings](/ai/integrations/vector-search-auto-embedding-huggingface.md)        |                                  | ✅                 | `bge-m3` 、 `multilingual-e5-large` |
-| NVIDIA NIM | [NVIDIA NIM エンベディング](/ai/integrations/vector-search-auto-embedding-nvidia-nim.md) |                                  | ✅                 | `bge-m3` 、 `nv-embed-v1`           |
+| NVIDIA NIM | [NVIDIA NIM 埋め込み](/ai/integrations/vector-search-auto-embedding-nvidia-nim.md) |                                  | ✅                 | `bge-m3` 、 `nv-embed-v1`           |
 
 <sup>1.</sup>ホスト型モデルはTiDB Cloudによってホストされており、APIキーは必要ありません。現在、これらのホスト型モデルは無料で利用できますが、すべてのユーザーが利用できるようにするために、一定の利用制限が適用される場合があります。
 

--- a/ai/integrations/vector-search-integrate-with-django-orm.md
+++ b/ai/integrations/vector-search-integrate-with-django-orm.md
@@ -6,7 +6,7 @@ aliases: ['/ja/tidb/stable/vector-search-integrate-with-django-orm/','/ja/tidb/d
 
 # TiDBベクトル検索をDjango ORMと統合する {#integrate-tidb-vector-search-with-django-orm}
 
-このチュートリアルでは[Django](https://www.djangoproject.com/)ORM を使用して[TiDB ベクトル検索](/ai/concepts/vector-search-overview.md)と対話し、エンベディングを保存し、ベクトル検索クエリを実行する方法を説明します。
+このチュートリアルでは[Django](https://www.djangoproject.com/)ORM を使用して[TiDB ベクトル検索](/ai/concepts/vector-search-overview.md)と対話し、埋め込みを保存し、ベクトル検索クエリを実行する方法を説明します。
 
 > **Note:**
 >

--- a/ai/integrations/vector-search-integrate-with-peewee.md
+++ b/ai/integrations/vector-search-integrate-with-peewee.md
@@ -6,7 +6,7 @@ aliases: ['/ja/tidb/stable/vector-search-integrate-with-peewee/','/ja/tidb/dev/v
 
 # TiDBベクトル検索をpeeweeと統合する {#integrate-tidb-vector-search-with-peewee}
 
-このチュートリアルでは[Peewee](https://docs.peewee-orm.com/)を使用して[TiDB ベクトル検索](/ai/concepts/vector-search-overview.md)と対話し、エンベディングを保存し、ベクトル検索クエリを実行する方法を説明します。
+このチュートリアルでは[Peewee](https://docs.peewee-orm.com/)を使用して[TiDB ベクトル検索](/ai/concepts/vector-search-overview.md)と対話し、埋め込みを保存し、ベクトル検索クエリを実行する方法を説明します。
 
 > **Note:**
 >


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Unifies the remaining 6 katakana エンベディング occurrences to 埋め込み, matching the dominant translated form used elsewhere in the vector search docs (ベクトル埋め込み/埋め込み, 400+ occurrences across 47 files):

- `ai/integrations/vector-search-auto-embedding-nvidia-nim.md` H1 and its inbound link text in `vector-search-auto-embedding-overview.md` (anchor unchanged, so the link still resolves) — the other 5 sibling provider pages (Amazon Titan, Gemini, Cohere, Jina AI, OpenAI) already use 埋め込み; NVIDIA NIM was the only outlier.
- `ai/concepts/vector-search-overview.md`, which previously mixed both forms in the same sentence (ベクトル埋め込み then ベクトル エンベディング).
- `ai/examples/vector-search-with-pytidb.md` and 2 near-identical intro sentences in `vector-search-integrate-with-peewee.md` / `vector-search-integrate-with-django-orm.md`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch