### PR TITLE
functions-and-operators, releases: clarify TIDB_DECODE_SQL_DIGESTS wording

### DIFF
--- a/functions-and-operators/tidb-functions.md
+++ b/functions-and-operators/tidb-functions.md
@@ -294,7 +294,7 @@ SELECT tidb_decode_plan('8QIYMAkzMV83CQEH8E85LjA0CWRhdGE6U2VsZWN0aW9uXzYJOTYwCXR
 
 ## TIDB_DECODE_SQL_DIGESTS
 
-The `TIDB_DECODE_SQL_DIGESTS()` function is used to query the normalized SQL statements (without value formats or arguments) corresponding to the set of SQL digests in the cluster. This function accepts 1 or 2 arguments:
+The `TIDB_DECODE_SQL_DIGESTS()` function is used to query the normalized SQL statements (in which literal values are replaced with placeholders such as `?` or `...`) corresponding to the set of SQL digests in the cluster. This function accepts 1 or 2 arguments:
 
 * `digests`: A string. This parameter is in the format of a JSON string array, and each string in the array is a SQL digest.
 * `stmtTruncateLength`: An integer (optional). It is used to limit the length of each SQL statement in the returned result. If a SQL statement exceeds the specified length, the statement is truncated. `0` means that the length is unlimited.

--- a/functions-and-operators/tidb-functions.md
+++ b/functions-and-operators/tidb-functions.md
@@ -17,7 +17,7 @@ The following functions are TiDB extensions, and are not present in MySQL:
 | [`TIDB_DECODE_BINARY_PLAN()`](#tidb_decode_binary_plan) | Decodes binary plans. |
 | [`TIDB_DECODE_KEY()`](#tidb_decode_key) | Decodes a TiDB-encoded key entry into a JSON structure containing `_tidb_rowid` and `table_id`. These encoded keys can be found in some system tables and logging outputs. |
 | [`TIDB_DECODE_PLAN()`](#tidb_decode_plan) | Decodes a TiDB execution plan. |
-| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. |
+| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (in which literal values are replaced with placeholders such as `?` or `...`) corresponding to a set of SQL digests in the cluster. |
 | [`TIDB_ENCODE_INDEX_KEY()`](#tidb_encode_index_key) | Encodes an index key. |
 | [`TIDB_ENCODE_RECORD_KEY()`](#tidb_encode_record_key) | Encodes a record key. |
 | [`TIDB_ENCODE_SQL_DIGEST()`](#tidb_encode_sql_digest) | Gets a digest for a query string. |

--- a/functions-and-operators/tidb-functions.md
+++ b/functions-and-operators/tidb-functions.md
@@ -42,7 +42,7 @@ The following functions are TiDB extensions, and are not present in MySQL:
 | [`TIDB_DECODE_BINARY_PLAN()`](#tidb_decode_binary_plan) | Decodes binary plans. |
 | [`TIDB_DECODE_KEY()`](#tidb_decode_key) | Decodes a TiDB-encoded key entry into a JSON structure containing `_tidb_rowid` and `table_id`. These encoded keys can be found in some system tables and logging outputs. |
 | [`TIDB_DECODE_PLAN()`](#tidb_decode_plan) | Decodes a TiDB execution plan. |
-| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. |
+| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (in which literal values are replaced with placeholders such as `?` or `...`) corresponding to a set of SQL digests in the cluster. |
 | [`TIDB_ENCODE_INDEX_KEY()`](#tidb_encode_index_key) | Encodes an index key. |
 | [`TIDB_ENCODE_RECORD_KEY()`](#tidb_encode_record_key) | Encodes a record key. |
 | [`TIDB_ENCODE_SQL_DIGEST()`](#tidb_encode_sql_digest) | Gets a digest for a query string. |

--- a/functions-and-operators/tidb-functions.md
+++ b/functions-and-operators/tidb-functions.md
@@ -17,7 +17,7 @@ The following functions are TiDB extensions, and are not present in MySQL:
 | [`TIDB_DECODE_BINARY_PLAN()`](#tidb_decode_binary_plan) | Decodes binary plans. |
 | [`TIDB_DECODE_KEY()`](#tidb_decode_key) | Decodes a TiDB-encoded key entry into a JSON structure containing `_tidb_rowid` and `table_id`. These encoded keys can be found in some system tables and logging outputs. |
 | [`TIDB_DECODE_PLAN()`](#tidb_decode_plan) | Decodes a TiDB execution plan. |
-| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (a form without formats and arguments) corresponding to a set of SQL digests in the cluster. |
+| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. |
 | [`TIDB_ENCODE_INDEX_KEY()`](#tidb_encode_index_key) | Encodes an index key. |
 | [`TIDB_ENCODE_RECORD_KEY()`](#tidb_encode_record_key) | Encodes a record key. |
 | [`TIDB_ENCODE_SQL_DIGEST()`](#tidb_encode_sql_digest) | Gets a digest for a query string. |
@@ -42,7 +42,7 @@ The following functions are TiDB extensions, and are not present in MySQL:
 | [`TIDB_DECODE_BINARY_PLAN()`](#tidb_decode_binary_plan) | Decodes binary plans. |
 | [`TIDB_DECODE_KEY()`](#tidb_decode_key) | Decodes a TiDB-encoded key entry into a JSON structure containing `_tidb_rowid` and `table_id`. These encoded keys can be found in some system tables and logging outputs. |
 | [`TIDB_DECODE_PLAN()`](#tidb_decode_plan) | Decodes a TiDB execution plan. |
-| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (a form without formats and arguments) corresponding to a set of SQL digests in the cluster. |
+| [`TIDB_DECODE_SQL_DIGESTS()`](#tidb_decode_sql_digests) | Queries the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. |
 | [`TIDB_ENCODE_INDEX_KEY()`](#tidb_encode_index_key) | Encodes an index key. |
 | [`TIDB_ENCODE_RECORD_KEY()`](#tidb_encode_record_key) | Encodes a record key. |
 | [`TIDB_ENCODE_SQL_DIGEST()`](#tidb_encode_sql_digest) | Gets a digest for a query string. |
@@ -294,7 +294,7 @@ SELECT tidb_decode_plan('8QIYMAkzMV83CQEH8E85LjA0CWRhdGE6U2VsZWN0aW9uXzYJOTYwCXR
 
 ## TIDB_DECODE_SQL_DIGESTS
 
-The `TIDB_DECODE_SQL_DIGESTS()` function is used to query the normalized SQL statements (a form without formats and arguments) corresponding to the set of SQL digests in the cluster. This function accepts 1 or 2 arguments:
+The `TIDB_DECODE_SQL_DIGESTS()` function is used to query the normalized SQL statements (without value formats or arguments) corresponding to the set of SQL digests in the cluster. This function accepts 1 or 2 arguments:
 
 * `digests`: A string. This parameter is in the format of a JSON string array, and each string in the array is a SQL digest.
 * `stmtTruncateLength`: An integer (optional). It is used to limit the length of each SQL statement in the returned result. If a SQL statement exceeds the specified length, the statement is truncated. `0` means that the length is unlimited.

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -112,7 +112,7 @@ In v5.2, the key new features and improvements are as follows:
     In v5.2, the following enhancements are made to Lock View:
 
     - In addition to the SQL digest column in the Lock View-related tables, add a column to these tables that shows the corresponding normalized SQL text. You do not have to manually query the statement corresponding to a SQL digest.
-    - Add the `TIDB_DECODE_SQL_DIGESTS` function to query the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. This simplifies the operation of querying the statements that have been historically executed by a transaction.
+    - Add the `TIDB_DECODE_SQL_DIGESTS` function to query the normalized SQL statements (in which literal values are replaced with placeholders such as `?` or `...`) corresponding to a set of SQL digests in the cluster. This simplifies the operation of querying the statements that have been historically executed by a transaction.
     - Add a column in the `DATA_LOCK_WAITS` and `DEADLOCKS` system tables to show the table name, row ID, index value, and other key information interpreted from a key. This simplifies the operations such as locating the table to which a key belongs and interpreting the key information.
     - Support collecting the information of retryable deadlock errors in the `DEADLOCKS` table, which makes it easier to troubleshoot issues caused by such errors. The error collection is disabled by default and can be enabled using the `pessimistic-txn.deadlock-history-collect-retryable` configuration.
     - Support distinguishing query-executing transactions from idle transactions on the `TIDB_TRX` system table. The `Normal` state is now divided into `Running` and `Idle` states.

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -112,7 +112,7 @@ In v5.2, the key new features and improvements are as follows:
     In v5.2, the following enhancements are made to Lock View:
 
     - In addition to the SQL digest column in the Lock View-related tables, add a column to these tables that shows the corresponding normalized SQL text. You do not have to manually query the statement corresponding to a SQL digest.
-    - Add the `TIDB_DECODE_SQL_DIGESTS` function to query the normalized SQL statements (a form without formats and arguments) corresponding to a set of SQL digests in the cluster. This simplifies the operation of querying the statements that have been historically executed by a transaction.
+    - Add the `TIDB_DECODE_SQL_DIGESTS` function to query the normalized SQL statements (without value formats or arguments) corresponding to a set of SQL digests in the cluster. This simplifies the operation of querying the statements that have been historically executed by a transaction.
     - Add a column in the `DATA_LOCK_WAITS` and `DEADLOCKS` system tables to show the table name, row ID, index value, and other key information interpreted from a key. This simplifies the operations such as locating the table to which a key belongs and interpreting the key information.
     - Support collecting the information of retryable deadlock errors in the `DEADLOCKS` table, which makes it easier to troubleshoot issues caused by such errors. The error collection is disabled by default and can be enabled using the `pessimistic-txn.deadlock-history-collect-retryable` configuration.
     - Support distinguishing query-executing transactions from idle transactions on the `TIDB_TRX` system table. The `Normal` state is now divided into `Running` and `Idle` states.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Rewords the parenthetical describing `TIDB_DECODE_SQL_DIGESTS()`'s output from
"a form without formats and arguments" to "without value formats or arguments",
in 4 places (3 in `functions-and-operators/tidb-functions.md`, 1 in
`releases/release-5.2.0.md`).

The original phrasing uses "form" and "formats" as two separate words with the
same root meaning right next to each other ("a form without formats"), which
reads as slightly self-contradictory even in English, and becomes worse once
translated: in Japanese, both "form" and "format" map to the same word (形式),
so the translated sentence ends up reading as "a 形式 without 形式" — literally
"a form without form" — with no way to distinguish the two senses. Simplifying
to a single clear phrase avoids this.

Found while reviewing the Japanese translation for this exact confusion.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that normalized SQL returned by `TIDB_DECODE_SQL_DIGESTS()` excludes literal value formats and arguments.
  * Updated the function reference and release notes to describe replaced values using placeholders such as `?` or `...`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->