### PR TITLE
i18n(ja): fix misattached parenthetical in dev-guide-delete-data.md

### DIFF
--- a/develop/dev-guide-delete-data.md
+++ b/develop/dev-guide-delete-data.md
@@ -37,7 +37,7 @@ DELETE FROM {table} WHERE {filter}
 
 - `DELETE`ステートメントには、必ず`WHERE`句を指定してください。 `WHERE`句が指定されていない場合、TiDB はテーブル内の***すべての行***を削除します。
 
-- TiDB では 1つのトランザクションのサイズが制限されているため (たとえば、1 万行以上)、大量の行を削除する場合は[一括削除](#bulk-delete)を使用します (段階[トランザクションの合計サイズ制限](/tidb-configuration-file.md#txn-total-size-limit)、デフォルトでは 100 MB)。
+- 大量の行 (たとえば、1 万行以上) を削除する場合は[一括削除](#bulk-delete)を使用します。これは、TiDB では 1つのトランザクションのサイズが制限されているためです ([トランザクションの合計サイズ制限](/tidb-configuration-file.md#txn-total-size-limit)、デフォルトでは 100 MB)。
 
 - テーブル内のすべてのデータを削除する場合は、 `DELETE`ステートメントを使用しないでください。代わりに、 [`TRUNCATE`](/sql-statements/sql-statement-truncate.md)ステートメントを使用してください。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fixes a mistranslation in `develop/dev-guide-delete-data.md` where the "(for example, more than
ten thousand)" parenthetical was attached to the wrong clause.

EN source: "Use [bulk-delete](#bulk-delete) when you delete a large number of rows (for example,
more than ten thousand), because TiDB limits the size of a single transaction
([txn-total-size-limit](/tidb-configuration-file.md#txn-total-size-limit), 100 MB by default)."

JA before: the "(たとえば、1万行以上)" parenthetical was placed right after "サイズが制限されているため"
(the transaction-size-limit clause) instead of after "大量の行" (a large number of rows) — the noun
it actually qualifies. Reordered the sentence to match EN's structure; the sibling file
`develop/dev-guide-update-data.md` already renders this identical sentence pattern correctly, so this
brings the two files in line with each other.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Japanese guidance for deleting large numbers of rows.
  * Retained the recommendation to use bulk deletion for datasets of approximately 10,000 rows or more.
  * Preserved information about TiDB’s default single-transaction size limit and the bulk-delete reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->