### PR TITLE
transaction-isolation-levels: fix wording and grammar issues

### DIFF
--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -36,7 +36,7 @@ TiDB implements Snapshot Isolation (SI) consistency, which it advertises as `REP
 
 ## Repeatable Read isolation level
 
-The Repeatable Read isolation level only sees data committed before the transaction begins, and it never sees either uncommitted data or changes committed during transaction execution by concurrent transactions. However, within its own transaction, a statement does see the effects of updates made by previous statements in that transaction, even though those updates are not yet committed.
+The Repeatable Read isolation level only sees data committed before the transaction begins, and it never sees either uncommitted data or changes committed during transaction execution by concurrent transactions. However, a statement within the transaction can see changes made by previous statements in the same transaction, even if those changes are not yet committed.
 
 For transactions running on different nodes, the start and commit order depends on the order that the timestamp is obtained from PD.
 

--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -55,7 +55,7 @@ commit;                         |
 
 ### Difference between TiDB and ANSI Repeatable Read
 
-The Repeatable Read isolation level in TiDB differs from ANSI Repeatable Read isolation level, though they sharing the same name. According to the standard described in the [A Critique of ANSI SQL Isolation Levels](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-95-51.pdf) paper, TiDB implements the Snapshot Isolation level. This isolation level does not allow strict phantoms (A3) but allows broad phantoms (P3) and write skews. In contrast, the ANSI Repeatable Read isolation level allows phantom reads but does not allow write skews.
+The Repeatable Read isolation level in TiDB differs from the ANSI Repeatable Read isolation level, though they share the same name. According to the standard described in the [A Critique of ANSI SQL Isolation Levels](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-95-51.pdf) paper, TiDB implements the Snapshot Isolation level. This isolation level does not allow strict phantoms (A3) but allows broad phantoms (P3) and write skews. In contrast, the ANSI Repeatable Read isolation level allows phantom reads but does not allow write skews.
 
 ### Difference between TiDB and MySQL Repeatable Read
 

--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -36,7 +36,7 @@ TiDB implements Snapshot Isolation (SI) consistency, which it advertises as `REP
 
 ## Repeatable Read isolation level
 
-The Repeatable Read isolation level only sees data committed before the transaction begins, and it never sees either uncommitted data or changes committed during transaction execution by concurrent transactions. However, the transaction statement does see the effects of previous updates executed within its own transaction, even though they are not yet committed.
+The Repeatable Read isolation level only sees data committed before the transaction begins, and it never sees either uncommitted data or changes committed during transaction execution by concurrent transactions. However, within its own transaction, a statement does see the effects of updates made by previous statements in that transaction, even though those updates are not yet committed.
 
 For transactions running on different nodes, the start and commit order depends on the order that the timestamp is obtained from PD.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Two EN clarity/grammar issues found while reviewing a Japanese translation of this file:

**1. Ambiguous "the transaction statement" wording**

The Repeatable Read section says "the transaction statement does see the effects of previous updates executed within its own transaction" — the definite noun phrase "the transaction statement" reads as if it names a specific category of statement, when the actual meaning is that a statement running within a transaction can see the effects of earlier statements in that SAME transaction (contrasted with not seeing other transactions' uncommitted or concurrently-committed changes).

Confirmed against the Chinese source (`docs-cn`'s corresponding sentence): "对于本事务而言，事务语句可以看到之前的语句做出的修改" — literally "as far as this [own] transaction is concerned, statements [in it] can see the modifications made by previous statements". The Chinese explicitly contrasts "本事务" (this own transaction) against the earlier-mentioned "其他事务" (other transactions); the EN translation dropped that contrast, leaving an ambiguous definite noun phrase.

Reworded to make the "within its own transaction" contrast explicit:

> However, within its own transaction, a statement does see the effects of updates made by previous statements in that transaction, even though those updates are not yet committed.

**2. Subject-verb agreement error**

"though they sharing the same name" is not a grammatical clause (a gerund cannot follow the subject "they" as the main verb). Fixed to "though they share the same name", and added the missing article before "ANSI Repeatable Read isolation level" for consistency with its other mention later in the same paragraph.

Verified against the Chinese source that the surrounding translation itself is accurate (`docs-cn`: "尽管名称是可重复读隔离级别，但是 TiDB 中可重复读隔离级别和 ANSI 可重复隔离级别是不同的") — only the EN grammar needed fixing, not the meaning.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): found while reviewing a Japanese translation of this file, [pingcap/docs#23639](https://github.com/pingcap/docs/pull/23639)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Repeatable Read transaction behavior, including visibility of earlier statements’ effects and uncommitted updates within the same transaction.
  * Corrected a grammar issue in the comparison between TiDB and ANSI Repeatable Read semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->