### PR TITLE
i18n(ja): translate remaining untranslated headings and phrases in AI docs

### DIFF
--- a/ai/integrations/vector-search-integration-overview.md
+++ b/ai/integrations/vector-search-integration-overview.md
@@ -1,12 +1,12 @@
 ---
-title: TiDB の AI Integrations
-summary: Auto Embedding プロバイダー、AI フレームワーク、ORM ライブラリ、クラウドサービス、MCP サーバーサポートを含む、TiDB の AI 連携の概要。
+title: TiDB の AI 統合
+summary: Auto Embedding プロバイダー、AI フレームワーク、ORM ライブラリ、クラウドサービス、MCP サーバーサポートを含む、TiDB の AI 統合の概要。
 aliases: ['/ja/tidb/stable/vector-search-integration-overview/','/ja/tidb/dev/vector-search-integration-overview/','/ja/tidbcloud/vector-search-integration-overview/']
 ---
 
-# TiDB の AI Integrations
+# TiDB の AI 統合
 
-このドキュメントでは、Auto Embedding プロバイダー、AI フレームワーク、Object Relational Mapping (ORM) ライブラリ、クラウドサービス、MCP サーバーサポートを含む、TiDB の AI 連携の概要を説明します。
+このドキュメントでは、Auto Embedding プロバイダー、AI フレームワーク、Object Relational Mapping (ORM) ライブラリ、クラウドサービス、MCP サーバーサポートを含む、TiDB の AI 統合の概要を説明します。
 
 > **Note:**
 >
@@ -15,13 +15,13 @@ aliases: ['/ja/tidb/stable/vector-search-integration-overview/','/ja/tidb/dev/ve
 
 ## Auto Embedding {#auto-embedding}
 
-[Auto Embedding](/ai/integrations/vector-search-auto-embedding-overview.md) 機能を使用すると、プレーンテキストを使って直接ベクトル検索を実行できます。TiDB がバックグラウンドで自動的にテキストをベクトルに変換するため、自分で embedding を生成または管理する必要はありません。
+[Auto Embedding](/ai/integrations/vector-search-auto-embedding-overview.md) 機能を使用すると、プレーンテキストを使って直接ベクトル検索を実行できます。TiDB がバックグラウンドで自動的にテキストをベクトルに変換するため、自分で埋め込みを生成または管理する必要はありません。
 
-TiDB Vector Search は最大 16383 次元のベクトルの保存をサポートしており、ほとんどの embedding モデルに対応できます。
+TiDB Vector Search は最大 16383 次元のベクトルの保存をサポートしており、ほとんどの埋め込みモデルに対応できます。
 
-ベクトルの生成には、自前でデプロイしたオープンソースの embedding モデル、またはサードパーティの embedding API のいずれかを使用できます。
+ベクトルの生成には、自前でデプロイしたオープンソースの埋め込みモデル、またはサードパーティの埋め込みAPIのいずれかを使用できます。
 
-次の表は、サポートされている embedding プロバイダーを示しています。各プロバイダーの設定方法については、対応するガイドを参照してください。
+次の表は、サポートされている埋め込みプロバイダーを示しています。各プロバイダーの設定方法については、対応するガイドを参照してください。
 
 | プロバイダー          | ガイド                                      |
 |-------------------|--------------------------------------------------------------------------------------|
@@ -58,7 +58,7 @@ TiDB Vector Search を ORM ライブラリと統合して、TiDB データベー
 
 ## クラウドサービス {#cloud-services}
 
-サードパーティのクラウド embedding サービスを使用してベクトルを生成し、それらを TiDB に保存できます。
+サードパーティのクラウド埋め込みサービスを使用してベクトルを生成し、それらを TiDB に保存できます。
 
 次の表は、サポートされているクラウドサービスと対応するチュートリアルを示しています。
 

--- a/ai/integrations/vector-search-integration-overview.md
+++ b/ai/integrations/vector-search-integration-overview.md
@@ -44,7 +44,7 @@ TiDB は次の AI フレームワークを公式にサポートしており、�
 
 また、TiDB は AI アプリケーション向けのドキュメントストレージやナレッジグラフストレージなど、さまざまな用途にも使用できます。
 
-## ORM libraries {#orm-libraries}
+## ORM ライブラリ {#orm-libraries}
 
 TiDB Vector Search を ORM ライブラリと統合して、TiDB データベースを操作できます。
 
@@ -67,13 +67,13 @@ TiDB Vector Search を ORM ライブラリと統合して、TiDB データベー
 | Jina AI        | [Integrate Vector Search with Jina AI Embeddings API](/ai/integrations/vector-search-integrate-with-jinaai-embedding.md)  |
 | Amazon Bedrock | [Integrate TiDB Vector Search with Amazon Bedrock](/ai/integrations/vector-search-integrate-with-amazon-bedrock.md)       |
 
-## MCP server {#mcp-server}
+## MCP サーバー {#mcp-server}
 
 [TiDB MCP Server](/ai/integrations/tidb-mcp-server.md) はオープンソースのツールであり、Model Context Protocol (MCP) を通じて自然言語の指示を使って TiDB データベースを操作できます。
 
 次の表は、サポートされている MCP クライアントと対応するセットアップガイドを示しています。
 
-| MCP client     | ガイド                                                                  |
+| MCP クライアント | ガイド                                                                  |
 |----------------|------------------------------------------------------------------------|
 | Claude Code    | [Claude Code](/ai/integrations/tidb-mcp-claude-code.md)                |
 | Claude Desktop | [Claude Desktop](/ai/integrations/tidb-mcp-claude-desktop.md)          |

--- a/tidb-cloud/monitor-datadog-integration-for-tidb-x.md
+++ b/tidb-cloud/monitor-datadog-integration-for-tidb-x.md
@@ -1,6 +1,6 @@
 ---
 title: TiDB CloudとDatadogを統合する (PREVIEW)
-summary: Datadog integration を使用して TiDB Cloud インスタンスを監視する方法を学びます。
+summary: Datadog統合を使用して TiDB Cloud インスタンスを監視する方法を学びます。
 ---
 
 # TiDB CloudとDatadogを統合する (PREVIEW)
@@ -17,14 +17,14 @@ TiDB Cloud は Datadog との統合をサポートしています。TiDB Cloud �
 
 ## 制限事項 {#limitations}
 
-- Datadog integration は [TiDB Cloud Starter](/tidb-cloud/select-cluster-tier.md#starter) インスタンスでは利用できません。
-- 対象の <CustomContent plan="essential">{{{ .essential }}}</CustomContent><CustomContent plan="premium">{{{ .premium }}}</CustomContent> インスタンスのステータスが **CREATING**、**RESTORING**、**PAUSED**、または **RESUMING** の場合、Datadog integration は利用できません。
+- Datadog統合は [TiDB Cloud Starter](/tidb-cloud/select-cluster-tier.md#starter) インスタンスでは利用できません。
+- 対象の <CustomContent plan="essential">{{{ .essential }}}</CustomContent><CustomContent plan="premium">{{{ .premium }}}</CustomContent> インスタンスのステータスが **CREATING**、**RESTORING**、**PAUSED**、または **RESUMING** の場合、Datadog統合は利用できません。
 
 ## 手順 {#steps}
 
 ### 手順 1. 事前構築済み Datadog ダッシュボードをインポートする {#step-1-import-the-pre-built-datadog-dashboard}
 
-現在、<CustomContent plan="essential">{{{ .essential }}}</CustomContent><CustomContent plan="premium">{{{ .premium }}}</CustomContent> 用の TiDB Cloud ダッシュボードは、Datadog integration marketplace ではまだ利用できません。ダッシュボード JSON ファイルを手動でダウンロードし、Datadog にインポートする必要があります。
+現在、<CustomContent plan="essential">{{{ .essential }}}</CustomContent><CustomContent plan="premium">{{{ .premium }}}</CustomContent> 用の TiDB Cloud ダッシュボードは、Datadog統合マーケットプレイスではまだ利用できません。ダッシュボード JSON ファイルを手動でダウンロードし、Datadog にインポートする必要があります。
 
 1. インスタンスタイプに対応する Datadog ダッシュボード JSON ファイルをダウンロードします。
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Fixes untranslated content and internal term inconsistency across two AI-docs files (not a style/notation issue — the text simply wasn't translated, or the same term was rendered 3 different ways within closely related pages):

1. `tidb-cloud/monitor-datadog-integration-for-tidb-x.md`: "Datadog integration" was left in English in 4 places (summary, 2 limitation bullets, and "Datadog integration marketplace"). Translated to Datadog統合 / Datadog統合マーケットプレイス, matching the established rendering already used consistently throughout the sibling file `monitor-datadog-integration.md`.
2. `ai/integrations/vector-search-integration-overview.md`:
   - The `## ORM libraries` and `## MCP server` section headings, and the `MCP client` table column header, were left in English while every other heading and table header on the same page is in Japanese.
   - "embedding" was left as raw English in 5 places (自分で embedding を生成, embedding モデル ×2, embedding API, embedding プロバイダー, embedding サービス); translated to 埋め込み, matching sibling `ai/` docs' established rendering.
   - The page's own title/H1/summary/body kept "Integrations" in English while its body used 連携 and the linking page (`ai/_index.md`) uses 統合 for the identical concept — a 3-way split for one term within two closely related pages. Unified to 統合, the term already used almost everywhere else in `ai/` (46 occurrences vs 2 for 連携, both previously in this same file), matching `ai/_index.md`'s own heading and inbound link text for this page.

## Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

## What is the related PR or file link(s)?

- This PR is translated from:

## Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Japanese terminology and headings for AI integrations, embeddings, ORM, and MCP clients.
  - Standardized references to Datadog integration in the Japanese monitoring documentation.
  - Preserved existing links, structure, feature descriptions, and supported integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->