### PR TITLE
i18n(ja): fix changefeed capacity heading, states mistranslation, and status/state term drift

### DIFF
--- a/TOC-tidb-cloud-essential.md
+++ b/TOC-tidb-cloud-essential.md
@@ -552,7 +552,7 @@
   - [TiDB X インスタンスで制限される SQL 機能](/tidb-cloud/limited-sql-features-tidb-x.md)
   - [TiDBの制限事項](/tidb-limitations.md)
   - [システム変数](/system-variables.md)
-  - [サーバー状態変数](/status-variables.md)
+  - [サーバーステータス変数](/status-variables.md)
   - [テーブルフィルター](/table-filter.md)
   - [外部ストレージサービスのURI形式](/external-storage-uri.md)
   - [データとインデックス間の不整合のトラブルシューティング](/troubleshoot-data-inconsistency-errors.md)

--- a/TOC-tidb-cloud-premium.md
+++ b/TOC-tidb-cloud-premium.md
@@ -470,7 +470,7 @@
   - [TiDB X インスタンスで制限される SQL 機能](/tidb-cloud/limited-sql-features-tidb-x.md)
   - [TiDBの制限事項](/tidb-limitations.md)
   - [システム変数](/system-variables.md)
-  - [サーバー状態変数](/status-variables.md)
+  - [サーバーステータス変数](/status-variables.md)
   - [テーブルフィルター](/table-filter.md)
   - [外部ストレージサービスのURI形式](/external-storage-uri.md)
   - [DDL ステートメントに埋め込まれた `ANALYZE`](/ddl_embedded_analyze.md)

--- a/TOC-tidb-cloud-starter.md
+++ b/TOC-tidb-cloud-starter.md
@@ -539,7 +539,7 @@
   - [TiDB X インスタンスでの制限付き SQL 機能](/tidb-cloud/limited-sql-features-tidb-x.md)
   - [TiDBの制限事項](/tidb-limitations.md)
   - [システム変数](/system-variables.md)
-  - [サーバー状態変数](/status-variables.md)
+  - [サーバーステータス変数](/status-variables.md)
   - [テーブルフィルター](/table-filter.md)
   - [外部ストレージサービスのURI形式](/external-storage-uri.md)
   - [データとインデックス間の不整合のトラブルシューティング](/troubleshoot-data-inconsistency-errors.md)

--- a/TOC-tidb-cloud.md
+++ b/TOC-tidb-cloud.md
@@ -613,7 +613,7 @@
       - [TPC-C性能試験報告書](/tidb-cloud/v6.5-performance-benchmarking-with-tpcc.md)
       - [Sysbenchパフォーマンステストレポート](/tidb-cloud/v6.5-performance-benchmarking-with-sysbench.md)
   - [システム変数](/system-variables.md)
-  - [サーバー状態変数](/status-variables.md)
+  - [サーバーステータス変数](/status-variables.md)
   - [テーブルフィルター](/table-filter.md)
   - [外部ストレージサービスのURI形式](/external-storage-uri.md)
   - [DDLステートメントに埋め込まれた`ANALYZE`](/ddl_embedded_analyze.md)

--- a/TOC.md
+++ b/TOC.md
@@ -27,7 +27,7 @@
     - [ハイブリッドトポロジー](/hybrid-deployment-topology.md)
   - [TiUPを使用してデプロイ](/production-deployment-using-tiup.md)
   - [Kubernetesにデプロイ](/tidb-in-kubernetes.md)
-  - [クラスタの状態を確認する](/post-installation-check.md)
+  - [クラスタのステータスを確認する](/post-installation-check.md)
   - テストクラスタのパフォーマンス
     - [Sysbenchを使用してTiDBをテストする](/benchmark/benchmark-tidb-using-sysbench.md)
     - [TPC-Cを使用してTiDBをテストする](/benchmark/benchmark-tidb-using-tpcc.md)
@@ -601,7 +601,7 @@
     - [TiDB グローバルソート](/tidb-global-sort.md)
   - [システム変数](/system-variables.md)
   - [システム変数リファレンス](/system-variable-reference.md)
-  - [サーバー状態変数](/status-variables.md)
+  - [サーバーステータス変数](/status-variables.md)
   - コンフィグレーションファイルパラメータ
     - [tidb-server](/tidb-configuration-file.md)
     - [tikvサーバー](/tikv-configuration-file.md)

--- a/tidb-cloud/changefeed-overview.md
+++ b/tidb-cloud/changefeed-overview.md
@@ -56,24 +56,24 @@ TiDB Cloud changefeed を使用すると、 TiDB Cloudから他のデータサ�
 
 </CustomContent>
 
-## クエリ変更フィード容量 {#query-changefeed-capacity}
+## 変更フィードの容量をクエリする {#query-changefeed-capacity}
 
 <CustomContent plan="dedicated">
 
 TiDB Cloud Dedicatedでは、変更フィードの TiCDC レプリケーション容量ユニット (RCU) を照会できます。
 
 1.  ターゲットのTiDB Cloud Dedicatedクラスターの[**変更フィード**](#view-the-changefeed-page)ページに移動します。
-2.  クエリを実行したい対応する変更フィードを見つけて、 **[アクション]**列の**[...]** &gt; **[ビュー]**をクリックします。
+2.  確認したい対応する変更フィードを見つけて、 **[アクション]**列の**[...]** &gt; **[ビュー]**をクリックします。
 3.  現在のTiCDCレプリケーション容量ユニット（RCU）は、ページの**仕様**欄で確認できます。
 
 </CustomContent>
 <CustomContent plan="premium">
 
-TiDB Cloud Premiumでは、チェンジフィードのTiCDC Changefeed容量ユニット（CCU）を照会できます。
+TiDB Cloud Premiumでは、チェンジフィードのTiCDC 変更フィード容量ユニット（CCU）を照会できます。
 
 1.  ターゲットのTiDB Cloud Premium インスタンスの[**変更フィード**](#view-the-changefeed-page)ページに移動します。
-2.  クエリを実行したい対応する変更フィードを見つけて、 **[アクション]**列の**[...]** &gt; **[ビュー]**をクリックします。
-3.  TiCDC Changefeedの現在の容量ユニット（CCU）は、ページの**仕様**欄で確認できます。
+2.  確認したい対応する変更フィードを見つけて、 **[アクション]**列の**[...]** &gt; **[ビュー]**をクリックします。
+3.  TiCDC 変更フィードの現在の容量ユニット（CCU）は、ページの**仕様**欄で確認できます。
 
 </CustomContent>
 
@@ -91,7 +91,7 @@ TiDB Cloud Premiumでは、チェンジフィードのTiCDC Changefeed容量ユ�
 </CustomContent>
 <CustomContent plan="premium">
 
-チェンジフィードのTiCDC Changefeed容量ユニット（CCU）は、チェンジフィードのスケールアップまたはスケールダウンによって変更できます。
+チェンジフィードのTiCDC 変更フィード容量ユニット（CCU）は、チェンジフィードのスケールアップまたはスケールダウンによって変更できます。
 
 </CustomContent>
 
@@ -158,7 +158,7 @@ TiDB Cloudでの変更フィードの請求については、[Changefeedの請�
 
 レプリケーションタスクの状態は、その実行中の状態を表します。実行中に、レプリケーションタスクはエラーで失敗したり、手動で一時停止または再開されたりすることがあります。これらの動作によって、レプリケーションタスクの状態が変化する可能性があります。
 
-各州は以下のように説明されます。
+状態は以下のように説明されます。
 
 -   `CREATING` : レプリケーションタスクが作成されています。
 -   `RUNNING` : レプリケーション タスクは正常に実行され、チェックポイント ts も正常に進行します。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

**`tidb-cloud/changefeed-overview.md`**:
- `## Query changefeed capacity` was translated as a broken word-for-word transliteration (クエリ変更フィード容量, no particles), breaking from this document's own consistent heading pattern ([Object]を[Verb]する, e.g. 変更フィードを作成する). Reworded to 変更フィードの容量をクエリする.
- Within that same section, "query" was translated two different ways for the identical EN word: 照会 (inquire/check) in the intro sentence vs クエリを実行 (execute a query, the SQL-query sense) in step 2. Unified to the checking-a-value sense.
- "TiCDC Changefeed Capacity Units (CCUs)" left "Changefeed" untranslated in 3 places while the parallel dedicated-tier term correctly translates "Replication" (TiCDC レプリケーション容量ユニット). Unified to TiCDC 変更フィード容量ユニット, matching this document's own changefeed→変更フィード convention.
- "The states are described as follows" was mistranslated as 各州 (each US-style state/province) instead of 状態 (state/condition) — a false-friend error with no sensible meaning in a changefeed-state-machine context.

**TOC files** (`TOC.md` and the 4 tidb-cloud plan variants): two navigation labels used 状態 (state) while the linked page's own title uses ステータス (status, katakana) for the same English word — サーバー状態変数 vs `status-variables.md`'s own サーバーステータス変数, and クラスタの状態を確認する vs `post-installation-check.md`'s own クラスタのステータスを確認する. Unified the TOC labels to match each target page's own established term.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch