### PR TITLE
docs: remove unnecessary Statement suffix from view links

### DIFF
--- a/develop/dev-guide-use-views.md
+++ b/develop/dev-guide-use-views.md
@@ -119,8 +119,8 @@ For limitations of views in TiDB, see [Limitations of Views](/views.md#limitatio
 ## Read More
 
 - [Views](/views.md)
-- [CREATE VIEW Statement](/sql-statements/sql-statement-create-view.md)
-- [DROP VIEW Statement](/sql-statements/sql-statement-drop-view.md)
+- [CREATE VIEW](/sql-statements/sql-statement-create-view.md)
+- [DROP VIEW](/sql-statements/sql-statement-drop-view.md)
 - [EXPLAIN Statements Using Views](/explain-views.md)
 - [TiFlink: Strongly Consistent Materialized Views Using TiKV and Flink](https://github.com/tiflink/tiflink)
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

`develop/dev-guide-use-views.md`'s Read More section links to the CREATE VIEW and DROP VIEW statement pages using the text `CREATE VIEW Statement` / `DROP VIEW Statement`. The linked pages' own titles/H1s are just `CREATE VIEW` and `DROP VIEW` (no "Statement" suffix). Dropped the redundant "Statement" suffix so the link text matches the target page's title.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): same wording issue also exists on `master`, not fixed here per request to target release-8.5 only

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch