### PR TITLE
i18n(ja): fix scrambled subject/object in changefeed event filter examples

### DIFF
--- a/tidb-cloud/changefeed-sink-to-apache-kafka.md
+++ b/tidb-cloud/changefeed-sink-to-apache-kafka.md
@@ -260,10 +260,10 @@ TiDB Cloudの変更フィードがデータをApache Kafkaにストリーミン�
     - **Event Filter**：以下のイベントフィルターを使用して、変更フィードから特定のイベントを除外できます。
         - **Ignore event**：指定されたイベントタイプを除外します。
         - **Ignore SQL**: 指定された式に一致する DDL イベントを除外します。たとえば、 `^drop` `DROP`で始まるステートメントを除外し、 `add column`は`ADD COLUMN`を含むステートメントを除外します。
-        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。
+        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。
         - **Ignore update new value expression**: 新しい値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `gender = 'male'`は`gender`が`male`になるような更新を除外します。
         - **Ignore update old value expression**: 古い値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `age < 18` `age`の古い値が 18 未満である場合の更新を除外します。
-        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、 `name = 'john'`は`DELETE`が`name`である`'john'`ステートメントを除外します。
+        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、`name = 'john'`は`name`が`'john'`である`DELETE`ステートメントを除外します。
 
 3. **Column Selector**カスタマイズして、イベントから列を選択し、選択した列に関連するデータ変更のみを下流に送信します。
 

--- a/tidb-cloud/changefeed-sink-to-apache-pulsar.md
+++ b/tidb-cloud/changefeed-sink-to-apache-pulsar.md
@@ -124,10 +124,10 @@ Apache PulsarサービスにパブリックIPアクセスを提供する場合�
     - **Event Filter**：以下のイベントフィルターを使用して、変更フィードから特定のイベントを除外できます。
         - **Ignore event**：指定されたイベントタイプを除外します。
         - **Ignore SQL**: 指定された式に一致する DDL イベントを除外します。たとえば、 `^drop` `DROP`で始まるステートメントを除外し、 `add column`は`ADD COLUMN`を含むステートメントを除外します。
-        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。
+        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。
         - **新しい値の更新式を無視する**: 新しい値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `gender = 'male'`は`gender`が`male`になるような更新を除外します。
         - **古い値の更新を無視する式**: 古い値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `age < 18` `age`の古い値が 18 未満である場合の更新を除外します。
-        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、 `name = 'john'`は`DELETE`が`name`である`'john'`ステートメントを除外します。
+        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、`name = 'john'`は`name`が`'john'`である`DELETE`ステートメントを除外します。
 
 3. **Start Replication Position**領域で、チェンジフィードがPulsarにデータをレプリケートする開始点を選択します。
 

--- a/tidb-cloud/changefeed-sink-to-cloud-storage.md
+++ b/tidb-cloud/changefeed-sink-to-cloud-storage.md
@@ -268,10 +268,10 @@ access key を使用して認証するには、以下の手順に従ってくだ
     - **Event Filter**：以下のイベントフィルターを使用して、変更フィードから特定のイベントを除外できます。
         - **Ignore event**：指定されたイベントタイプを除外します。
         - **Ignore SQL**: 指定された式に一致する DDL イベントを除外します。たとえば、 `^drop` `DROP`で始まるステートメントを除外し、 `add column`は`ADD COLUMN`を含むステートメントを除外します。
-        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。
+        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。
         - **新しい値の更新式を無視する**: 新しい値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `gender = 'male'`は`gender`が`male`になるような更新を除外します。
         - **古い値の更新を無視する式**: 古い値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `age < 18` `age`の古い値が 18 未満である場合の更新を除外します。
-        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、 `name = 'john'`は`DELETE`が`name`である`'john'`ステートメントを除外します。
+        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、`name = 'john'`は`name`が`'john'`である`DELETE`ステートメントを除外します。
 
 3. **Start Replication Position**領域で、以下のいずれかのレプリケーション位置を選択します。
 

--- a/tidb-cloud/changefeed-sink-to-mysql.md
+++ b/tidb-cloud/changefeed-sink-to-mysql.md
@@ -160,10 +160,10 @@ TiDB Cloud PremiumインスタンスがMySQLサービスに接続できること
     - **Event Filter**：以下のイベントフィルターを使用して、変更フィードから特定のイベントを除外できます。
         - **Ignore event**：指定されたイベントタイプを除外します。
         - **Ignore SQL**: 指定された式に一致する DDL イベントを除外します。たとえば、 `^drop` `DROP`で始まるステートメントを除外し、 `add column`は`ADD COLUMN`を含むステートメントを除外します。
-        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。
+        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。
         - **新しい値の更新式を無視する**: 新しい値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `gender = 'male'`は`gender`が`male`になるような更新を除外します。
         - **古い値の更新を無視する式**: 古い値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `age < 18` `age`の古い値が 18 未満である場合の更新を除外します。
-        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、 `name = 'john'`は`DELETE`が`name`である`'john'`ステートメントを除外します。
+        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、`name = 'john'`は`name`が`'john'`である`DELETE`ステートメントを除外します。
 
 8. **Start Replication Position**で、MySQLシンクの開始位置を設定します。
 

--- a/tidb-cloud/changefeed-sink-to-tidb-cloud.md
+++ b/tidb-cloud/changefeed-sink-to-tidb-cloud.md
@@ -89,10 +89,10 @@ summary: このドキュメントでは、TiDB Cloud Dedicatedクラスタから
     - **Event Filter**：以下のイベントフィルターを使用して、変更フィードから特定のイベントを除外できます。
         - **Ignore event**：指定されたイベントタイプを除外します。
         - **Ignore SQL**: 指定された式に一致する DDL イベントを除外します。たとえば、 `^drop` `DROP`で始まるステートメントを除外し、 `add column`は`ADD COLUMN`を含むステートメントを除外します。
-        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。
+        - **Ignore insert value expression**: 特定の条件を満たす`INSERT`ステートメントを除外します。たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。
         - **新しい値の更新式を無視する**: 新しい値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `gender = 'male'`は`gender`が`male`になるような更新を除外します。
         - **古い値の更新を無視する式**: 古い値が指定された条件に一致する`UPDATE`ステートメントを除外します。たとえば、 `age < 18` `age`の古い値が 18 未満である場合の更新を除外します。
-        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、 `name = 'john'`は`DELETE`が`name`である`'john'`ステートメントを除外します。
+        - **Ignore delete value expression**: 指定された条件を満たす`DELETE`ステートメントを除外します。たとえば、`name = 'john'`は`name`が`'john'`である`DELETE`ステートメントを除外します。
 
 7. **Start Replication Position**領域に、Dumplingでエクスポートしたメタデータファイルから取得したTSOを入力します。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fixes a machine-translation defect found in 5 `tidb-cloud/changefeed-sink-to-*.md` files: the Japanese translation of the "Ignore insert value expression" and "Ignore delete value expression" bullet examples had the subject and object swapped, producing grammatically nonsensical sentences (e.g. an "`id` statement whose `INSERT` is >= 100", and there is no such thing as an "id statement").

Before (mysql example):
> たとえば、 `id >= 100`は、 `INSERT`が 100 以上である`id`ステートメントを除外します。

After:
> たとえば、`id >= 100`は、`id`が 100 以上である`INSERT`ステートメントを除外します。

This matches the English source: "For example, `id >= 100` excludes `INSERT` statements where `id` is greater than or equal to 100."

The same swap pattern was also present in the adjacent "Ignore delete value expression" bullet in the same 5 files, and is fixed the same way.

Affected files:
- tidb-cloud/changefeed-sink-to-apache-pulsar.md
- tidb-cloud/changefeed-sink-to-tidb-cloud.md
- tidb-cloud/changefeed-sink-to-apache-kafka.md
- tidb-cloud/changefeed-sink-to-cloud-storage.md
- tidb-cloud/changefeed-sink-to-mysql.md

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A (JA-only defect fix, no corresponding English change)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Japanese descriptions for event filter options across changefeed sink documentation.
  * Clarified that matching `INSERT`, `DELETE`, and related statements are excluded when specified conditions are met.
  * Improved example wording for sinks to Apache Kafka, Apache Pulsar, cloud storage, MySQL, and TiDB Cloud.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->