### PR TITLE
troubleshoot-tidb-cluster: fix TiDB error message text

### DIFF
--- a/troubleshoot-tidb-cluster.md
+++ b/troubleshoot-tidb-cluster.md
@@ -24,7 +24,7 @@ For other information, see [Frequently Asked Questions (FAQ)](/faq/tidb-faq.md).
     - If a certain process is not running, see the following corresponding sections to diagnose and solve the issue.
 
     + If all the processes are running, check the `tidb-server` log to see if the following messages are displayed:
-        - InformationSchema is out of date: This message is displayed if the `tikv-server` cannot be connected. Check the state and log of `pd-server` and `tikv-server`.
+        - Information schema is out of date: This message is displayed if the `tikv-server` cannot be connected. Check the state and log of `pd-server` and `tikv-server`.
         - panic: This message is displayed if there is an issue with the program. Please provide the detailed panic log and you can [report a bug](/support.md).
 
 3. If the data is cleared and the services are re-deployed, make sure that:


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Found while reviewing a Japanese translation fix (CodeRabbit review on pingcap/docs#23618): `troubleshoot-tidb-cluster.md` says the error message is `InformationSchema is out of date` (one word), but this doesn't match the actual TiDB error text.

Verified against `ErrInfoSchemaExpired` in pingcap/tidb:

https://github.com/pingcap/tidb/blob/1f9469913409f0c6bf4a946c51948ebdfc2d2bb8/pkg/errno/errname.go#L991

```go
ErrInfoSchemaExpired: mysql.Message("Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV", nil),
```

The correct text is `Information schema is out of date` (with a space between "Information" and "schema"), matching 7 other occurrences of this string elsewhere in this same docs corpus (`faq/sql-faq.md`, several `releases/*.md` files, `tidb-troubleshooting-map.md`). Only this one file had the wrong spelling.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master

### What is the related PR or file link(s)?

- Related: pingcap/docs#23618 (CodeRabbit review comment that flagged this)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch