### PR TITLE
i18n(ja): fix version-mark heading spans in config file references

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -75,7 +75,7 @@ Info: {"upstream_id":7178706266519722477,"namespace":"default","id":"simple-repl
 -   形式は`"h m s"`です。例えば、 `"24h30m30s"`です。
 -   デフォルト値: `"24h"`
 
-### `sql-mode` <span class="version-mark">v6.5.6、v7.1.3、v7.5.0 で新たに追加されました。</span> {#sql-mode-new-in-v656-v713-and-v750}
+### `sql-mode` <span class="version-mark">v6.5.6、v7.1.3、および v7.5.0 で追加</span> {#sql-mode-new-in-v656-v713-and-v750}
 
 -   DDLステートメントを解析する際に使用する[SQLモード](/sql-mode.md)を指定します。複数のモードを指定する場合は、カンマで区切ります。
 -   デフォルト値： `"ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"` 。これはTiDBのデフォルトのSQLモードと同じです。
@@ -272,7 +272,7 @@ Info: {"upstream_id":7178706266519722477,"namespace":"default","id":"simple-repl
 -   デフォルト値： `false` 。これは、スキーマ情報の出力を有効にすることを意味します。
 -   このパラメータは、シンクタイプがMQで、出力プロトコルがDebeziumの場合にのみ有効です。
 
-#### sink.csv は<span class="version-mark">v6.5.0 で追加されました。</span> {#sink-csv-span-class-version-mark-new-in-v6-5-0-span}
+#### sink.csv <span class="version-mark">v6.5.0で追加</span> {#sinkcsv-new-in-v650}
 
 バージョン6.5.0以降、TiCDCはデータ変更をCSV形式でストレージサービスに保存することをサポートしています。データをMQまたはMySQLシンクにレプリケートする場合は、以下の設定は無視してください。
 
@@ -402,13 +402,13 @@ REDO ログを使用する場合の変更フィードのレプリケーション
 -   再実行モジュール内のフラッシングワーカーの数。
 -   デフォルト値: `8`
 
-#### `compression` <span class="version-mark">v6.5.6、v7.1.3、v7.5.1、v7.6.0で新たに追加されました。</span> {#compression-new-in-v656-v713-v751-and-v760}
+#### `compression` <span class="version-mark">v6.5.6、v7.1.3、v7.5.1、および v7.6.0 で追加</span> {#compression-new-in-v656-v713-v751-and-v760}
 
 -   リドゥログファイルを圧縮する動作。
 -   デフォルト値： `""` 、これは圧縮なしを意味します。
 -   値のオプション: `""` 、 `"lz4"`
 
-#### `flush-concurrency`<span class="version-mark">は、v6.5.6、v7.1.3、v7.5.1、およびv7.6.0で追加されました。</span> {#flush-concurrency-new-in-v656-v713-v751-and-v760}
+#### `flush-concurrency` <span class="version-mark">v6.5.6、v7.1.3、v7.5.1、および v7.6.0 で追加</span> {#flush-concurrency-new-in-v656-v713-v751-and-v760}
 
 -   単一のリドゥファイルをアップロードする際の同時実行数。
 -   デフォルト値： `1` 。これは同時実行が無効になっていることを意味します。

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -43,7 +43,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 -   最小値: `1`
 -   最大値: `1048576`
 
-### `temp-dir` <span class="version-mark">v6.3.0 で追加されました。</span> {#temp-dir-new-in-v630}
+### `temp-dir` <span class="version-mark">v6.3.0で追加</span> {#temp-dir-new-in-v630}
 
 -   TiDBが一時データを保存するために使用されるファイルシステム上の場所。機能がTiDBノード内でローカルストレージを必要とする場合、TiDBはこの場所に対応する一時データを保存します。
 -   インデックスを作成する際に、 [`tidb_ddl_enable_fast_reorg`](/system-variables.md#tidb_ddl_enable_fast_reorg-new-in-v630)が有効になっている場合、新しく作成されたインデックスのバックフィルが必要なデータは、まず TiDB のローカル一時ディレクトリに保存され、その後バッチ処理で TiKV にインポートされるため、インデックス作成が高速化されます。
@@ -221,7 +221,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 >
 > -   Kubernetesを使用する場合、デフォルトの[`terminationGracePeriodSeconds`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)は30秒です。
 
-### `enable-global-kill` <span class="version-mark">v6.1.0 で追加されました。</span> {#enable-global-kill-new-in-v610}
+### `enable-global-kill` <span class="version-mark">v6.1.0で追加</span> {#enable-global-kill-new-in-v610}
 
 -   グローバルキル（インスタンスをまたいでクエリや接続を終了する）機能を有効にするかどうかを制御します。
 -   デフォルト値: `true`
@@ -463,7 +463,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 -   [`tidb_auth_token`](/security-compatibility-with-mysql.md#tidb_auth_token)認証方式で使用するJSON Web Key Sets（JWKS）のローカルファイルパスを設定します。
 -   デフォルト値: `""`
 
-### `auth-token-refresh-interval` <span class="version-mark">v6.4.0 で追加されました。</span> {#auth-token-refresh-interval-new-in-v640}
+### `auth-token-refresh-interval` <span class="version-mark">v6.4.0で追加</span> {#auth-token-refresh-interval-new-in-v640}
 
 -   [`tidb_auth_token`](/security-compatibility-with-mysql.md#tidb_auth_token)認証方式のJWKS更新間隔を設定します。
 -   デフォルト値: `1h`
@@ -520,7 +520,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 -   デフォルト値: `5000`
 -   ステートメント数が`stmt-count-limit`を超えた後にトランザクションがロールバックまたはコミットされない場合、TiDB は`statement count 5001 exceeds the transaction limitation, autocommit = false`エラーを返します。この設定は、再試行可能な楽観的トランザクションで**のみ**有効です。悲観的トランザクションを使用している場合、またはトランザクションの再試行を無効にしている場合は、トランザクション内のステートメント数はこの設定によって制限されません。
 
-### `txn-entry-size-limit`<span class="version-mark">は v4.0.10 および v5.0.0 で追加されました。</span> {#txn-entry-size-limit-new-in-v4010-and-v500}
+### `txn-entry-size-limit` <span class="version-mark">v4.0.10 および v5.0.0 で追加</span> {#txn-entry-size-limit-new-in-v4010-and-v500}
 
 -   TiDBにおける単一行データのサイズ制限。
 -   デフォルト値: `6291456` (バイト単位)
@@ -620,7 +620,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 -   デフォルト値: `1000`
 -   現在、有効な値の範囲は`[1, 100000]`です。
 
-### `concurrently-init-stats` <span class="version-mark">v8.1.0 および v7.5.2 で追加されました。</span> {#concurrently-init-stats-new-in-v810-and-v752}
+### `concurrently-init-stats` <span class="version-mark">v8.1.0 および v7.5.2 で追加</span> {#concurrently-init-stats-new-in-v810-and-v752}
 
 -   TiDB の起動時に統計情報を同時に初期化するかどうかを制御します。この設定項目は、 [`lite-init-stats`](#lite-init-stats-new-in-v710)が`false`に設定されている場合にのみ有効になります。
 -   デフォルト値: v8.2.0 より前のバージョンでは`false` 、v8.2.0 以降のバージョンでは`true` 。
@@ -632,7 +632,7 @@ TiDB 構成ファイルは、コマンドライン パラメーターよりも�
 -   `lite-init-stats`の値が`true`の場合、統計情報の初期化では、インデックスと列のヒストグラム、TopN、または Count-Min Sketch はメモリにロードされません。 `lite-init-stats`の値が`false`の場合、統計情報の初期化では、インデックスのヒストグラム、TopN、および Count-Min Sketch はメモリにロードされますが、主キーと列のヒストグラム、TopN、または Count-Min Sketch はメモリにロードされません。オプティマイザが特定の主キーまたは列のヒストグラム、TopN、および Count-Min Sketch を必要とする場合、必要な統計情報は同期または非同期でメモリにロードされます ( [`tidb_stats_load_sync_wait`](/system-variables.md#tidb_stats_load_sync_wait-new-in-v540)で制御)。
 -   `lite-init-stats`を`true`に設定すると、統計情報の初期化が高速化され、不要な統計情報の読み込みを回避することで TiDB のメモリ使用量が削減されます。詳細については、[負荷統計](/statistics.md#load-statistics)を参照してください。
 
-### `force-init-stats` <span class="version-mark">v6.5.7 および v7.1.0 で追加されました。</span> {#force-init-stats-new-in-v657-and-v710}
+### `force-init-stats` <span class="version-mark">v6.5.7 および v7.1.0 で追加</span> {#force-init-stats-new-in-v657-and-v710}
 
 -   TiDBの起動時に、サービスを提供する前に統計情報の初期化が完了するまで待機するかどうかを制御します。
 -   デフォルト値: v7.2.0 より前のバージョンでは`false` 、v7.2.0 以降のバージョンでは`true` 。
@@ -878,7 +878,7 @@ TiDBサービスの状態に関するコンフィグレーション。
 -   [`INFORMATION_SCHEMA.DEADLOCKS`](/information-schema/information-schema-deadlocks.md)テーブルが再試行可能なデッドロック エラーの情報を収集するかどうかを制御します。再試行可能なデッドロック エラーの説明については、 [再試行可能なデッドロックエラー](/information-schema/information-schema-deadlocks.md#retryable-deadlock-errors)を参照してください。
 -   デフォルト値: `false`
 
-### pessimistic-auto-commit は<span class="version-mark">v6.0.0 で追加されました。</span> {#pessimistic-auto-commit-new-in-v600}
+### pessimistic-auto-commit <span class="version-mark">v6.0.0で追加</span> {#pessimistic-auto-commit-new-in-v600}
 
 -   悲観的トランザクション モードがグローバルに有効になっている場合 ( `tidb_txn_mode='pessimistic'` ) に、自動コミット トランザクションが使用するトランザクション モードを決定します。デフォルトでは、悲観的トランザクション モードがグローバルに有効になっていても、自動コミット トランザクションは楽観的トランザクション モードを使用します。 `pessimistic-auto-commit`を有効にすると ( `true` に設定)、自動コミット トランザクションも悲観的モードを使用するようになり、明示的にコミットされた他の悲観的トランザクションと一貫性が保たれます。
 -   競合が発生するシナリオでは、この設定を有効にすると、TiDB は自動コミットトランザクションをグローバルロック待機管理に組み込み、デッドロックを回避し、デッドロックを引き起こす競合によって発生するレイテンシーの急増を軽減します。
@@ -981,7 +981,7 @@ TiDBサービスの状態に関するコンフィグレーション。
 -   この設定値は、システム変数[`tidb_enable_ddl`](/system-variables.md#tidb_enable_ddl-new-in-v630)の値を初期化します。
 -   v6.3.0より前は、この設定は`run-ddl`によって設定されます。
 
-### `tidb_enable_stats_owner` <span class="version-mark">v8.4.0 で追加されました。</span> {#tidb_enable_stats_owner-new-in-v840}
+### `tidb_enable_stats_owner` <span class="version-mark">v8.4.0で追加</span> {#tidb_enable_stats_owner-new-in-v840}
 
 -   この構成は、対応する TiDB インスタンスが[統計情報の自動更新](/statistics.md#automatic-update)タスクを実行できるかどうかを制御します。
 -   デフォルト値: `true`
@@ -1007,7 +1007,7 @@ TiDBサービスの状態に関するコンフィグレーション。
 -   明細書の要約データの永続化が有効になっている場合、この設定では永続データが書き込まれるファイルを指定します。
 -   デフォルト値: `tidb-statements.log`
 
-### `tidb_stmt_summary_file_max_days` <span class="version-mark">v6.6.0 で追加されました。</span> {#tidb_stmt_summary_file_max_days-new-in-v660}
+### `tidb_stmt_summary_file_max_days` <span class="version-mark">v6.6.0で追加</span> {#tidb_stmt_summary_file_max_days-new-in-v660}
 
 > **Warning:**
 >
@@ -1018,7 +1018,7 @@ TiDBサービスの状態に関するコンフィグレーション。
 -   単位：日
 -   データ保持要件とディスク容量の使用状況に基づいて値を調整できます。
 
-### `tidb_stmt_summary_file_max_size` <span class="version-mark">v6.6.0 で追加されました。</span> {#tidb_stmt_summary_file_max_size-new-in-v660}
+### `tidb_stmt_summary_file_max_size` <span class="version-mark">v6.6.0で追加</span> {#tidb_stmt_summary_file_max_size-new-in-v660}
 
 > **Warning:**
 >

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -843,7 +843,7 @@ Raftstoreに関連するコンフィグレーション項目。
 -   デフォルト値: `"30s"`
 -   最小値: `0`
 
-### `max-apply-unpersisted-log-limit` <span class="version-mark">v8.1.0 で追加されました。</span> {#max-apply-unpersisted-log-limit-new-in-v810}
+### `max-apply-unpersisted-log-limit` <span class="version-mark">v8.1.0で追加</span> {#max-apply-unpersisted-log-limit-new-in-v810}
 
 -   適用可能な、コミット済みだが永続化されていないRaftログの最大数。
 
@@ -1187,7 +1187,7 @@ Raftstoreに関連するコンフィグレーション項目。
     -   `periodic-full-compact-start-times = ["03:00 +0800", "23:00 +0800"]`は、TiKVがUTC+08:00タイムゾーンで毎日午前3時と午後11時に完全な圧縮を実行することを示しています。
 -   デフォルト値: `[]`は、定期的な完全圧縮がデフォルトで無効になっていることを意味します。
 
-### `periodic-full-compact-start-max-cpu`<span class="version-mark">は v7.6.0 で追加されました。</span> {#periodic-full-compact-start-max-cpu-new-in-v760}
+### `periodic-full-compact-start-max-cpu` <span class="version-mark">v7.6.0で追加</span> {#periodic-full-compact-start-max-cpu-new-in-v760}
 
 -   TiKVの定期的な完全圧縮におけるCPU使用率の上限を制限します。
 -   デフォルト値: `0.1` 、定期的な圧縮処理の最大 CPU 使用率が 10% であることを意味します。
@@ -1197,7 +1197,7 @@ Raftstoreに関連するコンフィグレーション項目。
 -   フォロワーが読み取りリクエストを処理する際に、遅延が許容されるログの最大数。この制限を超えると、読み取りリクエストは拒否されます。
 -   デフォルト値: `100`
 
-### `inspect-cpu-util-thd` <span class="version-mark">v7.6.0 で追加されました。</span> {#inspect-cpu-util-thd-new-in-v760}
+### `inspect-cpu-util-thd` <span class="version-mark">v7.6.0で追加</span> {#inspect-cpu-util-thd-new-in-v760}
 
 -   低速ノード検出時に、TiKVノードがビジー状態かどうかを判断するためのCPU使用率のしきい値。
 -   値の範囲: `[0, 1]`
@@ -1495,7 +1495,7 @@ RocksDBに関連するコンフィグレーション項目
 -   RocksDBのログレベル
 -   デフォルト値: `"info"`
 
-### `write-buffer-flush-oldest-first`<span class="version-mark">は v6.6.0 で追加されました。</span> {#write-buffer-flush-oldest-first-new-in-v660}
+### `write-buffer-flush-oldest-first` <span class="version-mark">v6.6.0で追加</span> {#write-buffer-flush-oldest-first-new-in-v660}
 
 > **Warning:**
 >
@@ -1508,7 +1508,7 @@ RocksDBに関連するコンフィグレーション項目
     -   `false` : データ量が最も大きい`memtable`が SST ファイルに書き込まれます。
     -   `true` : 最も早い`memtable`が SST ファイルに書き込まれます。この戦略により`memtable`からコールドデータを消去できるため、コールドデータとホットデータが明確に存在するシナリオに適しています。
 
-### `write-buffer-limit` <span class="version-mark">v6.6.0 で追加されました。</span> {#write-buffer-limit-new-in-v660}
+### `write-buffer-limit` <span class="version-mark">v6.6.0で追加</span> {#write-buffer-limit-new-in-v660}
 
 > **Warning:**
 >
@@ -1523,7 +1523,7 @@ RocksDBに関連するコンフィグレーション項目
 
 -   単位：KiB｜MiB｜GiB
 
-### `track-and-verify-wals-in-manifest` <span class="version-mark">、v6.5.9、v7.1.5、v7.5.2、v8.0.0 で新しく追加されました。</span> {#track-and-verify-wals-in-manifest-new-in-v659-v715-v752-and-v800}
+### `track-and-verify-wals-in-manifest` <span class="version-mark">v6.5.9、v7.1.5、v7.5.2、および v8.0.0 で追加</span> {#track-and-verify-wals-in-manifest-new-in-v659-v715-v752-and-v800}
 
 -   RocksDB MANIFEST ファイルに先行書き込みログ (WAL) ファイルに関する情報を記録するかどうか、および起動時に WAL ファイルの整合性を検証するかどうかを制御します。詳細については、RocksDB [マニフェストでWALを追跡する](https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST)を参照してください。
 -   デフォルト値: `true`
@@ -1531,7 +1531,7 @@ RocksDBに関連するコンフィグレーション項目
     -   `true` : WAL ファイルに関する情報を MANIFEST ファイルに記録し、起動時に WAL ファイルの整合性を検証します。
     -   `false` : WAL ファイルに関する情報を MANIFEST ファイルに記録せず、起動時に WAL ファイルの整合性を検証しません。
 
-### `enable-multi-batch-write` <span class="version-mark">v6.2.0 で追加されました。</span> {#enable-multi-batch-write-new-in-v620}
+### `enable-multi-batch-write` <span class="version-mark">v6.2.0で追加</span> {#enable-multi-batch-write-new-in-v620}
 
 -   RocksDBの書き込み最適化を有効にするかどうかを制御します。有効にすると、WriteBatchの内容をmemtableに同時に書き込むことができ、書き込みレイテンシーが削減されます。
 -   デフォルト値：なし。ただし、 `false`に明示的に設定するか、 `rocksdb.enable-pipelined-write`または`rocksdb.enable-unordered-write`が有効になっている場合を除き、デフォルトで有効になります。
@@ -2337,7 +2337,7 @@ TiDB LightningのインポートおよびBR復元に関連するコンフィグ�
 -   GCをトリガーするガベージ比率のしきい値。
 -   デフォルト値: `1.1`
 
-### `num-threads` <span class="version-mark">、v6.5.8、v7.1.4、v7.5.1、v7.6.0 で追加されました。</span> {#num-threads-new-in-v658-v714-v751-and-v760}
+### `num-threads` <span class="version-mark">v6.5.8、v7.1.4、v7.5.1、および v7.6.0 で追加</span> {#num-threads-new-in-v658-v714-v751-and-v760}
 
 -   `enable-compaction-filter`が`false`の場合の GC スレッドの数。
 -   デフォルト値: `1`
@@ -2346,12 +2346,12 @@ TiDB LightningのインポートおよびBR復元に関連するコンフィグ�
 
 TiKVの自動圧縮の動作を設定します。
 
-### `check-interval` <span class="version-mark">v7.5.7およびv8.5.4で追加されました。</span> {#check-interval-new-in-v757-and-v854}
+### `check-interval` <span class="version-mark">v7.5.7 および v8.5.4 で追加</span> {#check-interval-new-in-v757-and-v854}
 
 -   TiKVが自動圧縮をトリガーするかどうかを確認する間隔。この間隔内では、自動圧縮条件を満たすリージョンが優先度に基づいて処理されます。間隔が経過すると、TiKVはリージョン情報を再スキャンし、優先度を再計算します。
 -   デフォルト値: `"300s"`
 
-### `tombstone-num-threshold`<span class="version-mark">は v7.5.7 および v8.5.4 で追加されました。</span> {#tombstone-num-threshold-new-in-v757-and-v854}
+### `tombstone-num-threshold` <span class="version-mark">v7.5.7 および v8.5.4 で追加</span> {#tombstone-num-threshold-new-in-v757-and-v854}
 
 -   TiKVの自動圧縮をトリガーするために必要なRocksDBのtombstoneの数。tombstoneの数がこのしきい値に達するか、tombstoneの割合が[`tombstone-percent-threshold`](#tombstone-percent-threshold-new-in-v757-and-v854)に達すると、TiKVは自動圧縮をトリガーします。
 -   この設定項目は[圧縮フィルター](/garbage-collection-configuration.md)が無効な場合にのみ有効になります。
@@ -2498,7 +2498,7 @@ BRバックアップに関連するコンフィグレーション項目。
 -   デフォルト値：CPU * 0.5
 -   値の範囲：[2, 12]
 
-### `temp-path` <span class="version-mark">v6.2.0 で追加されました。</span> {#temp-path-new-in-v620}
+### `temp-path` <span class="version-mark">v6.2.0で追加</span> {#temp-path-new-in-v620}
 
 -   ログファイルが外部ストレージに書き込まれる前に一時的に保存されるパス。
 -   デフォルト値: `${deploy-dir}/data/log-backup-temp`


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Normalizes 24 "New in vX.Y.Z" heading spans across `tidb-configuration-file.md`, `tikv-configuration-file.md`, and `ticdc/ticdc-changefeed-config.md` to match the dominant, already-correct form used by 55+ sibling headings in the same files:

- Verbose "vX.Y.Zで追加されました。" (with trailing period, and an extra space before で追加 for single-version cases) shortened to the established "vX.Y.Zで追加" form.
- Removed a stray leading は particle before the `<span>` on 5 headings (e.g. `` pessimistic-auto-commit は<span ...> `` → `` pessimistic-auto-commit <span ...> ``) and a stray leading 、 on 2 multi-version headings.
- For 4+ multi-version headings that only used 、 between all versions (missing the final および connector) or omitted spacing entirely, normalized to the established "vA、vB、および vC で追加" / "vA および vB で追加" conventions.
- Fixed one corrupted heading+anchor pair (`` #### sink.csv は<span class="version-mark">... `` had auto-generated the broken anchor `{#sink-csv-span-class-version-mark-new-in-v6-5-0-span}` from its own malformed text) — restored the heading text and gave it a clean anchor; verified no inbound links reference the old broken anchor anywhere in the corpus, so nothing else needed updating.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch