### PR TITLE
information-schema: note the extra cost of querying TABLE/PARTITION size columns

### DIFF
--- a/information-schema/information-schema-partitions.md
+++ b/information-schema/information-schema-partitions.md
@@ -7,6 +7,10 @@ summary: Learn the `PARTITIONS` INFORMATION_SCHEMA table.
 
 The `PARTITIONS` table provides information about [partitioned tables](/partitioned-table.md).
 
+> **Note:**
+>
+> Computing `AVG_ROW_LENGTH`, `DATA_LENGTH`, or `INDEX_LENGTH` requires TiDB to read per-column size statistics from the `mysql.stats_histograms` system table, which holds one row for each column of every table. On clusters with a large number of tables, selecting any of these columns can consume noticeably more time and resources than selecting only `TABLE_ROWS`, which reads only the smaller `mysql.stats_meta` system table. If you need only the estimated row count, select `TABLE_ROWS` without the size columns to avoid this overhead.
+
 ```sql
 USE INFORMATION_SCHEMA;
 DESC partitions;

--- a/information-schema/information-schema-tables.md
+++ b/information-schema/information-schema-tables.md
@@ -123,6 +123,10 @@ The description of columns in the `TABLES` table is as follows:
 * `CREATE_OPTIONS`: Creates options.
 * `TABLE_COMMENT`: The comments and notes of the table.
 
+> **Note:**
+>
+> Computing `AVG_ROW_LENGTH`, `DATA_LENGTH`, or `INDEX_LENGTH` requires TiDB to read per-column size statistics from the `mysql.stats_histograms` system table, which holds one row for each column of every table. On clusters with a large number of tables, selecting any of these columns can consume noticeably more time and resources than selecting only `TABLE_ROWS`, which reads only the smaller `mysql.stats_meta` system table. If you need only the estimated row count, select `TABLE_ROWS` without the size columns to avoid this overhead.
+
 Most of the information in the table is the same as MySQL. The following columns are newly defined by TiDB:
 
 * `TIDB_TABLE_ID`: to indicate the internal ID of a table. This ID is unique in a TiDB cluster.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Adds a **Note** to the `INFORMATION_SCHEMA.TABLES` and `INFORMATION_SCHEMA.PARTITIONS` reference pages explaining that querying the size columns (`AVG_ROW_LENGTH`, `DATA_LENGTH`, `INDEX_LENGTH`) makes TiDB read per-column size statistics from `mysql.stats_histograms` (one row per column of every table), which costs noticeably more time and resources on clusters with many tables than querying only `TABLE_ROWS`, which reads only the smaller `mysql.stats_meta` table.

This documents the behavior introduced by pingcap/tidb#69955 (fixing pingcap/tidb#69818), where TABLE_ROWS-only queries now skip the `mysql.stats_histograms` read. The note helps users avoid the size columns when they only need the estimated row count.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):
  - Product PR: pingcap/tidb#69955
  - Issue: pingcap/tidb#69818

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to `TABLES` and `PARTITIONS` reference documentation about the relative cost of retrieving table size metrics.
  * Recommended selecting only `TABLE_ROWS` when an estimated row count is needed for better performance on clusters with many tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->