### PR TITLE
i18n(ja): fix noun-smashed translation of a TiCDC release-note bullet

### DIFF
--- a/releases/release-6.0.0-dmr.md
+++ b/releases/release-6.0.0-dmr.md
@@ -396,7 +396,7 @@ TiDB v6.0.0 は DMR であり、そのバージョンは 6.0.0-DMR です。
     - TiCDC
 
         - Grafana に`Lag analyze`パネルを追加する [＃4891](https://github.com/pingcap/tiflow/issues/4891)
-        - サポート配置ルール[＃4846](https://github.com/pingcap/tiflow/issues/4846)
+        - 配置ルールのサポート[＃4846](https://github.com/pingcap/tiflow/issues/4846)
         - HTTP API処理の同期[＃1710](https://github.com/pingcap/tiflow/issues/1710)
         - チェンジフィードを再開するための指数バックオフ メカニズムを追加します。 [＃3329](https://github.com/pingcap/tiflow/issues/3329)
         - MySQL でのデッドロックを減らすために、MySQL シンクのデフォルトの分離レベルを読み取りコミットに設定します。 [＃3589](https://github.com/pingcap/tiflow/issues/3589)


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

`releases/release-6.0.0-dmr.md`: EN "Support placement rules" (a verb-initial release-note bullet) had been word-for-word reordered into a bare noun compound with no particle, reading as a smashed-together "Support-Placement-Rule" noun rather than a sentence. Reworded to the noun-ending form used by sibling bullets in the same list.

1 file changed, 1 site.

Note: a broader corpus-wide sweep found ~50 similar "Support X" release-note bullets across ~30 files (mostly older release notes, release-1.0 through release-7.x) with the same word-order issue — this PR fixes only the single site the user flagged; the rest are tracked separately for a future dedicated sweep since each needs individual EN verification.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch