### PR TITLE
ticdc: remove awkward directly from Debezium doc

### DIFF
--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -27,7 +27,7 @@ For the new TiCDC architecture, the Debezium protocol supports the following typ
 </div>
 <div label="Classic TiCDC architecture">
 
-For the classic TiCDC architecture, the Debezium protocol only supports Row Changed events and directly ignores DDL events and WATERMARK events. A Row changed event represents a data change in a row. When a row changes, the Row Changed event is sent, including relevant information about the row both before and after the change. A WATERMARK event marks the replication progress of a table, indicating that all events earlier than the watermark have been sent to the downstream.
+For the classic TiCDC architecture, the Debezium protocol only supports Row Changed events and ignores DDL events and WATERMARK events. A Row changed event represents a data change in a row. When a row changes, the Row Changed event is sent, including relevant information about the row both before and after the change. A WATERMARK event marks the replication progress of a table, indicating that all events earlier than the watermark have been sent to the downstream.
 
 </div>
 </SimpleTab>


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

`ticdc/ticdc-debezium.md`'s classic-architecture description says "the Debezium protocol only supports Row Changed events and directly ignores DDL events and WATERMARK events." "directly ignores" is an overly literal rendering of the Chinese source's "直接忽略" ([docs-cn#16513](https://github.com/pingcap/docs-cn/pull/16513)) - in English, "directly" reads as a spatial/routing adverb and doesn't collocate naturally with "ignores". Dropped it; the preceding "only supports Row Changed events" already makes the contrast to the ignored event types clear.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): this "classic TiCDC architecture" tab/section does not exist on `master` (that doc has already moved past the classic/new architecture split), so master does not need this fix

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the description of how classic TiCDC handles DDL and WATERMARK events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->