### PR TITLE
performance-tuning-overview: use Key Visualizer proper noun consistently

### DIFF
--- a/performance-tuning-overview.md
+++ b/performance-tuning-overview.md
@@ -83,7 +83,7 @@ To tune performance efficiently, you need to capture the current performance dat
 - Mean and long-tail values of user response time, and throughput of your application
 - Database performance data such as database time, query latency, and QPS
 
-    TiDB measures and stores performance data thoroughly in different dimensions, such as [slow query logs](/identify-slow-queries.md), [Top SQL](/dashboard/top-sql.md), [Continuous Performance Profiling](/dashboard/continuous-profiling.md), and [traffic visualizer](/dashboard/dashboard-key-visualizer.md). In addition, you can perform historical backtracking and comparison of the timing metrics data stored in Prometheus.
+    TiDB measures and stores performance data thoroughly in different dimensions, such as [slow query logs](/identify-slow-queries.md), [Top SQL](/dashboard/top-sql.md), [Continuous Performance Profiling](/dashboard/continuous-profiling.md), and [Key Visualizer](/dashboard/dashboard-key-visualizer.md). In addition, you can perform historical backtracking and comparison of the timing metrics data stored in Prometheus.
 
 - Resource utilization, including resources such as CPU, IO, and network
 - Configuration information, such as application configurations, database configurations, and operating system configurations


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Found while reviewing a Japanese translation fix (docs#23627): `performance-tuning-overview.md` linked to the Key Visualizer feature page (`/dashboard/dashboard-key-visualizer.md`) using the generic link text "traffic visualizer" instead of the established proper noun "Key Visualizer" used consistently everywhere else this feature is referenced (`TOC.md`, `troubleshoot-hot-spot-issues.md`, `tidb-cloud/tune-performance.md`, `develop/dev-guide-use-follower-read.md`, etc.).

This inconsistency also caused the Japanese translation to render it as a literal (and confusing) "交通ビジュアライザー" ("traffic" in the transportation sense) instead of keeping the established English term.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master

### What is the related PR or file link(s)?

- Related: pingcap/docs#23627 (the Japanese translation fix this was found while reviewing)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the performance baseline documentation link text to clearly reference the Key Visualizer dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->