### PR TITLE
cloud: update the default TiDB version for newly created Dedicated clusters

### DIFF
--- a/tidb-cloud/releases/_index.md
+++ b/tidb-cloud/releases/_index.md
@@ -24,7 +24,7 @@ The database kernel is the core engine that processes your SQL queries and manag
 | TiDB Cloud **Starter** | Running on a customized [TiDB X](/tidb-cloud/tidb-x-architecture.md) engine based on the classic [TiDB v8.5.3](https://docs.pingcap.com/tidb/stable/release-8.5.3/) kernel. |
 | TiDB Cloud **Essential** | Running on a customized [TiDB X](/tidb-cloud/tidb-x-architecture.md) engine based on the classic [TiDB v8.5.3](https://docs.pingcap.com/tidb/stable/release-8.5.3/) kernel by default. |
 | TiDB Cloud **Premium** | Running on the [`TiDB-X-CLOUD.202510.1`](/tidb-cloud/releases/tidb-x-cloud.202510.1.md) version of the [TiDB X](/tidb-cloud/tidb-x-architecture.md) kernel. |
-| TiDB Cloud **Dedicated** | Running on the classic TiDB kernel, and the kernel version corresponds directly to TiDB Self-Managed versions. Currently, the default TiDB version of newly created TiDB Cloud Dedicated clusters is [v8.5.7](https://docs.pingcap.com/tidb/stable/release-8.5.7/). |
+| TiDB Cloud **Dedicated** | Running on the classic TiDB kernel, and the kernel version corresponds directly to TiDB Self-Managed versions. Currently, the default TiDB version of newly created TiDB Cloud Dedicated clusters is [v8.5.8](https://docs.pingcap.com/tidb/stable/release-8.5.8/). |
 
 > **Note:**
 >

--- a/tidb-cloud/releases/tidb-cloud-release-notes.md
+++ b/tidb-cloud/releases/tidb-cloud-release-notes.md
@@ -8,6 +8,14 @@ aliases: ['/tidbcloud/supported-tidb-versions','/tidbcloud/release-notes','/ai/v
 
 This page lists the release notes of [TiDB Cloud](https://www.pingcap.com/tidb-cloud/) in 2026.
 
+## August 28, 2026
+
+**General changes**
+
+- **TiDB Cloud Dedicated**
+
+    - Upgrade the default TiDB version of new [TiDB Cloud Dedicated](/tidb-cloud/select-cluster-tier.md#tidb-cloud-dedicated) clusters from [v8.5.7](https://docs.pingcap.com/tidb/stable/release-8.5.7/) to [v8.5.8](https://docs.pingcap.com/tidb/stable/release-8.5.8/).
+
 ## August 25, 2026
 
 **General changes**

--- a/tidb-cloud/tidb-cloud-faq.md
+++ b/tidb-cloud/tidb-cloud-faq.md
@@ -41,7 +41,7 @@ No.
 
 ### What versions of TiDB are supported on TiDB Cloud?
 
-- For new TiDB Cloud Dedicated clusters, the default TiDB version is [v8.5.7](https://docs.pingcap.com/tidb/v8.5/release-8.5.7) starting from July 9, 2026.
+- For new TiDB Cloud Dedicated clusters, the default TiDB version is [v8.5.8](https://docs.pingcap.com/tidb/v8.5/release-8.5.8) starting from August 28, 2026.
 - For {{{ .starter }}} instances, the TiDB version is [v8.5.3](https://docs.pingcap.com/tidb/stable/release-8.5.3) starting from February 10, 2026.
 - For {{{ .essential }}} instances, the TiDB version is [v7.5.2](https://docs.pingcap.com/tidb/stable/release-7.5.2) starting from April 22, 2025.
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

As in the title

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated TiDB Cloud Dedicated release notes for August 28, 2026.
  - New Dedicated clusters now use TiDB v8.5.8 by default, replacing v8.5.7.
  - Updated the supported-version FAQ and release-notes reference accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->