### PR TITLE
docs: unify "standardized" to "normalized" for SQL statements in sql-plan-management.md

### DIFF
--- a/sql-plan-management.md
+++ b/sql-plan-management.md
@@ -200,7 +200,7 @@ explain SELECT * FROM t1, t2 WHERE t1.id = t2.id;
 
 When the first `SELECT` statement is being executed, the optimizer adds the `sm_join(t1, t2)` hint to the statement through the binding in the GLOBAL scope. The top node of the execution plan in the `explain` result is MergeJoin. When the second `SELECT` statement is being executed, the optimizer uses the binding in the SESSION scope instead of the binding in the GLOBAL scope and adds the `hash_join(t1, t2)` hint to the statement. The top node of the execution plan in the `explain` result is HashJoin.
 
-Each standardized SQL statement can have only one binding created using `CREATE BINDING` at a time. When multiple bindings are created for the same standardized SQL statement, the last created binding is retained, and all previous bindings (created and evolved) are marked as deleted. But session bindings and global bindings can coexist and are not affected by this logic.
+Each normalized SQL statement can have only one binding created using `CREATE BINDING` at a time. When multiple bindings are created for the same normalized SQL statement, the last created binding is retained, and all previous bindings (created and evolved) are marked as deleted. But session bindings and global bindings can coexist and are not affected by this logic.
 
 In addition, when you create a binding, TiDB requires that the session is in a database context, which means that a database is specified when the client is connected or `use ${database}` is executed.
 
@@ -819,9 +819,9 @@ To reduce the impact that the automatic evolution has on clusters, use the follo
 
 Because the baseline evolution automatically creates a new binding, when the query environment changes, the automatically created binding might have multiple behavior choices. Pay attention to the following notes:
 
-+ Baseline evolution only evolves standardized SQL statements that have at least one global binding.
++ Baseline evolution only evolves normalized SQL statements that have at least one global binding.
 
-+ Because creating a new binding deletes all previous bindings (for a standardized SQL statement), the automatically evolved binding will be deleted after manually creating a new binding.
++ Because creating a new binding deletes all previous bindings (for a normalized SQL statement), the automatically evolved binding will be deleted after manually creating a new binding.
 
 + All hints related to the calculation process are retained during the evolution. These hints are as follows:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

`sql-plan-management.md` defines the term `` `Normalization` `` and uses "normalizes" / "normalized" consistently elsewhere in the same file (e.g. "The TiDB optimizer normalizes bound SQL statements", and the `sql_digest` table row "Digest of a normalized SQL statement"), but 3 sentences used the inconsistent synonym "standardized" for the exact same concept (a SQL statement that has gone through Normalization). This was found while investigating a related Japanese translation inconsistency that traced back to this English source ambiguity.

Unified all 3 occurrences to "normalized" to match the file's own defined terminology.

**Origin of the "standardized" wording** (found via `git blame`):
- Line 203 ("Each standardized SQL statement...") was introduced by #5088, translated from [pingcap/docs-cn#5740](https://github.com/pingcap/docs-cn/pull/5740).
- Lines 822/824 ("...standardized SQL statements...") were introduced by #2679, translated from [pingcap/docs-cn#3450](https://github.com/pingcap/docs-cn/pull/3450) and [pingcap/docs-cn#2848](https://github.com/pingcap/docs-cn/pull/2848).

Both trace back to the same Chinese source term "标准化" (literally "standardize"), which this file's own English translation deliberately renders as "Normalization" as its formal defined term elsewhere - the "standardized" instances are just places where that established EN term wasn't applied consistently.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): #5088, #2679

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch