### PR TITLE
dm: fix gh-ost and pt-osc casing

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -454,7 +454,7 @@
         - [Pessimistic Mode](/dm/feature-shard-merge-pessimistic.md)
         - [Optimistic Mode](/dm/feature-shard-merge-optimistic.md)
         - [Manually Handle Sharding DDL Lock](/dm/manually-handling-sharding-ddl-locks.md)
-      - [Migrate from MySQL Databases that Use GH-ost/PT-osc](/dm/feature-online-ddl.md)
+      - [Migrate from MySQL Databases that Use gh-ost/pt-osc](/dm/feature-online-ddl.md)
       - [Migrate Data to a Downstream TiDB Table with More Columns](/migrate-with-more-columns-downstream.md)
       - [Continuous Data Validation](/dm/dm-continuous-data-validation.md)
     - Maintain

--- a/dm/dm-best-practices.md
+++ b/dm/dm-best-practices.md
@@ -196,7 +196,7 @@ There are some restrictions on using the relay log. DM supports high availabilit
 
 #### Use pt-osc/gh-ost in upstream
 
-In daily MySQL operation and maintenance, usually you use tools such as pt-osc/gh-ost to change the schema online to minimize impact on the business. However, the whole process will be logged to MySQL Binlog. Migrating such data to TiDB downstream will result in a lot of unnecessary write operations, which is neither efficient nor economical.
+In daily MySQL operation and maintenance, usually you use tools such as pt-osc/gh-ost to change the schema online to minimize impact on the business. However, the whole process will be logged to MySQL Binlog. Migrating such data to TiDB downstream will result in many unnecessary write operations, which is neither efficient nor economical.
 
 To resolve this issue, DM supports third-party data tools such as pt-osc and gh-ost when you configure the migration task. When you use such tools, DM does not migrate redundant data and ensure data consistency. For details, see [Migrate from Databases that Use gh-ost/pt-osc](/dm/feature-online-ddl.md).
 

--- a/dm/dm-best-practices.md
+++ b/dm/dm-best-practices.md
@@ -194,11 +194,11 @@ In the MySQL master/standby mechanism, the standby node saves a copy of relay lo
 
 There are some restrictions on using the relay log. DM supports high availability. When a DM-worker fails, it will try to promote an idle DM-worker instance to a working instance. If the upstream binlogs do not contain the necessary migration logs, it may cause interruption. You need to intervene manually to copy the relay log to the new DM-worker node as soon as possible, and modify the corresponding relay meta file. For details, see [Troubleshooting](/dm/dm-error-handling.md#the-relay-unit-throws-error-event-from--in--diff-from-passed-in-event--or-a-migration-task-is-interrupted-with-failing-to-get-or-parse-binlog-errors-like-get-binlog-error-error-1236-hy000-and-binlog-checksum-mismatch-data-may-be-corrupted-returned).
 
-#### Use PT-osc/GH-ost in upstream
+#### Use pt-osc/gh-ost in upstream
 
-In daily MySQL operation and maintenance, usually you use tools such as PT-osc/GH-ost to change the schema online to minimize impact on the business. However, the whole process will be logged to MySQL Binlog. Migrating such data to TiDB downstream will result in a lot of unnecessary write operations, which is neither efficient nor economical.
+In daily MySQL operation and maintenance, usually you use tools such as pt-osc/gh-ost to change the schema online to minimize impact on the business. However, the whole process will be logged to MySQL Binlog. Migrating such data to TiDB downstream will result in a lot of unnecessary write operations, which is neither efficient nor economical.
 
-To resolve this issue, DM supports third-party data tools such as PT-osc and GH-ost when you configure the migration task. When you use such tools, DM does not migrate redundant data and ensure data consistency. For details, see [Migrate from Databases that Use GH-ost/PT-osc](/dm/feature-online-ddl.md).
+To resolve this issue, DM supports third-party data tools such as pt-osc and gh-ost when you configure the migration task. When you use such tools, DM does not migrate redundant data and ensure data consistency. For details, see [Migrate from Databases that Use gh-ost/pt-osc](/dm/feature-online-ddl.md).
 
 ## Best practices during migration
 

--- a/dm/dm-ddl-compatible.md
+++ b/dm/dm-ddl-compatible.md
@@ -140,4 +140,4 @@ When DM merges and migrates tables in pessimistic or optimistic mode, the behavi
 
 ## Online DDL
 
-The Online DDL feature also handles DDL events in a special way. For details, refer to [Migrate from Databases that Use GH-ost/PT-osc](/dm/feature-online-ddl.md).
+The Online DDL feature also handles DDL events in a special way. For details, refer to [Migrate from Databases that Use gh-ost/pt-osc](/dm/feature-online-ddl.md).

--- a/dm/feature-online-ddl.md
+++ b/dm/feature-online-ddl.md
@@ -1,9 +1,9 @@
 ---
-title: Migrate from Databases that Use GH-ost/PT-osc
+title: Migrate from Databases that Use gh-ost/pt-osc
 summary: This document introduces the `online-ddl/online-ddl-scheme` feature of DM.
 ---
 
-# Migrate from Databases that Use GH-ost/PT-osc
+# Migrate from Databases that Use gh-ost/pt-osc
 
 In production scenarios, table locking during DDL execution can block the reads from or writes to the database to a certain extent. Therefore, online DDL tools are often used to execute DDLs to minimize the impact on reads and writes. Common DDL tools are [gh-ost](https://github.com/github/gh-ost) and [pt-osc](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html).
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The official tool names are lowercase `gh-ost` (GitHub Online Schema Transmogrifier) and `pt-osc` (Percona Toolkit pt-online-schema-change). Four files had them capitalized as `GH-ost`/`PT-osc`:

- `dm/dm-best-practices.md` (8 occurrences)
- `dm/feature-online-ddl.md` (4 occurrences, including the page title and H1)
- `TOC.md` (2 occurrences)
- `dm/dm-ddl-compatible.md` (2 occurrences)

The rest of the corpus already uses the correct lowercase casing consistently (`gh-ost` 51x, `pt-osc` 27x). Verified no headings' anchors changed and no link targets were affected — only prose, page title, and link-text casing.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): same casing issue likely also exists on `master`, not fixed here
- Source for the official casing (already linked elsewhere in this same doc):
  - gh-ost: https://github.com/github/gh-ost
  - pt-osc: https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch