### PR TITLE
releases: fix typo INFORMMATION_SCHEMA in release-2.1-rc.1.md

### DIFF
--- a/releases/release-2.1-rc.1.md
+++ b/releases/release-2.1-rc.1.md
@@ -56,7 +56,7 @@ On August 24, 2018, TiDB 2.1 RC1 is released! Compared with TiDB 2.1 Beta, this 
     - Add the `GrpcKeepAlive` option [#7100](https://github.com/pingcap/tidb/pull/7100)
     - Add the connection or `Token` time monitor [#7110](https://github.com/pingcap/tidb/pull/7110)
     - Optimize the data decoding performance [#7149](https://github.com/pingcap/tidb/pull/7149)
-    - Add the `PROCESSLIST` table in `INFORMMATION_SCHEMA` [#7236](https://github.com/pingcap/tidb/pull/7236)
+    - Add the `PROCESSLIST` table in `INFORMATION_SCHEMA` [#7236](https://github.com/pingcap/tidb/pull/7236)
     - Fix the order issue when multiple rules are hit in verifying the privilege [#7211](https://github.com/pingcap/tidb/pull/7211)
     - Change some default values of encoding related system variables to UTF-8 [#7198](https://github.com/pingcap/tidb/pull/7198)
     - Make the slow query log show more detailed information [#7302](https://github.com/pingcap/tidb/pull/7302)


### PR DESCRIPTION
### First-time contributors' checklist

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

Fixes a typo in `releases/release-2.1-rc.1.md`: `INFORMMATION_SCHEMA` (extra `M`) should be `INFORMATION_SCHEMA`.

Found while reviewing CodeRabbit feedback on a Japanese translation PR (pingcap/docs#23598), where the Japanese text faithfully mirrored this pre-existing English typo. Verified the typo is present in this exact form on both `master` and `release-8.5`; this PR fixes it on `master` per the standard "master only, let the bot backport" guideline since it's not a feature/compatibility change.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): found via pingcap/docs#23598 (review comment)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a terminology typo in the `PROCESSLIST` table release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->