### PR TITLE
i18n(ja): unify remaining Read Committed isolation level notation

### DIFF
--- a/basic-features.md
+++ b/basic-features.md
@@ -172,8 +172,8 @@ summary: TiDBの機能概要について学びましょう。
 | [大規模トランザクション（1 TiB）](/transaction-overview.md#transaction-size-limit)                                |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
 | [悲観的トランザクション](/pessimistic-transaction.md)                                                                |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
 | [楽観的トランザクション](/optimistic-transaction.md)                                                                 |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
-| [反復読み取り分離（スナップショット分離）](/transaction-isolation-levels.md)                                             |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
-| [リードコミット隔離](/transaction-isolation-levels.md)                                                        |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
+| [Repeatable-read isolation（スナップショット分離）](/transaction-isolation-levels.md) |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
+| [Read-committed isolation](/transaction-isolation-levels.md) |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |  Y  |
 | [長時間実行されているアイドル状態のトランザクションを自動的に終了する](/system-variables.md#tidb_idle_transaction_timeout-new-in-v760) |  Y  |  Y  |  N  |  N  |  N  |  N  |  N  |
 | [一括DML実行モード（ `tidb_dml_type = "bulk"` ）](/system-variables.md#tidb_dml_type-new-in-v800)   |  E  |  E  |  N  |  N  |  N  |  N  |  N  |
 

--- a/releases/release-2.0.6.md
+++ b/releases/release-2.0.6.md
@@ -37,7 +37,7 @@ summary: TiDB 2.0.6は、システムの互換性と安定性の向上を伴い�
     - `Index Join`一部のシナリオでタイムスタンプを初期化しないとpanicが発生する問題を修正[＃7246](https://github.com/pingcap/tidb/pull/7246)
     - セッションでタイムゾーンを誤って使用した`ADMIN CHECK TABLE`の誤報問題を修正 [＃7258](https://github.com/pingcap/tidb/pull/7258)
     - `ADMIN CLEANUP INDEX`一部のシナリオでインデックスがクリーンアップされない問題を修正[＃7265](https://github.com/pingcap/tidb/pull/7265)
-    - 読み取りコミット分離レベルを無効にする [＃7282](https://github.com/pingcap/tidb/pull/7282)
+    - Read Committed分離レベルを無効にする [＃7282](https://github.com/pingcap/tidb/pull/7282)
 
 ## TiKV {#tikv}
 

--- a/releases/release-6.0.0-dmr.md
+++ b/releases/release-6.0.0-dmr.md
@@ -98,9 +98,9 @@ TiDB v6.0.0 は DMR であり、そのバージョンは 6.0.0-DMR です。
 
     [ユーザードキュメント](/pessimistic-transaction.md#in-memory-pessimistic-lock) [＃11452](https://github.com/tikv/tikv/issues/11452)
 
-- リードコミット分離レベルでTSOを実現するための最適化
+- Read Committed分離レベルでTSOを取得するための最適化
 
-    クエリのレイテンシーを削減するため、読み取り/書き込み競合がまれな場合、TiDBは[コミット読み取り分離レベル](/transaction-isolation-levels.md#read-committed-isolation-level)時点で`tidb_rc_read_check_ts`のシステム変数を追加し、不要なTSOを削減します。この変数はデフォルトで無効になっています。この変数を有効にすると、読み取り/書き込み競合が発生しないシナリオでは、この最適化によりTSOの重複が回避され、レイテンシーが削減されます。ただし、読み取り/書き込み競合が頻繁に発生するシナリオでは、この変数を有効にするとパフォーマンスが低下する可能性があります。
+    クエリのレイテンシーを削減するため、読み取り/書き込み競合がまれな場合、TiDBは[Read Committed分離レベル](/transaction-isolation-levels.md#read-committed-isolation-level)において`tidb_rc_read_check_ts`のシステム変数を追加し、不要なTSOの取得を削減します。この変数はデフォルトで無効になっています。この変数を有効にすると、読み取り/書き込み競合が発生しないシナリオでは、この最適化によりTSOの重複取得が回避され、レイテンシーが削減されます。ただし、読み取り/書き込み競合が頻繁に発生するシナリオでは、この変数を有効にするとパフォーマンスが低下する可能性があります。
 
     [ユーザードキュメント](/transaction-isolation-levels.md#read-committed-isolation-level) [＃33159](https://github.com/pingcap/tidb/issues/33159)
 
@@ -399,7 +399,7 @@ TiDB v6.0.0 は DMR であり、そのバージョンは 6.0.0-DMR です。
         - サポート配置ルール[＃4846](https://github.com/pingcap/tiflow/issues/4846)
         - HTTP API処理の同期[＃1710](https://github.com/pingcap/tiflow/issues/1710)
         - チェンジフィードを再開するための指数バックオフ メカニズムを追加します。 [＃3329](https://github.com/pingcap/tiflow/issues/3329)
-        - MySQL でのデッドロックを減らすために、MySQL シンクのデフォルトの分離レベルを読み取りコミットに設定します。 [＃3589](https://github.com/pingcap/tiflow/issues/3589)
+        - MySQL でのデッドロックを減らすために、MySQL シンクのデフォルトの分離レベルをread-committedに設定します。 [＃3589](https://github.com/pingcap/tiflow/issues/3589)
         - 作成時に変更フィードパラメータを検証し、エラーメッセージを改善する[＃1716](https://github.com/pingcap/tiflow/issues/1716) [＃1718](https://github.com/pingcap/tiflow/issues/1718) [＃1719](https://github.com/pingcap/tiflow/issues/1719) [＃4472](https://github.com/pingcap/tiflow/issues/4472)
         - Kafka プロデューサーの設定パラメータを公開して、TiCDC で設定できるようにします。 [＃4385](https://github.com/pingcap/tiflow/issues/4385)
 

--- a/releases/release-6.3.0.md
+++ b/releases/release-6.3.0.md
@@ -129,7 +129,7 @@ TiDBバージョン: 6.3.0-DMR
 
 - Read-Committed 分離レベルで TSO を取得する方法を最適化します [#36812](https://github.com/pingcap/tidb/issues/36812) @[TonsnakeLin](https://github.com/TonsnakeLin)
 
-    リードコミット分離レベルでは、システム変数[`tidb_rc_write_check_ts`](/system-variables.md#tidb_rc_write_check_ts-new-in-v630)導入され、TSOのフェッチ方法を制御します。プランキャッシュヒットの場合、TiDBはTSOのフェッチ頻度を減らすことでバッチDMLステートメントの実行効率を向上させ、バッチで実行されるタスクの実行時間を短縮します。
+    Read-Committed 分離レベルでは、TSOのフェッチ方法を制御するためのシステム変数[`tidb_rc_write_check_ts`](/system-variables.md#tidb_rc_write_check_ts-new-in-v630)が導入されます。プランキャッシュがヒットした場合、TiDBはTSOのフェッチ頻度を減らすことでバッチDMLステートメントの実行効率を向上させ、バッチで実行されるタスクの実行時間を短縮します。
 
 ### 安定性 {#stability}
 
@@ -233,9 +233,9 @@ TiDBバージョン: 6.3.0-DMR
 | [`tidb_opt_force_inline_cte`](/system-variables.md#tidb_opt_force_inline_cte-new-in-v630)                                   | 新しく追加された | セッション全体の共通テーブル式 (CTE) をインライン化するかどうかを制御します。デフォルト値は`OFF`で、これはデフォルトでは CTE のインライン化が強制されないことを意味します。                                                                                                                                       |
 | [`tidb_opt_three_stage_distinct_agg`](/system-variables.md#tidb_opt_three_stage_distinct_agg-new-in-v630)                   | 新しく追加された | `COUNT(DISTINCT)`集計を MPP モードで 3 段階集計に書き換えるかどうかを指定します。デフォルト値は`ON`です。                                                                                                                                                                  |
 | [`tidb_partition_prune_mode`](/system-variables.md#tidb_partition_prune_mode-new-in-v51)                                    | 変更     | 動的剪定を有効にするかどうかを指定します。v6.3.0 以降、デフォルト値は`dynamic`に変更されます。                                                                                                                                                                              |
-| [`tidb_rc_read_check_ts`](/system-variables.md#tidb_rc_read_check_ts-new-in-v600)                                           | 変更     | タイムスタンプの取得を最適化するために使用され、読み取りコミット分離レベルのシナリオ（読み取りと書き込みの競合がまれなシナリオ）に適しています。この機能は特定のサービスワークロード向けに設計されており、他のシナリオではパフォーマンスが低下する可能性があります。そのため、v6.3.0以降、この変数の適用範囲が`GLOBAL \| SESSION`から`INSTANCE`に変更されました。つまり、特定のTiDBインスタンスに対してこの機能を有効にできます。 |
-| [`tidb_rc_write_check_ts`](/system-variables.md#tidb_rc_write_check_ts-new-in-v630)                                         | 新しく追加された | タイムスタンプの取得を最適化するために使用され、悲観的トランザクションのRC分離レベルにおいてポイントライト競合が少ないシナリオに適しています。この変数を有効にすると、ポイントライトステートメントの実行中にグローバルタイムスタンプを取得する際に発生するレイテンシーとオーバーヘッドを回避できます。                                                                                 |
-| [`tiflash_fastscan`](/system-variables.md#tiflash_fastscan-new-in-v630)                                                     | 新しく追加された | FastScanを有効にするかどうかを制御します。FastScan[ファストスキャン](/tiflash/use-fastscan.md)有効になっている場合（ `ON`に設定）、 TiFlashはより効率的なクエリパフォーマンスを提供しますが、クエリ結果の正確性やデータの一貫性は保証されません。                                                                                |
+| [`tidb_rc_read_check_ts`](/system-variables.md#tidb_rc_read_check_ts-new-in-v600)                                           | 変更     | タイムスタンプの取得を最適化するために使用され、read-committed分離レベルのシナリオ（読み取りと書き込みの競合がまれなシナリオ）に適しています。この機能は特定のサービスワークロード向けに設計されており、他のシナリオではパフォーマンスが低下する可能性があります。そのため、v6.3.0以降、この変数の適用範囲が`GLOBAL \| SESSION`から`INSTANCE`に変更されました。つまり、特定のTiDBインスタンスに対してこの機能を有効にできます。 |
+| [`tidb_rc_write_check_ts`](/system-variables.md#tidb_rc_write_check_ts-new-in-v630)                                         | 新しく追加された | タイムスタンプの取得を最適化するために使用され、悲観的トランザクションのRC分離レベルにおいてポイント書き込み競合が少ないシナリオに適しています。この変数を有効にすると、ポイント書き込みステートメントの実行中にグローバルタイムスタンプを取得する際に発生するレイテンシーとオーバーヘッドを回避できます。                                                                                 |
+| [`tiflash_fastscan`](/system-variables.md#tiflash_fastscan-new-in-v630)                                                     | 新しく追加された | FastScanを有効にするかどうかを制御します。FastScan[ファストスキャン](/tiflash/use-fastscan.md)が有効になっている場合（ `ON`に設定）、 TiFlashはより効率的なクエリパフォーマンスを提供しますが、クエリ結果の正確性やデータの一貫性は保証されません。                                                                                |
 
 ### コンフィグレーションファイルパラメータ {#configuration-file-parameters}
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -3340,7 +3340,7 @@ MPP は、 TiFlashエンジンによって提供される分散コンピュー�
     - `schemaVersion` : 現在のスキーマバージョン。
     - `txnStartTS` : 現在のトランザクションが開始されたタイムスタンプ。
     - `forUpdateTS` :悲観的トランザクションモードでは、 `forUpdateTS`は SQL ステートメントの現在のタイムスタンプです。悲観的トランザクションで書き込み競合が発生すると、TiDB は現在実行中の SQL ステートメントを再試行し、このタイムスタンプを更新します。再試行回数は[`max-retry-count`](/tidb-configuration-file.md#max-retry-count)で設定できます。楽観的トランザクションモデルでは、 `forUpdateTS`は`txnStartTS`と同等です。
-    - `isReadConsistency` : 現在のトランザクション分離レベルが読み取りコミット済み (RC) かどうかを示します。
+    - `isReadConsistency` : 現在のトランザクション分離レベルがRead Committed (RC) かどうかを示します。
     - `current_db` : 現在のデータベースの名前。
     - `txn_mode` : トランザクションモード。値のオプションは`OPTIMISTIC`と`PESSIMISTIC`です。
     - `sql` : 現在のクエリに対応する SQL ステートメント。
@@ -5586,8 +5586,8 @@ SHOW WARNINGS;
 - ヒント[SET_VAR](/optimizer-hints.md#set_varvar_namevar_value)に適用：いいえ
 - 型: Boolean
 - デフォルト値: `OFF`
-- この変数はタイムスタンプの取得を最適化するために使用され、読み取りコミット分離レベルが採用され、読み書きの競合がまれなシナリオに適しています。この変数を有効にすることで、グローバルタイムスタンプの取得に伴うレイテンシーとコストを回避し、トランザクションレベルの読み取りレイテンシーを最適化できます。
-- 読み取り/書き込み競合が深刻な場合、この機能を有効にすると、グローバル タイムスタンプを取得するコストとレイテンシーが増加し、パフォーマンスの低下を引き起こす可能性があります。詳細については、 [隔離レベルを遵守する](/transaction-isolation-levels.md#read-committed-isolation-level)をご覧ください。
+- この変数はタイムスタンプの取得を最適化するために使用され、read-committed分離レベルが採用され、読み書きの競合がまれなシナリオに適しています。この変数を有効にすることで、グローバルタイムスタンプの取得に伴うレイテンシーとコストを回避し、トランザクションレベルの読み取りレイテンシーを最適化できます。
+- 読み取り/書き込み競合が深刻な場合、この機能を有効にすると、グローバル タイムスタンプを取得するコストとレイテンシーが増加し、パフォーマンスの低下を引き起こす可能性があります。詳細については、 [Read Committed分離レベル](/transaction-isolation-levels.md#read-committed-isolation-level)をご覧ください。
 
 ### tidb_rc_write_check_ts <span class="version-mark">New in v6.3.0</span>
 
@@ -5601,7 +5601,7 @@ SHOW WARNINGS;
 - 型: Boolean
 - デフォルト値: `OFF`
 - この変数は、タイムスタンプの取得を最適化するために使用され、悲観的トランザクションの分離レベル`READ-COMMITTED`でポイント書き込み競合が少ないシナリオに適しています。この変数を有効にすると、ポイント書き込みステートメントの実行中にグローバルタイムスタンプを取得することによって発生するレイテンシーとオーバーヘッドを回避できます。現在、この変数は、 `UPDATE` 、 `DELETE` 、および`SELECT ...... FOR UPDATE`ポイント書き込みステートメントに適用できます。ポイント書き込みステートメントとは、フィルタ条件として主キーまたは一意キーを使用し、最終実行演算子に`POINT-GET`が含まれる書き込みステートメントを指します。
-- ポイントと書き込みの競合が深刻な場合、この変数を有効にすると、余分なオーバーヘッドとレイテンシーが増加し、パフォーマンスの低下につながります。詳細については、 [隔離レベルを遵守する](/transaction-isolation-levels.md#read-committed-isolation-level)をご覧ください。
+- ポイント書き込みの競合が深刻な場合、この変数を有効にすると、余分なオーバーヘッドとレイテンシーが増加し、パフォーマンスの低下につながります。詳細については、 [Read Committed分離レベル](/transaction-isolation-levels.md#read-committed-isolation-level)をご覧ください。
 
 ### tidb_read_consistency <span class="version-mark">New in v5.4.0</span>
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Follow-up to #23639 (which unified the Repeatable Read isolation level term and part of the Read Committed backlog). This PR converts the remaining Japanese-only / inconsistently-cased renderings of the SQL standard "Read Committed" isolation level to English, verified per-site against the corresponding English text and mirroring each site's own EN casing (e.g. Title Case "Read Committed" vs lowercase-hyphenated "read-committed", depending on how EN itself renders it at that specific site).

Also fixed one same-paragraph self-contradiction found in passing in `releases/release-6.3.0.md`: a bullet heading already correctly said "Read-Committed" while the very next line's body prose still said the katakana form.

Deliberately excludes `transaction-isolation-levels.md` and `tidb-performance-tuning-config.md` — both already fixed by the still-open #23639 on an unmerged branch; touching them here would conflict.

5 files changed, 6 sites converted.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): follow-up to #23639

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized Read Committed and read-committed terminology across transaction isolation, system variable, and release documentation.
  - Clarified descriptions of Read Committed behavior, TSO-related features, and TiCDC’s default isolation level.
  - Improved wording and link labels while preserving existing documentation links, version availability, and documented configuration scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->