### PR TITLE
i18n(ja): translate residual English availability zone left in JA prose

### DIFF
--- a/tidb-cloud/architecture-concepts.md
+++ b/tidb-cloud/architecture-concepts.md
@@ -103,9 +103,9 @@ BYOC は、次の機能を提供します。
 - **Cloud-account-level controls**: ネットワーキング、セキュリティ、監査可能性、コンプライアンスに対して、お客様独自のクラウドポリシーを適用できます。
 - **Private connectivity**: BYOC の設定に応じて、VPC ピアリング などのプライベートネットワークアクセスパターンをサポートします。
 
-さまざまなワークロード要件に対応するため、TiDB Cloud BYOC は Single-AZ と Multi-AZ の両方のデプロイをサポートしており、低レイテンシーのゾーン単位デプロイと、複数の availability zone にまたがる高い耐障害性を持つデプロイのどちらかを選択できます。
+さまざまなワークロード要件に対応するため、TiDB Cloud BYOC は Single-AZ と Multi-AZ の両方のデプロイをサポートしており、低レイテンシーのゾーン単位デプロイと、複数のアベイラビリティゾーンにまたがる高い耐障害性を持つデプロイのどちらかを選択できます。
 
-各リソースプールの高可用性モードは、[プールを作成する](/tidb-cloud/byoc/create-resource-pool-byoc.md)際に **Zonal** または **Regional** に設定できます。ゾーンリソースプールは単一の availability zone にデプロイされ、リージョンリソースプールは複数の availability zone にまたがってデプロイされます。TiDB Cloud は、BYOC リージョンの設定と利用可能なクラウドリソースに基づいて availability zone の配置を決定します。リソースプール内で作成または復元された TiDB Cloud BYOC インスタンスは、そのプールの高可用性モードを継承します。リソースプールの作成後は、その高可用性モードまたは availability zone の配置を変更できません。
+各リソースプールの高可用性モードは、[プールを作成する](/tidb-cloud/byoc/create-resource-pool-byoc.md)際に **Zonal** または **Regional** に設定できます。ゾーンリソースプールは単一のアベイラビリティゾーンにデプロイされ、リージョンリソースプールは複数のアベイラビリティゾーンにまたがってデプロイされます。TiDB Cloud は、BYOC リージョンの設定と利用可能なクラウドリソースに基づいてアベイラビリティゾーンの配置を決定します。リソースプール内で作成または復元された TiDB Cloud BYOC インスタンスは、そのプールの高可用性モードを継承します。リソースプールの作成後は、その高可用性モードまたはアベイラビリティゾーンの配置を変更できません。
 
 ![TiDB Cloud BYOC Architecture](/media/tidb-cloud/byoc-architecture.png)
 

--- a/tidb-cloud/premium/connect-to-premium-via-aws-private-endpoint.md
+++ b/tidb-cloud/premium/connect-to-premium-via-aws-private-endpoint.md
@@ -66,7 +66,7 @@ TiDB Cloud で AWS CLI コマンドを生成するには、**Create AWS Private 
 
 1. **Your VPC ID** を入力します。
 2. **Your Subnet IDs** を入力します。複数の subnet を指定する場合は、subnet ID をスペースで区切ります。
-3. subnet がダイアログでサポートされている availability zone にあることを確認します。他の availability zone の subnet は使用しないでください。
+3. subnet がダイアログでサポートされているアベイラビリティゾーンにあることを確認します。他のアベイラビリティゾーンの subnet は使用しないでください。
 4. **Generate Command** をクリックします。
 
 生成されるコマンドは次のようになります。
@@ -88,7 +88,7 @@ AWS CLI を使用して VPC endpoint を作成するには、次の手順を実�
 >
 > - コマンドを実行する前に、AWS CLI をインストールして設定しておく必要があります。詳細は [AWS CLI configuration basics](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) を参照してください。
 >
-> - サービスが 3つを超える availability zone (AZ) にまたがっている場合、VPC endpoint service が subnet の AZ をサポートしていないことを示すエラーメッセージが表示されます。この問題は、選択したリージョンに、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されている AZ に加えて、余分な AZ が存在する場合に発生します。この場合は、[PingCAP Technical Support](https://docs.pingcap.com/tidbcloud/tidb-cloud-support) にお問い合わせください。
+> - サービスが 3つを超えるアベイラビリティゾーン（AZ）にまたがっている場合、VPC endpoint service が subnet の AZ をサポートしていないことを示すエラーメッセージが表示されます。この問題は、選択したリージョンに、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されている AZ に加えて、余分な AZ が存在する場合に発生します。この場合は、[PingCAP Technical Support](https://docs.pingcap.com/tidbcloud/tidb-cloud-support) にお問い合わせください。
 
 </div>
 <div label="Use AWS Console">
@@ -106,11 +106,11 @@ AWS Management Console を使用して VPC endpoint を作成するには、次�
 4. **Service settings** エリアで、TiDB Cloud からコピーした **Endpoint Service Name** を入力します。
 5. **Verify service** をクリックします。
 6. **Network settings** エリアで、ドロップダウンリストから VPC を選択します。
-7. **Subnets** エリアで、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されている availability zone を選択します。
+7. **Subnets** エリアで、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されているアベイラビリティゾーンを選択します。
 
     > **Tip:**
     >
-    > サービスが 3つを超える availability zone (AZ) にまたがっている場合、**Subnets** エリアで AZ を選択できないことがあります。この問題は、選択したリージョンに、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されている AZ に加えて、余分な AZ が存在する場合に発生します。この場合は、[PingCAP Technical Support](https://docs.pingcap.com/tidbcloud/tidb-cloud-support) にお問い合わせください。
+    > サービスが 3つを超えるアベイラビリティゾーン（AZ）にまたがっている場合、**Subnets** エリアで AZ を選択できないことがあります。この問題は、選択したリージョンに、{{{ .premium }}}<CustomContent plan="byoc"> または {{{ .byoc }}}</CustomContent> インスタンスが配置されている AZ に加えて、余分な AZ が存在する場合に発生します。この場合は、[PingCAP Technical Support](https://docs.pingcap.com/tidbcloud/tidb-cloud-support) にお問い合わせください。
 
 8. **Security groups** エリアで、適切な security group を選択します。
 

--- a/tidb-cloud/setup-aws-msk-provisioned-private-link-service.md
+++ b/tidb-cloud/setup-aws-msk-provisioned-private-link-service.md
@@ -14,21 +14,21 @@ TiDB Cloud で Amazon MSK Provisioned のダウンストリームサービス用
 ## 前提条件 {#prerequisites}
 
 - AWS 上でホストされ、**Active** 状態の [TiDB Cloud Premium インスタンス](/tidb-cloud/premium/create-tidb-instance-premium.md)。
-- TiDB Cloud Premium インスタンスの **AWS Account ID** と **availability zone IDs (AZ IDs)**。
+- TiDB Cloud Premium インスタンスの **AWS Account ID** と **アベイラビリティゾーンID（AZ ID）**。
 
   これらの値を取得するには、次の手順を実行します。
 
     1. [TiDB Cloud コンソール](https://tidbcloud.com)でインスタンスの概要ページに移動し、**Settings** > **Networking** をクリックします。
     2. **Private Link Endpoint For External Services** エリアで、**Create Private Endpoint for External Services** をクリックします。
-    3. ダイアログで **Connection Type** を **AWS MSK Provisioned** に切り替え、**AWS Account ID** と **availability zone IDs**（例: `use1-az1`）を確認します。
+    3. ダイアログで **Connection Type** を **AWS MSK Provisioned** に切り替え、**AWS Account ID** と **アベイラビリティゾーンID**（例: `use1-az1`）を確認します。
 
-    **AZ の整合性に関する重要事項**: AWS アカウント間で availability zone の整合性を確認する際は、AZ 名（例: `us-east-1a`）ではなく AZ ID（例: `use1-az1`）を使用してください。同じ AZ 名でも、アカウントによって異なる物理ゾーンに対応している場合があります。MSK クラスターは、TiDB Cloud Premium インスタンスと同じ AZ ID を使用する必要があります。
+    **AZ の整合性に関する重要事項**: AWS アカウント間でアベイラビリティゾーンの整合性を確認する際は、AZ 名（例: `us-east-1a`）ではなく AZ ID（例: `use1-az1`）を使用してください。同じ AZ 名でも、アカウントによって異なる物理ゾーンに対応している場合があります。MSK クラスターは、TiDB Cloud Premium インスタンスと同じ AZ ID を使用する必要があります。
 
 ## ステップ 1. Amazon VPC とサブネットをセットアップする {#step-1-set-up-the-amazon-vpc-and-subnets}
 
-必要な availability zone にまたがる少なくとも 3つのプライベートサブネットを持つ Amazon VPC がすでにある場合は、このステップをスキップできます。
+必要なアベイラビリティゾーンにまたがる少なくとも 3つのプライベートサブネットを持つ Amazon VPC がすでにある場合は、このステップをスキップできます。
 
-1. [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、TiDB Cloud Premium インスタンスが稼働する各 availability zone に 1つずつ、合計3つのプライベートサブネットを持つ [VPC を作成](https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html)します。これらのサブネットは同じ AZ に存在し、AZ 名ではなく AZ ID で一致している必要があります。
+1. [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、TiDB Cloud Premium インスタンスが稼働する各アベイラビリティゾーンに 1つずつ、合計3つのプライベートサブネットを持つ [VPC を作成](https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html)します。これらのサブネットは同じ AZ に存在し、AZ 名ではなく AZ ID で一致している必要があります。
 2. VPC ダッシュボードで、後から起動するクライアント EC2 インスタンスがプライベートネットワーク経由で MSK クラスターと通信できるように、ルートテーブルとセキュリティグループを設定します。
 3. サブネットの AZ ID を記録します。これらのサブネットは、[MSK クラスターを作成する](#step-3-create-an-amazon-msk-provisioned-cluster)際に選択します。
 
@@ -60,7 +60,7 @@ TiDB Cloud で Amazon MSK Provisioned のダウンストリームサービス用
 - **Broker type**: multi-VPC private connectivity でサポートされる broker type を選択します（`t3.small` は不可）。
 - **Authentication**: SASL/SCRAM 認証を有効にします。
 - **Public access**: このオプションを無効にします。
-- **Number of brokers**: availability zone ごとに少なくとも 1つ（最小 3）。
+- **Number of brokers**: アベイラビリティゾーンごとに少なくとも 1つ（最小 3）。
 - **Encryption in transit**: セキュリティ要件に応じて設定します。
 - **Client subnets**: [ステップ 1](#step-1-set-up-the-amazon-vpc-and-subnets) で作成した 3つのプライベートサブネットを選択します。
 - **Cluster configuration**: 次の設定を含むカスタム設定を作成します（初期 ACL セットアップに必要）。

--- a/tidb-cloud/setup-aws-msk-provisioned-private-link-service.md
+++ b/tidb-cloud/setup-aws-msk-provisioned-private-link-service.md
@@ -28,7 +28,7 @@ TiDB Cloud で Amazon MSK Provisioned のダウンストリームサービス用
 
 必要なアベイラビリティゾーンにまたがる少なくとも 3つのプライベートサブネットを持つ Amazon VPC がすでにある場合は、このステップをスキップできます。
 
-1. [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、TiDB Cloud Premium インスタンスが稼働する各アベイラビリティゾーンに 1つずつ、合計3つのプライベートサブネットを持つ [VPC を作成](https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html)します。これらのサブネットは同じ AZ に存在し、AZ 名ではなく AZ ID で一致している必要があります。
+1. [Amazon VPC コンソール](https://console.aws.amazon.com/vpc/)で、TiDB Cloud Premium インスタンスが稼働する各アベイラビリティゾーンに 1つずつ、合計3つのプライベートサブネットを持つ [VPC を作成](https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html)します。これらのサブネットは、AZ 名ではなく AZ ID に基づいて、TiDB Cloud Premium インスタンスが稼働する各アベイラビリティゾーンと一致している必要があります。
 2. VPC ダッシュボードで、後から起動するクライアント EC2 インスタンスがプライベートネットワーク経由で MSK クラスターと通信できるように、ルートテーブルとセキュリティグループを設定します。
 3. サブネットの AZ ID を記録します。これらのサブネットは、[MSK クラスターを作成する](#step-3-create-an-amazon-msk-provisioned-cluster)際に選択します。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

3 files had the raw English words "availability zone(s)" left untranslated directly in otherwise-translated Japanese sentences, instead of アベイラビリティゾーン matching the rest of each file's own prose:

- `tidb-cloud/setup-aws-msk-provisioned-private-link-service.md` (6 sites)
- `tidb-cloud/architecture-concepts.md` (2 sites)
- `tidb-cloud/premium/connect-to-premium-via-aws-private-endpoint.md` (4 sites)

Bold UI-field labels matching literal console field names (e.g. `**Availability Zone**: \`us-west-2a\``) are intentionally kept in English elsewhere per the established convention and are unaffected by this change.

Note: this corpus also has a separate, larger 3-way notation split for the "availability zone" concept itself (可用性ゾーン / アベイラビリティゾーン / アベイラビリティーゾーン, ~129 occurrences across 40+ files) — out of scope here since it's a term-unification decision, not a clear mistranslation; will be scoped separately.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
