### PR TITLE
i18n(ja): restore literal FLUSH STATUS command name instead of a katakana transliteration

### DIFF
--- a/status-variables.md
+++ b/status-variables.md
@@ -9,7 +9,7 @@ summary: ステータス変数を使用してシステムとセッションの�
 
 [グローバルステータスを表示](/sql-statements/sql-statement-show-status.md)コマンドを使用してグローバル ステータスを取得し、 [セッションステータスを表示](/sql-statements/sql-statement-show-status.md)コマンドを使用して現在のセッションのステータスを取得できます。
 
-さらに、MySQL との互換性のために[フラッシュステータス](/sql-statements/sql-statement-flush-status.md)コマンドがサポートされています。
+さらに、MySQL との互換性のために[FLUSH STATUS](/sql-statements/sql-statement-flush-status.md)コマンドがサポートされています。
 
 ## 変数参照 {#variable-reference}
 

--- a/status-variables.md
+++ b/status-variables.md
@@ -7,7 +7,7 @@ summary: ステータス変数を使用してシステムとセッションの�
 
 サーバーステータス変数は、サーバーのグローバルステータスとTiDBの現在のセッションステータスに関する情報を提供します。これらの変数のほとんどはMySQLと互換性があるように設計されています。
 
-[グローバルステータスを表示](/sql-statements/sql-statement-show-status.md)コマンドを使用してグローバル ステータスを取得し、 [セッションステータスを表示](/sql-statements/sql-statement-show-status.md)コマンドを使用して現在のセッションのステータスを取得できます。
+[SHOW GLOBAL STATUS](/sql-statements/sql-statement-show-status.md)コマンドを使用してグローバル ステータスを取得し、 [SHOW SESSION STATUS](/sql-statements/sql-statement-show-status.md)コマンドを使用して現在のセッションのステータスを取得できます。
 
 さらに、MySQL との互換性のために[FLUSH STATUS](/sql-statements/sql-statement-flush-status.md)コマンドがサポートされています。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

In `status-variables.md`, the link anchor text for the `FLUSH STATUS` SQL statement was transliterated into katakana (フラッシュステータス) instead of keeping the literal SQL statement name, unlike every other reference to this command across the corpus (TOC entries, `sql-statements/sql-statement-overview.md`), which all keep it as literal SQL syntax `FLUSH STATUS`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch