### PR TITLE
i18n(ja): fix Load balancer type adjacent-bold-span defect

### DIFF
--- a/tidb-cloud/migrate-from-mysql-using-data-migration.md
+++ b/tidb-cloud/migrate-from-mysql-using-data-migration.md
@@ -409,7 +409,7 @@ AWS は RDS またはAuroraへの PrivateLink による直接アクセスをサ�
 
 2.  [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、左側のナビゲーションペインの**[エンドポイント サービス]**をクリックし、 **Create endpoint service**をクリックします。次の設定を構成します。
 
-    -   **Load balancer type**を**「ネットワーク」**に設定し、前の手順で作成したNLBを選択します。**Available load balancers**リストが空の場合は、NLBが**アクティブ**状態になるまで待ってから、リストの横にある更新アイコンをクリックします。
+    -   **Load balancer type**を**Network**に設定し、前の手順で作成したNLBを選択します。**Available load balancers**リストが空の場合は、NLBが**アクティブ**状態になるまで待ってから、リストの横にある更新アイコンをクリックします。
     -   **承認が必要**：有効（デフォルト）。
     -   **Supported IP address types**： **IPv4**を選択してください。
 
@@ -495,7 +495,7 @@ AWS は RDS またはAuroraへの PrivateLink による直接アクセスをサ�
 
 2.  [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、左側のナビゲーションペインの**[エンドポイント サービス]**をクリックし、 **Create endpoint service**をクリックします。次の設定を構成します。
 
-    -   **Load balancer type**を**「ネットワーク」**に設定し、前の手順で作成したNLBを選択します。**Available load balancers**リストが空の場合は、NLBが**アクティブ**状態になるまで待ってから、リストの横にある更新アイコンをクリックします。
+    -   **Load balancer type**を**Network**に設定し、前の手順で作成したNLBを選択します。**Available load balancers**リストが空の場合は、NLBが**アクティブ**状態になるまで待ってから、リストの横にある更新アイコンをクリックします。
     -   **承認が必要**：有効（デフォルト）。
     -   **Supported IP address types**： **IPv4**を選択してください。
 


### PR DESCRIPTION
## Summary
EN: "**Load balancer type**: **Network**, and select the NLB created in the previous step. If the **Available load balancers** list is empty, wait until the NLB shows the **Active** state..."

JA had merged `Load balancer type` and `Network` into two adjacent `**bold**` spans with no space between them (part of the deferred adjacent-bold-span defect class), and left `Available load balancers` partially untranslated. Restored both confirmed English labels; kept アクティブ (Active) as-is, matching the established corpus-wide convention for that status word. Same duplicated paragraph appears twice in the file (AWS and Google Cloud RDS/Aurora sections), fixed both.

## Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

## What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch