### PR TITLE
fix(lake): set-cluster-key note format

### DIFF
--- a/tidb-cloud-lake/sql/set-cluster-key.md
+++ b/tidb-cloud-lake/sql/set-cluster-key.md
@@ -9,7 +9,9 @@ Set a cluster key when creating a table.
 
 Cluster key is intended to improve query performance by physically clustering data together. For example, when you set a column as your cluster key for a table, the table data will be physically sorted by the column you set. This will maximize the query performance if your most queries are filtered by the column.
 
-> **Note:** For String column, the cluster statistics uses only the first 8 bytes. You can use a substring to provide sufficient cardinality.
+> **Note:**
+>
+> For String column, the cluster statistics uses only the first 8 bytes. You can use a substring to provide sufficient cardinality.
 
 See also:
 


### PR DESCRIPTION
Change the note in `set-cluster-key.md` from single-line to multi-line format, matching the convention used by other Lake SQL docs (e.g. `recluster-table.md`).

The single-line `> **Note:** content` format causes the note body to render as empty on the docs site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of the cluster statistics note for easier reading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->