### PR TITLE
release notes, perf-tuning: fix gPRC typo to gRPC

### DIFF
--- a/performance-tuning-methods.md
+++ b/performance-tuning-methods.md
@@ -409,7 +409,7 @@ The TSO wait time is recorded as `TSO WAIT` and the network time of the TSO requ
 The indicators in this section correspond to the following three panels.
 
 - Avg TiDB KV Request Duration: The average latency of KV requests measured by TiDB
-- Avg TiKV GRPC Duration: The average latency in processing gPRC messages in TiKV
+- Avg TiKV GRPC Duration: The average latency in processing gRPC messages in TiKV
 - PD TSO Wait/RPC Duration: TiDB executor TSO wait time and network latency for TSO requests (RPC)
 
 The relationship between `Avg TiDB KV Request Duration` and `Avg TiKV GRPC Duration` is as follows:
@@ -474,7 +474,7 @@ According to the preceding formula, the QPS of a write-heavy OLTP workload in v5
 - v5.3.0: 24.4 ms ~= 17.7 ms + 6.59 ms
 - v5.4.0: 21.4 ms ~= 14.0 ms + 7.33 ms
 
-In v5.4.0, the gPRC module has been optimized to accelerate Raft log replication, which reduces `Store Duration` compared with v5.3.0.
+In v5.4.0, the gRPC module has been optimized to accelerate Raft log replication, which reduces `Store Duration` compared with v5.3.0.
 
 v5.3.0:
 
@@ -521,7 +521,7 @@ The QPS of a write-heavy OLTP workload in v5.4.0 is improved by 14% compared wit
 | Commit Log Duration | 13 | 8.68 |
 | Apply Log Duration | 0.457|0.514 |
 
-In v5.4.0, the gPRC module has been optimized to accelerate Raft log replication, which reduces `Commit Log Duration` and `Store Duration` compared with v5.3.0.
+In v5.4.0, the gRPC module has been optimized to accelerate Raft log replication, which reduces `Commit Log Duration` and `Store Duration` compared with v5.3.0.
 
 v5.3.0:
 

--- a/releases/release-2.0.6.md
+++ b/releases/release-2.0.6.md
@@ -23,7 +23,7 @@ On August 6, 2018, TiDB 2.0.6 is released. Compared with TiDB 2.0.5, this releas
     - Fix the issue that the `DROP USER` statement is incompatible with MySQL behavior in some cases [#7014](https://github.com/pingcap/tidb/pull/7014)
     - Fix the issue that statements like `INSERT`/`LOAD DATA` meet OOM after opening `tidb_batch_insert` [#7092](https://github.com/pingcap/tidb/pull/7092)
     - Fix the issue that the statistics fail to automatically update when the data of a table keeps updating [#7093](https://github.com/pingcap/tidb/pull/7093)
-    - Fix the issue that the firewall breaks inactive gPRC connections [#7099](https://github.com/pingcap/tidb/pull/7099)
+    - Fix the issue that the firewall breaks inactive gRPC connections [#7099](https://github.com/pingcap/tidb/pull/7099)
     - Fix the issue that prefix index returns a wrong result in some scenarios [#7126](https://github.com/pingcap/tidb/pull/7126)
     - Fix the panic issue caused by outdated statistics in some scenarios [#7155](https://github.com/pingcap/tidb/pull/7155)
     - Fix the issue that one piece of index data is missed after the `ADD INDEX` operation in some scenarios [#7156](https://github.com/pingcap/tidb/pull/7156)

--- a/releases/release-4.0.16.md
+++ b/releases/release-4.0.16.md
@@ -41,7 +41,7 @@ TiDB version: 4.0.16
     + TiCDC
 
         - Add a tick frequency limit to EtcdWorker to prevent frequent etcd writes from affecting PD services [#3112](https://github.com/pingcap/tiflow/issues/3112)
-        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/tiflow/issues/3110)
+        - Optimize rate-limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/tiflow/issues/3110)
 
 ## Bug fixes
 

--- a/releases/release-4.0.16.md
+++ b/releases/release-4.0.16.md
@@ -41,7 +41,7 @@ TiDB version: 4.0.16
     + TiCDC
 
         - Add a tick frequency limit to EtcdWorker to prevent frequent etcd writes from affecting PD services [#3112](https://github.com/pingcap/tiflow/issues/3112)
-        - Optimize rate limiting control on TiKV reloads to reduce gPRC congestion during changefeed initialization [#3110](https://github.com/pingcap/tiflow/issues/3110)
+        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/tiflow/issues/3110)
 
 ## Bug fixes
 

--- a/releases/release-5.0.6.md
+++ b/releases/release-5.0.6.md
@@ -42,7 +42,7 @@ TiDB version: 5.0.6
 
     + TiCDC
 
-        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
+        - Optimize rate-limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
         - Add a tick frequency limit to EtcdWorker to prevent frequent etcd writes from affecting PD services [#3112](https://github.com/pingcap/ticdc/issues/3112)
         - Add the default configuration for `config.Metadata.Timeout` in Kafka sink [#3352](https://github.com/pingcap/tiflow/issues/3352)
         - Set the default value of `max-message-bytes` to `10M`, to reduce the probability that Kafka messages cannot be sent [#3081](https://github.com/pingcap/tiflow/issues/3081)

--- a/releases/release-5.0.6.md
+++ b/releases/release-5.0.6.md
@@ -42,7 +42,7 @@ TiDB version: 5.0.6
 
     + TiCDC
 
-        - Optimize rate limiting control on TiKV reloads to reduce gPRC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
+        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
         - Add a tick frequency limit to EtcdWorker to prevent frequent etcd writes from affecting PD services [#3112](https://github.com/pingcap/ticdc/issues/3112)
         - Add the default configuration for `config.Metadata.Timeout` in Kafka sink [#3352](https://github.com/pingcap/tiflow/issues/3352)
         - Set the default value of `max-message-bytes` to `10M`, to reduce the probability that Kafka messages cannot be sent [#3081](https://github.com/pingcap/tiflow/issues/3081)

--- a/releases/release-5.1.4.md
+++ b/releases/release-5.1.4.md
@@ -55,7 +55,7 @@ TiDB version: 5.1.4
         - Add metrics for observing the remaining time of incremental scan [#2985](https://github.com/pingcap/tiflow/issues/2985)
         - Reduce the count of "EventFeed retry rate limited" logs [#4006](https://github.com/pingcap/tiflow/issues/4006)
         - Add more Prometheus and Grafana monitoring metrics and alerts, including `no owner alert`, `mounter row`, `table sink total row`, and `buffer sink total row` [#4054](https://github.com/pingcap/tiflow/issues/4054) [#1606](https://github.com/pingcap/tiflow/issues/1606)
-        - Optimize rate limiting control on TiKV reloads to reduce gPRC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
+        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
         - Reduce the time for the KV client to recover when a TiKV store is down [#3191](https://github.com/pingcap/tiflow/issues/3191)
 
 ## Bug fixes

--- a/releases/release-5.1.4.md
+++ b/releases/release-5.1.4.md
@@ -55,7 +55,7 @@ TiDB version: 5.1.4
         - Add metrics for observing the remaining time of incremental scan [#2985](https://github.com/pingcap/tiflow/issues/2985)
         - Reduce the count of "EventFeed retry rate limited" logs [#4006](https://github.com/pingcap/tiflow/issues/4006)
         - Add more Prometheus and Grafana monitoring metrics and alerts, including `no owner alert`, `mounter row`, `table sink total row`, and `buffer sink total row` [#4054](https://github.com/pingcap/tiflow/issues/4054) [#1606](https://github.com/pingcap/tiflow/issues/1606)
-        - Optimize rate limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
+        - Optimize rate-limiting control on TiKV reloads to reduce gRPC congestion during changefeed initialization [#3110](https://github.com/pingcap/ticdc/issues/3110)
         - Reduce the time for the KV client to recover when a TiKV store is down [#3191](https://github.com/pingcap/tiflow/issues/3191)
 
 ## Bug fixes

--- a/releases/release-6.1.0.md
+++ b/releases/release-6.1.0.md
@@ -342,7 +342,7 @@ In 6.1.0, the key new features or improvements are as follows:
     - CDC supports RawKV [#11965](https://github.com/tikv/tikv/issues/11965)
     - Support splitting a large snapshot file into multiple files [#11595](https://github.com/tikv/tikv/issues/11595)
     - Move the snapshot garbage collection from Raftstore to background thread to prevent snapshot GC from blocking Raftstore message loops [#11966](https://github.com/tikv/tikv/issues/11966)
-    - Support dynamic setting of the maximum message length (`max-grpc-send-msg-len`) and the maximum batch size of gPRC messages (`raft-msg-max-batch-size`) [#12334](https://github.com/tikv/tikv/issues/12334)
+    - Support dynamic setting of the maximum message length (`max-grpc-send-msg-len`) and the maximum batch size of gRPC messages (`raft-msg-max-batch-size`) [#12334](https://github.com/tikv/tikv/issues/12334)
     - Support executing online unsafe recovery plan through Raft [#10483](https://github.com/tikv/tikv/issues/10483)
 
 + PD

--- a/releases/release-6.1.3.md
+++ b/releases/release-6.1.3.md
@@ -44,7 +44,7 @@ Quick access: [Quick start](https://docs-archive.pingcap.com/tidb/v6.1/quick-sta
     - Fix the issue of the wrong query result that occurs when the mistakenly pushed-down conditions are discarded by Join Reorder [#38736](https://github.com/pingcap/tidb/issues/38736) @[winoros](https://github.com/winoros)
     - Fix the issue that the lock acquired by `get_lock()` cannot hold for more than 10 minutes [#38706](https://github.com/pingcap/tidb/issues/38706) @[tangenta](https://github.com/tangenta)
     - Fix the issue that the auto-increment column cannot be used with check constraint [#38894](https://github.com/pingcap/tidb/issues/38894) @[YangKeao](https://github.com/YangKeao)
-    - Fix the issue that the gPRC log is output to a wrong file [#38941](https://github.com/pingcap/tidb/issues/38941) @[xhebox](https://github.com/xhebox)
+    - Fix the issue that the gRPC log is output to a wrong file [#38941](https://github.com/pingcap/tidb/issues/38941) @[xhebox](https://github.com/xhebox)
     - Fix the issue that the TiFlash sync status of a table is not deleted from etcd when the table is truncated or dropped [#37168](https://github.com/pingcap/tidb/issues/37168) @[CalvinNeo](https://github.com/CalvinNeo)
     - Fix the issue that data files can be accessed unrestrainedly via data source name injection (CVE-2022-3023) [#38541](https://github.com/pingcap/tidb/issues/38541) @[lance6716](https://github.com/lance6716)
     - Fix the issue that the function `str_to_date` returns wrong result in the `NO_ZERO_DATE` SQL mode [#39146](https://github.com/pingcap/tidb/issues/39146) @[mengxin9014](https://github.com/mengxin9014)


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Fixes a recurring misspelling of "gRPC" as "gPRC" across several release notes and the performance tuning guide:

- `releases/release-2.0.6.md`
- `releases/release-4.0.16.md`
- `releases/release-5.0.6.md`
- `releases/release-5.1.4.md`
- `releases/release-6.1.0.md`
- `releases/release-6.1.3.md`
- `performance-tuning-methods.md` (3 occurrences)

Found while reviewing CodeRabbit feedback on JA translation PR #23599 — the JA translations correctly mirrored this EN typo, so fixing it at the source here instead of diverging the translation.

## Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)

## What is the related PR or file link(s)?

N/A

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple occurrences of the “gPRC” typo to “gRPC” across performance documentation and release notes.
  * Clarified references to TiKV latency, Raft log replication, firewall fixes, TiCDC improvements, and gRPC message settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->