### PR TITLE
i18n(ja): restore literal Expected-Output.txt link text in sample-app guides

### DIFF
--- a/develop/dev-guide-sample-application-golang-gorm.md
+++ b/develop/dev-guide-sample-application-golang-gorm.md
@@ -210,7 +210,7 @@ cd tidb-golang-gorm-quickstart
     make
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-golang-gorm-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-golang-gorm-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-golang-sql-driver.md
+++ b/develop/dev-guide-sample-application-golang-sql-driver.md
@@ -210,7 +210,7 @@ cd tidb-golang-sql-driver-quickstart
     make
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-golang-sql-driver-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-golang-sql-driver-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-java-hibernate.md
+++ b/develop/dev-guide-sample-application-java-hibernate.md
@@ -211,7 +211,7 @@ cd tidb-java-hibernate-quickstart
     make
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-java-hibernate-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-java-hibernate-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-java-jdbc.md
+++ b/develop/dev-guide-sample-application-java-jdbc.md
@@ -214,7 +214,7 @@ cd tidb-java-jdbc-quickstart
     make
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-java-jdbc-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-java-jdbc-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-java-mybatis.md
+++ b/develop/dev-guide-sample-application-java-mybatis.md
@@ -211,7 +211,7 @@ cd tidb-java-mybatis-quickstart
     make
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-java-mybatis-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-java-mybatis-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-java-spring-boot.md
+++ b/develop/dev-guide-sample-application-java-spring-boot.md
@@ -217,7 +217,7 @@ cd tidb-java-springboot-jpa-quickstart
     make request
     ```
 
-3. [期待される出力.txt](https://github.com/tidb-samples/tidb-java-springboot-jpa-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+3. [Expected-Output.txt](https://github.com/tidb-samples/tidb-java-springboot-jpa-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-python-mysql-connector.md
+++ b/develop/dev-guide-sample-application-python-mysql-connector.md
@@ -214,7 +214,7 @@ pip install -r requirements.txt
     python mysql_connector_example.py
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-python-mysqlconnector-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-python-mysqlconnector-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-python-mysqlclient.md
+++ b/develop/dev-guide-sample-application-python-mysqlclient.md
@@ -219,7 +219,7 @@ pip install -r requirements.txt
     python mysqlclient_example.py
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-python-mysqlclient-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-python-mysqlclient-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-python-peewee.md
+++ b/develop/dev-guide-sample-application-python-peewee.md
@@ -218,7 +218,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     python peewee_example.py
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-python-peewee-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-python-peewee-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-python-pymysql.md
+++ b/develop/dev-guide-sample-application-python-pymysql.md
@@ -214,7 +214,7 @@ pip install -r requirements.txt
     python pymysql_example.py
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-python-pymysql-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-python-pymysql-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 

--- a/develop/dev-guide-sample-application-python-sqlalchemy.md
+++ b/develop/dev-guide-sample-application-python-sqlalchemy.md
@@ -224,7 +224,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     python sqlalchemy_example.py
     ```
 
-2. [期待される出力.txt](https://github.com/tidb-samples/tidb-python-sqlalchemy-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
+2. [Expected-Output.txt](https://github.com/tidb-samples/tidb-python-sqlalchemy-quickstart/blob/main/Expected-Output.txt)をチェックして、出力が一致するかどうかを確認してください。
 
 ## サンプルコードスニペット {#sample-code-snippets}
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Continuation of the literal-identifier-mistranslation sweep (#23617/#23618/#23619/#23622). 11 `develop/dev-guide-sample-application-*.md` files link to the actual GitHub file `Expected-Output.txt` using the translated link text `期待される出力.txt` instead of the literal filename, e.g.:

```
[期待される出力.txt](https://github.com/tidb-samples/tidb-java-hibernate-quickstart/blob/main/Expected-Output.txt)
```

should be:

```
[Expected-Output.txt](https://github.com/tidb-samples/tidb-java-hibernate-quickstart/blob/main/Expected-Output.txt)
```

All 11 sites verified against the English source (`Check the [Expected-Output.txt](url) to see if the output matches.`).

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): continuation of #23617/#23618/#23619/#23622

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
