### PR TITLE
i18n(ja): remove orphaned MT leftover in backup-and-restore-premium.md

### DIFF
--- a/tidb-cloud/premium/backup-and-restore-premium.md
+++ b/tidb-cloud/premium/backup-and-restore-premium.md
@@ -25,7 +25,7 @@ aliases: ['/ja/tidbcloud/restore-deleted-tidb-cluster']
 
 > **Tip:**
 >
-> - TiDB Cloud Dedicatedクラスター上のデータをバックアップおよび復元する方法については、 [TiDB Cloud Dedicatedデータのバックアップと復元](/tidb-cloud/backup-and-restore.md)復元」を参照してください。
+> - TiDB Cloud Dedicatedクラスター上のデータをバックアップおよび復元する方法については、 [TiDB Cloud Dedicatedデータのバックアップと復元](/tidb-cloud/backup-and-restore.md)を参照してください。
 > - TiDB Cloud StarterまたはTiDB Cloud Essentialインスタンスのデータをバックアップおよび復元する方法については、 [TiDB Cloud StarterまたはEssentialデータのバックアップと復元](/tidb-cloud/backup-and-restore-serverless.md)を参照してください。
 
 ## バックアップページを確認する {#view-the-backup-page}


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Removes a stray `復元」` fragment left after a sentence-ending link in the Tip block — a duplicated word plus an unmatched closing quote mark, a leftover from the old MT pipeline. Matches the correct pattern already used by the sibling bullet directly below it in the same block.

Two other defects noted in an earlier review pass (a bold-span splitting 有効期限, and a particle trapped inside `**[ごみ箱]**`) were re-verified against the current file and are already fixed — no longer present.

## Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

## What is the related PR or file link(s)?

- This PR is translated from:

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch