### PR TITLE
i18n(ja): restore English CSV Configuration field names

### DIFF
--- a/tidb-cloud/csv-config-for-import-data.md
+++ b/tidb-cloud/csv-config-for-import-data.md
@@ -11,7 +11,7 @@ summary: TiDB Cloudのインポートデータサービスで CSV 構成を使�
 
 <img src="https://docs-download.pingcap.com/media/images/docs/tidb-cloud/import-data-csv-config.png" width="500" />
 
-## セパレーター {#separator}
+## Separator {#separator}
 
 -   定義: フィールドセパレーターを定義します。1文字または複数文字を指定できますが、空にすることはできません。
 
@@ -22,9 +22,9 @@ summary: TiDB Cloudのインポートデータサービスで CSV 構成を使�
 
 -   デフォルト: `,`
 
-## デリミタ {#delimiter}
+## Delimiter {#delimiter}
 
--   定義: 引用符で囲む際に使用する区切り文字を定義します。**区切り文字**が空の場合、すべてのフィールドは引用符で囲まれません。
+-   定義: 引用符で囲む際に使用する区切り文字を定義します。**Delimiter**が空の場合、すべてのフィールドは引用符で囲まれません。
 
 -   共通の値:
 
@@ -33,17 +33,17 @@ summary: TiDB Cloudのインポートデータサービスで CSV 構成を使�
 
 -   デフォルト: `"`
 
-## NULL値 {#null-value}
+## Null Value {#null-value}
 
 -   定義: CSV ファイル内の`NULL`値を表す文字列を定義します。
 
 -   デフォルト: `\N`
 
-## バックスラッシュエスケープ {#backslash-escape}
+## Backslash Escape {#backslash-escape}
 
 -   定義: フィールド内のバックスラッシュをエスケープ文字として解析するかどうかを制御します。**Backslash Escape**が有効になっている場合、以下のシーケンスが認識され、変換されます。
 
-    | シーケンス | 変換された                    |
+    | シーケンス | 変換後                    |
     | ----- | ------------------------ |
     | `\0`  | ヌル文字（ `U+0000` ）         |
     | `\b`  | バックスペース ( `U+0008` )     |
@@ -73,7 +73,7 @@ summary: TiDB Cloudのインポートデータサービスで CSV 構成を使�
 
 -   デフォルト: 有効
 
-## ヘッダーをスキップ {#skip-header}
+## Skip Header {#skip-header}
 
 -   定義: CSVファイルのヘッダー行をスキップするかどうかを制御します。 **Skip Header**が有効になっている場合、インポート時にCSVファイルの最初の行がスキップされます。
 

--- a/tidb-cloud/migrate-sql-shards.md
+++ b/tidb-cloud/migrate-sql-shards.md
@@ -221,7 +221,7 @@ Amazon S3へのアクセスを設定した後、 TiDB Cloudコンソールで次
 
 6.  必要に応じてCSV設定を編集してください。
 
-    また、 **Edit CSV configuration**をクリックすると、バックスラッシュエスケープ、セパレータ、区切り文字を設定して、より詳細な制御を行うことができます。
+    また、 **Edit CSV configuration**をクリックすると、Backslash Escape、Separator、Delimiterを設定して、より詳細な制御を行うことができます。
 
     > **Note:**
     >

--- a/tidb-cloud/tidb-cloud-import-local-files.md
+++ b/tidb-cloud/tidb-cloud-import-local-files.md
@@ -72,7 +72,7 @@ summary: ローカル ファイルをTiDB Cloud Starter にインポートする
 
 7.  必要に応じて CSV 構成を編集します。
 
-    **Edit CSV configuration**をクリックすると、バックスラッシュエスケープ、セパレーター、区切り文字を設定して、よりきめ細かな制御を行うことができます。CSV設定の詳細については、 [データのインポートのためのCSV構成](/tidb-cloud/csv-config-for-import-data.md)を参照してください。
+    **Edit CSV configuration**をクリックすると、Backslash Escape、Separator、Delimiterを設定して、よりきめ細かな制御を行うことができます。CSV設定の詳細については、 [データのインポートのためのCSV構成](/tidb-cloud/csv-config-for-import-data.md)を参照してください。
 
 8.  **Start Import**をクリックします。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

`csv-config-for-import-data.md` documents the literal field names shown in TiDB Cloud's CSV Configuration window (Separator, Delimiter, Null Value, Backslash Escape, Skip Header) — all confirmed as genuine UI labels via `tidbcloud/dbaas-ui` (`dbaas/screens/DataImportV2/CSVConfiguration.tsx`, each rendered as its own `<Typography variant="label-lg">` field label). These were translated into Japanese instead of kept in English, both in the section headings and their inline body references.

Also fixed the same "Edit CSV configuration" button + field-name list in `tidb-cloud-import-local-files.md` and `migrate-sql-shards.md`, and a column-header fluency issue in the Backslash Escape sequence table (変換された → 変換後).

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch