### PR TITLE
i18n(ja): keep the literal information_schema identifier in table-page summaries

### DIFF
--- a/TOC-tidb-cloud-essential.md
+++ b/TOC-tidb-cloud-essential.md
@@ -414,7 +414,7 @@
     - `mysql`スキーマ
       - [概要](/mysql-schema/mysql-schema.md)
       - [`user`](/mysql-schema/mysql-schema-user.md)
-    - 情報スキーマ
+    - INFORMATION_SCHEMA
       - [概要](/information-schema/information-schema.md)
       - [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
       - [`CHECK_CONSTRAINTS`](/information-schema/information-schema-check-constraints.md)

--- a/TOC-tidb-cloud-premium.md
+++ b/TOC-tidb-cloud-premium.md
@@ -401,7 +401,7 @@
     - `mysql`スキーマ
       - [概要](/mysql-schema/mysql-schema.md)
       - [`user`](/mysql-schema/mysql-schema-user.md)
-    - 情報スキーマ
+    - INFORMATION_SCHEMA
       - [概要](/information-schema/information-schema.md)
       - [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
       - [`CHECK_CONSTRAINTS`](/information-schema/information-schema-check-constraints.md)

--- a/TOC-tidb-cloud-starter.md
+++ b/TOC-tidb-cloud-starter.md
@@ -413,7 +413,7 @@
     - `mysql`スキーマ
       - [概要](/mysql-schema/mysql-schema.md)
       - [`user`](/mysql-schema/mysql-schema-user.md)
-    - 情報スキーマ
+    - INFORMATION_SCHEMA
       - [概要](/information-schema/information-schema.md)
       - [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
       - [`CHECK_CONSTRAINTS`](/information-schema/information-schema-check-constraints.md)

--- a/TOC-tidb-cloud.md
+++ b/TOC-tidb-cloud.md
@@ -510,7 +510,7 @@
       - [概要](/mysql-schema/mysql-schema.md)
       - [`tidb_mdl_view`](/mysql-schema/mysql-schema-tidb-mdl-view.md)
       - [`user`](/mysql-schema/mysql-schema-user.md)
-    - 情報スキーマ
+    - INFORMATION_SCHEMA
       - [概要](/information-schema/information-schema.md)
       - [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
       - [`CHECK_CONSTRAINTS`](/information-schema/information-schema-check-constraints.md)

--- a/TOC.md
+++ b/TOC.md
@@ -880,7 +880,7 @@
         - [概要](/mysql-schema/mysql-schema.md)
         - [`tidb_mdl_view`](/mysql-schema/mysql-schema-tidb-mdl-view.md)
         - [`user`](/mysql-schema/mysql-schema-user.md)
-      - 情報スキーマ
+      - INFORMATION_SCHEMA
         - [概要](/information-schema/information-schema.md)
         - [`ANALYZE_STATUS`](/information-schema/information-schema-analyze-status.md)
         - [`CHECK_CONSTRAINTS`](/information-schema/information-schema-check-constraints.md)

--- a/information-schema/information-schema-analyze-status.md
+++ b/information-schema/information-schema-analyze-status.md
@@ -1,6 +1,6 @@
 ---
 title: ANALYZE_STATUS
-summary: ANALYZE_STATUS`情報スキーマテーブルについて学習してください。
+summary: ANALYZE_STATUS`information_schemaテーブルについて学習してください。
 ---
 
 # ANALYZE_STATUS {#analyze-status}

--- a/information-schema/information-schema-placement-policies.md
+++ b/information-schema/information-schema-placement-policies.md
@@ -1,6 +1,6 @@
 ---
 title: PLACEMENT_POLICIES
-summary: PLACEMENT_POLICIES`情報スキーマテーブルについて学習してください。
+summary: PLACEMENT_POLICIES`information_schemaテーブルについて学習してください。
 ---
 
 # PLACEMENT_POLICIES {#placement-policies}

--- a/information-schema/information-schema-resource-groups.md
+++ b/information-schema/information-schema-resource-groups.md
@@ -1,6 +1,6 @@
 ---
 title: RESOURCE_GROUPS
-summary: RESOURCE_GROUPS`情報スキーマテーブルについて学習してください。
+summary: RESOURCE_GROUPS`information_schemaテーブルについて学習してください。
 ---
 
 # RESOURCE_GROUPS {#resource-groups}

--- a/information-schema/information-schema-tidb-hot-regions-history.md
+++ b/information-schema/information-schema-tidb-hot-regions-history.md
@@ -1,6 +1,6 @@
 ---
 title: TIDB_HOT_REGIONS_HISTORY
-summary: TIDB_HOT_REGIONS_HISTORY`情報スキーマテーブルについて学習してください。
+summary: TIDB_HOT_REGIONS_HISTORY`information_schemaテーブルについて学習してください。
 ---
 
 # TIDB_HOT_REGIONS_HISTORY {#tidb-hot-regions-history}

--- a/information-schema/information-schema-tikv-region-status.md
+++ b/information-schema/information-schema-tikv-region-status.md
@@ -1,6 +1,6 @@
 ---
 title: TIKV_REGION_STATUS
-summary: TIKV_REGION_STATUS`情報スキーマテーブルについて学習してください。
+summary: TIKV_REGION_STATUS`information_schemaテーブルについて学習してください。
 ---
 
 # TIKV_REGION_STATUS {#tikv-region-status}


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Found while checking for `information_schema` mistranslations: 5 `information-schema/*.md` summary lines translate the literal, lowercase schema identifier `information_schema` (matching the `USE information_schema;` statement shown in each page's own example code block) as "情報スキーマ" instead of keeping it literal. The other 57 pages in the same directory already keep it correctly (e.g. `` COLUMNS` INFORMATION_SCHEMA テーブルについて学習します。 ``), so these 5 were outliers.

Fixed:

- `information-schema/information-schema-analyze-status.md`
- `information-schema/information-schema-resource-groups.md`
- `information-schema/information-schema-placement-policies.md`
- `information-schema/information-schema-tidb-hot-regions-history.md`
- `information-schema/information-schema-tikv-region-status.md`

Note: the general translation "情報スキーマ" for the *Information Schema* feature/concept name (e.g. `information-schema/information-schema.md`'s own H1) is correct and separate from this — only the literal lowercase `information_schema` identifier in these 5 summaries was wrong. A separate, much larger pre-existing issue (a missing opening backtick before the table name in ~58 of the 62 summary lines in this directory) was found in the same pass and is intentionally left out of this PR per the user's request to handle it separately.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): found while reviewing #23616

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Japanese page summaries to consistently use the `information_schema` table name for several Information Schema references.
  * Improved terminology consistency across documentation for ANALYZE_STATUS, PLACEMENT_POLICIES, RESOURCE_GROUPS, TIDB_HOT_REGIONS_HISTORY, and TIKV_REGION_STATUS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
