### PR TITLE
i18n(ja): fix HTML strong-tag leaks, bastion node term, and misc MT defects

### DIFF
--- a/dashboard/dashboard-faq.md
+++ b/dashboard/dashboard-faq.md
@@ -25,7 +25,7 @@ summary: このドキュメントは、TiDB Dashboardに関するよくある質
 
 ## UIに関するよくあるFAQ {#ui-related-faq}
 
-### 概要ページの<strong>QPS</strong>と<strong>レイテンシの</strong>セクションに`prometheus_not_found`エラーが表示される {#a-prometheus_not_found-error-is-shown-in-qps-and-latency-sections-on-the-overview-page}
+### 概要ページの**QPS**と**レイテンシの**セクションに`prometheus_not_found`エラーが表示される {#a-prometheus_not_found-error-is-shown-in-qps-and-latency-sections-on-the-overview-page}
 
 **概要**ページの**QPS**と**レイテンシの**セクションには、Prometheusがデプロイされたクラスターが必要です。そうでない場合、エラーが表示されます。この問題を解決するには、クラスターにPrometheusインスタンスをデプロイしてください。
 
@@ -50,7 +50,7 @@ Prometheusインスタンスをデプロイしてもこの問題が引き続き�
 
     クラスタが起動している場合でも、このコマンドを実行してください。このコマンドはクラスタ内の通常のアプリケーションには影響を与えませんが、メトリクスアドレスを更新してレポートするため、TiDB Dashboardに監視メトリクスが正常に表示されるようになります。
 
-### <strong>スロークエリ</strong>ページに`invalid connection`エラーが表示されます {#an-invalid-connection-error-is-shown-on-the-slow-queries-page}
+### **スロークエリ**ページに`invalid connection`エラーが表示されます {#an-invalid-connection-error-is-shown-on-the-slow-queries-page}
 
 原因として考えられるのは、TiDBのプリペアドプランキャッシュ機能を有効にしていることです。これは実験的機能であるため、有効にすると特定のTiDBバージョンでプリペアドプランキャッシュが正常に機能しない可能性があり、TiDB Dashboard（およびその他のアプリケーション）でこの問題が発生する可能性があります。プリペアドプランキャッシュを無効にするには、システム変数[`tidb_enable_prepared_plan_cache = OFF`](/system-variables.md#tidb_enable_prepared_plan_cache-new-in-v610)を設定します。
 
@@ -127,7 +127,7 @@ tiup update playground
 
 </details>
 
-### <strong>スロークエリ</strong>ページに`unknown field`エラーが表示されます {#an-unknown-field-error-is-shown-on-the-slow-queries-page}
+### **スロークエリ**ページに`unknown field`エラーが表示されます {#an-unknown-field-error-is-shown-on-the-slow-queries-page}
 
 クラスターのアップグレード後に**「スロークエリ」**ページにエラー`unknown field`が表示される場合、そのエラーはTiDB Dashboardのサーバーフィールド（更新される可能性があります）とユーザー設定フィールド（ブラウザキャッシュ内）の差異に起因する互換性の問題に関連しています。この問題は修正されています。クラスターのバージョンがv5.0.3またはv4.0.14より前の場合は、以下の手順に従ってブラウザキャッシュをクリアしてください。
 

--- a/releases/release-5.0.0.md
+++ b/releases/release-5.0.0.md
@@ -84,7 +84,7 @@ TiDB バージョン: 5.0.0
 
 ### SQL {#sql}
 
-#### List パーティショニング（<strong>Experimental</strong>） {#list-partitioning-strong-experimental-strong}
+#### List パーティショニング（**Experimental**） {#list-partitioning-experimental}
 
 [ユーザー向けドキュメント](/partitioned-table.md#list-partitioning)
 
@@ -94,7 +94,7 @@ TiDB バージョン: 5.0.0
 
 リストパーティショニングを有効にするには、セッション変数[`tidb_enable_list_partition`](/system-variables.md#tidb_enable_list_partition-new-in-v50) `ON`に設定します。
 
-#### List COLUMNS パーティショニング（<strong>Experimental</strong>） {#list-columns-partitioning-strong-experimental-strong}
+#### List COLUMNS パーティショニング（**Experimental**） {#list-columns-partitioning-experimental}
 
 [ユーザー向けドキュメント](/partitioned-table.md#list-columns-partitioning)
 
@@ -318,7 +318,7 @@ TiDBがガベージコレクション（GC）とデータ圧縮を実行する�
 
 GC の CPU および I/O リソースの消費を削減するために、GC コンパクション フィルタ機能は、これら 2 つのタスクを 1 つに結合し、同じタスクで実行します。この機能はデフォルトで有効になっています。 `gc.enable-compaction-filter = false`を設定することで無効にできます。
 
-#### TiFlashは、圧縮とデータソートにおけるI/Oリソースの使用を制限します（<strong>実験的機能</strong>）。 {#tiflash-limits-the-compression-and-data-sorting-s-use-of-i-o-resources-strong-experimental-feature-strong}
+#### TiFlashは、圧縮とデータソートにおけるI/Oリソースの使用を制限します（**実験的機能**）。 {#tiflash-limits-the-compression-and-data-sorting-s-use-of-i-o-resources-experimental-feature}
 
 この機能は、バックグラウンドタスクとフォアグラウンドの読み書き処理の間で発生するI/Oリソースの競合を軽減します。
 
@@ -398,7 +398,7 @@ TiDB Lightningは、特にAWS T1.standard構成（または同等の構成）の
 
 ## データ共有と購読 {#data-sharing-and-subscription}
 
-### TiCDCを使用してTiDBをKafka Connect（Confluent Platform）に統合する（<strong>実験的機能</strong>） {#integrate-tidb-to-kafka-connect-confluent-platform-using-ticdc-strong-experimental-feature-strong}
+### TiCDCを使用してTiDBをKafka Connect（Confluent Platform）に統合する（**実験的機能**） {#integrate-tidb-to-kafka-connect-confluent-platform-using-ticdc-experimental-feature}
 
 [ユーザー向けドキュメント](/ticdc/integrate-confluent-using-ticdc.md) [#660](https://github.com/pingcap/tiflow/issues/660)
 

--- a/tidb-cloud/setup-self-hosted-kafka-private-service-connect.md
+++ b/tidb-cloud/setup-self-hosted-kafka-private-service-connect.md
@@ -91,7 +91,7 @@ Kafka クラスターを簡単に構成できるように、Kafka VPC 用に 2 �
 
 VM をプロビジョニングするには、 [VMインスタンス](https://console.cloud.google.com/compute/instances)ページに移動します。
 
-1.  バスティオンノード
+1.  要塞ノード
 
     -   **名前**: `bastion-node`
     -   **リージョン**: `us-west1`


### PR DESCRIPTION
## Summary
- Convert leaked `<strong>...</strong>` HTML tags to markdown `**` in `release-5.0.0.md` (4 headings) and `dashboard-faq.md` (3 headings), matching EN's own markdown bold syntax. Also fixes 4 corrupted anchor slugs in `release-5.0.0.md` that had baked in the literal "strong" text (verified no inbound links to the old anchors exist corpus-wide).
- Unify the sole バスティオンノード outlier to 要塞ノード in `setup-self-hosted-kafka-private-service-connect.md` (32 other occurrences already use 要塞ノード).

Two smaller fixes originally bundled here were moved out during review to avoid conflicting with #23541 (which independently rewrites the same lines):
- The missing `。` after backtick-quoted values in `setup-aws-self-hosted-kafka-private-link-service.md` was pushed directly onto the #23541 branch instead.
- The "Bucket owner enforced" term-inconsistency fix in `troubleshoot-import-access-denied-error.md` is already resolved by #23541's English-label conversion of the same spans.

## Test plan
- [ ] Verified no inbound links to the 4 renamed anchors exist anywhere in the corpus
- [ ] Verified EN source uses markdown `**` (not HTML `<strong>`) at all touched headings
- [ ] Confirmed 0 merge conflicts against 15 open sibling ja PR branches via `git merge-tree`