### PR TITLE
i18n(ja): fix swapped word order across the corpus

### DIFF
--- a/releases/release-5.1.0.md
+++ b/releases/release-5.1.0.md
@@ -64,7 +64,7 @@ TiDB バージョン: 5.1.0
 - TiDBローリングアップグレード中は、TiDB Binlogを使用するクラスタでクラスター化インデックスを持つテーブルを作成しないようにしてください。
 - TiDB のローリングアップグレード中は`alter table ... modify column`や`alter table ... change column`のようなステートメントを実行しないでください。
 - バージョン5.1以降、各テーブルのTiFlashレプリカを作成する際に、システムテーブルのレプリカを設定する機能はサポートされなくなりました。クラスタをアップグレードする前に、関連するシステムテーブルのレプリカをクリアする必要があります。クリアしないと、アップグレードは失敗します。
-- TiCDC の`--sort-dir`コマンドの`cdc cli changefeed`パラメータは非推奨です。代わりに、 `--sort-dir`コマンドで`cdc server` を設定できます。 [#1795](https://github.com/pingcap/tiflow/pull/1795)
+- TiCDC の`cdc cli changefeed`コマンドの`--sort-dir`は非推奨です。代わりに、 `cdc server`コマンドで`--sort-dir` を設定できます。 [#1795](https://github.com/pingcap/tiflow/pull/1795)
 - TiDB 5.1 にアップグレードした後、TiDB が「関数 READ ONLY には noop 実装しかありません」というエラーを返す場合、 [`tidb_enable_noop_functions`](/system-variables.md#tidb_enable_noop_functions-new-in-v40)の値を`ON`に設定することで、TiDB がこのエラーを無視するようにできます。これは、MySQL の`read_only`変数が TiDB ではまだ有効になっていないためです (TiDB では「noop」動作です)。したがって、この変数が TiDB で設定されていても、TiDB クラスタにデータを書き込むことができます。
 
 ## 新機能 {#new-features}
@@ -284,7 +284,7 @@ TiDBは、実行ステータスと失敗ステータスを含む、TiDBクラス
     - 悲観的ロックが `ErrKeyExists` エラーを受け取った場合、不要な悲観的ロールバックを回避する [#23799](https://github.com/pingcap/tidb/issues/23799)
     - sql_modeに`ANSI_QUOTES`が含まれている場合に数値リテラルが認識されない問題を修正しました [#24429](https://github.com/pingcap/tidb/issues/24429)
     - `INSERT INTO table PARTITION (<partitions>) ... ON DUPLICATE KEY UPDATE`のようなステートメントがリストにないパーティションからデータを読み取ることを禁止する [#24746](https://github.com/pingcap/tidb/issues/24746)
-    - SQL文に`index out of range`と`GROUP BY`両方が含まれている場合に発生する可能性のある`UNION`エラーを修正し [#24281](https://github.com/pingcap/tidb/issues/24281)
+    - SQL文に`UNION`と`GROUP BY`両方が含まれている場合に発生する可能性のある`index out of range`エラーを修正し [#24281](https://github.com/pingcap/tidb/issues/24281)
     - `CONCAT`関数が照合順序を正しく処理しない問題を修正しました [#24296](https://github.com/pingcap/tidb/issues/24296)
     - `collation_server`グローバル変数が新しいセッションで有効にならない問題を修正しました [#24156](https://github.com/pingcap/tidb/pull/24156)
 

--- a/releases/release-5.1.0.md
+++ b/releases/release-5.1.0.md
@@ -284,7 +284,7 @@ TiDBは、実行ステータスと失敗ステータスを含む、TiDBクラス
     - 悲観的ロックが `ErrKeyExists` エラーを受け取った場合、不要な悲観的ロールバックを回避する [#23799](https://github.com/pingcap/tidb/issues/23799)
     - sql_modeに`ANSI_QUOTES`が含まれている場合に数値リテラルが認識されない問題を修正しました [#24429](https://github.com/pingcap/tidb/issues/24429)
     - `INSERT INTO table PARTITION (<partitions>) ... ON DUPLICATE KEY UPDATE`のようなステートメントがリストにないパーティションからデータを読み取ることを禁止する [#24746](https://github.com/pingcap/tidb/issues/24746)
-    - SQL文に`UNION`と`GROUP BY`両方が含まれている場合に発生する可能性のある`index out of range`エラーを修正し [#24281](https://github.com/pingcap/tidb/issues/24281)
+    - SQL文に`UNION`と`GROUP BY`両方が含まれている場合に発生する可能性のある`index out of range`エラーを修正しました [#24281](https://github.com/pingcap/tidb/issues/24281)
     - `CONCAT`関数が照合順序を正しく処理しない問題を修正しました [#24296](https://github.com/pingcap/tidb/issues/24296)
     - `collation_server`グローバル変数が新しいセッションで有効にならない問題を修正しました [#24156](https://github.com/pingcap/tidb/pull/24156)
 

--- a/releases/release-5.1.5.md
+++ b/releases/release-5.1.5.md
@@ -23,7 +23,7 @@ TiDBバージョン：5.1.5
 
     - ウィンドウ関数がエラーを報告する代わりにTiDBをpanicにする問題を修正しました [#30326](https://github.com/pingcap/tidb/issues/30326)
     - TiFlashのパーティションテーブルで動的モードを有効にした際に発生する誤った結果を修正します [#37254](https://github.com/pingcap/tidb/issues/37254)
-    - 符号なしの`GREATEST`引数を渡した場合の`LEAST`と`BIGINT`の誤った結果を修正 [#30101](https://github.com/pingcap/tidb/issues/30101)
+    - 符号なしの`BIGINT`引数を渡した場合の`GREATEST`と`LEAST`の誤った結果を修正 [#30101](https://github.com/pingcap/tidb/issues/30101)
     - `left join`を使用して複数のテーブルのデータを削除する際の誤った結果を修正 [#31321](https://github.com/pingcap/tidb/issues/31321)
     - TiDB における`concat(ifnull(time(3)))`の結果が MySQL における結果と異なる問題を修正しました [#29498](https://github.com/pingcap/tidb/issues/29498)
     - `cast(integer as char) union string`を含むSQL文が誤った結果を返す問題を修正しました [#29513](https://github.com/pingcap/tidb/issues/29513)

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -203,7 +203,7 @@ Apple M1チップを搭載したMacコンピュータで`tiup playground`コマ�
     - MPP外部結合で、テーブルの行数に基づいて構築テーブルを選択できるようにする [#25142](https://github.com/pingcap/tidb/pull/25142)
     - リージョンに基づいて、異なるTiFlashノード間でMPPクエリワークロードのバランスを取ることをサポートする [#24724](https://github.com/pingcap/tidb/pull/24724)
     - MPPクエリ実行後にキャッシュ内の古いリージョンを無効化する機能をサポートする [#24432](https://github.com/pingcap/tidb/pull/24432)
-    - フォーマット指定子`str_to_date`に対する組み込み関数`%b/%M/%r/%T` の MySQL 互換性を向上させる [#25767](https://github.com/pingcap/tidb/pull/25767)
+    - フォーマット指定子`%b/%M/%r/%T`に対する組み込み関数`str_to_date` の MySQL 互換性を向上させる [#25767](https://github.com/pingcap/tidb/pull/25767)
     - 同じクエリに対して異なるバインディングを再作成した後に、複数の TiDB で一貫性のないバインディング キャッシュが作成される可能性がある問題を修正します [#26015](https://github.com/pingcap/tidb/pull/26015)
     - アップグレード後に既存のバインディングをキャッシュにロードできない問題を修正しました [#23295](https://github.com/pingcap/tidb/pull/23295)
     - `SHOW BINDINGS`の結果を ( `original_sql` 、 `update_time` ) で並べ替えることをサポートする [#26139](https://github.com/pingcap/tidb/pull/26139)
@@ -266,7 +266,7 @@ Apple M1チップを搭載したMacコンピュータで`tiup playground`コマ�
     - ODBC スタイルの定数 (例: `{d '2020-01-01'}` ) を式として使用できない問題を修正しました [#25531](https://github.com/pingcap/tidb/issues/25531)
     - `SELECT DISTINCT` `Batch Get`に変換されることで誤った結果が生じる問題を修正します [#25320](https://github.com/pingcap/tidb/issues/25320)
     - TiFlashからTiKVへのバックオフクエリがトリガーできない問題を修正[#23665](https://github.com/pingcap/tidb/issues/23665) [#24421](https://github.com/pingcap/tidb/issues/24421)
-    - `index-out-of-range`をチェックした際に発生する`only_full_group_by`エラーを修正します[#23839](https://github.com/pingcap/tidb/issues/23839) )
+    - `only_full_group_by`をチェックした際に発生する`index-out-of-range`エラーを修正します[#23839](https://github.com/pingcap/tidb/issues/23839) )
     - 相関サブクエリにおけるインデックス結合の結果が間違っている問題を修正しました [#25799](https://github.com/pingcap/tidb/issues/25799)
 
 - TiKV

--- a/releases/release-5.2.0.md
+++ b/releases/release-5.2.0.md
@@ -266,7 +266,7 @@ Apple M1チップを搭載したMacコンピュータで`tiup playground`コマ�
     - ODBC スタイルの定数 (例: `{d '2020-01-01'}` ) を式として使用できない問題を修正しました [#25531](https://github.com/pingcap/tidb/issues/25531)
     - `SELECT DISTINCT` `Batch Get`に変換されることで誤った結果が生じる問題を修正します [#25320](https://github.com/pingcap/tidb/issues/25320)
     - TiFlashからTiKVへのバックオフクエリがトリガーできない問題を修正[#23665](https://github.com/pingcap/tidb/issues/23665) [#24421](https://github.com/pingcap/tidb/issues/24421)
-    - `only_full_group_by`をチェックした際に発生する`index-out-of-range`エラーを修正します[#23839](https://github.com/pingcap/tidb/issues/23839) )
+    - `only_full_group_by`をチェックした際に発生する`index-out-of-range`エラーを修正します[#23839](https://github.com/pingcap/tidb/issues/23839)
     - 相関サブクエリにおけるインデックス結合の結果が間違っている問題を修正しました [#25799](https://github.com/pingcap/tidb/issues/25799)
 
 - TiKV

--- a/releases/release-5.2.4.md
+++ b/releases/release-5.2.4.md
@@ -36,7 +36,7 @@ TiDBバージョン：5.2.4
     - 解決ロック手順を必要とするリージョンの数を減らすことで、TiCDC のリカバリ時間を短縮します。 [#11993](https://github.com/tikv/tikv/issues/11993)
     - procファイルシステム（procfs）をv0.12.0にアップデートする [#11702](https://github.com/tikv/tikv/issues/11702)
     - RaftログへのGC実行時に書き込みバッチサイズを増やすことで、ガベージコレクション（GC）プロセスを高速化する [#11404](https://github.com/tikv/tikv/issues/11404)
-    - 検証プロセスを`Import`スレッドプールから`Apply`スレッドプールに移動することで、SSTファイルの挿入速度を向上させます [#11239](https://github.com/tikv/tikv/issues/11239)
+    - 検証プロセスを`Apply`スレッドプールから`Import`スレッドプールに移動することで、SSTファイルの挿入速度を向上させます [#11239](https://github.com/tikv/tikv/issues/11239)
 
 - ツール
 
@@ -73,7 +73,7 @@ TiDBバージョン：5.2.4
     - `INSERT ... SELECT ... ON DUPLICATE KEY UPDATE`文を実行するとpanicが発生する問題を修正しました [#28078](https://github.com/pingcap/tidb/issues/28078)
     - `Order By`の最適化による誤ったクエリ結果を修正 [#30271](https://github.com/pingcap/tidb/issues/30271)
     - `ENUM`型の列で`JOIN`を実行した際に発生する可能性のある誤った結果を修正します [#27831](https://github.com/pingcap/tidb/issues/27831)
-    - `CASE WHEN`データ型で`ENUM`関数を使用した際に発生panicを修正しました [#29357](https://github.com/pingcap/tidb/issues/29357)
+    - `ENUM`データ型で`CASE WHEN`関数を使用した際に発生panicを修正しました [#29357](https://github.com/pingcap/tidb/issues/29357)
     - ベクトル化された式における`microsecond`関数の誤った結果を修正 [#29244](https://github.com/pingcap/tidb/issues/29244)
     - ウィンドウ関数がエラーを報告する代わりにTiDBをpanicにする問題を修正しました [#30326](https://github.com/pingcap/tidb/issues/30326)
     - マージ結合オペレーターが特定の場合に誤った結果を返す問題を修正しました [#33042](https://github.com/pingcap/tidb/issues/33042)

--- a/releases/release-5.2.4.md
+++ b/releases/release-5.2.4.md
@@ -73,7 +73,7 @@ TiDBバージョン：5.2.4
     - `INSERT ... SELECT ... ON DUPLICATE KEY UPDATE`文を実行するとpanicが発生する問題を修正しました [#28078](https://github.com/pingcap/tidb/issues/28078)
     - `Order By`の最適化による誤ったクエリ結果を修正 [#30271](https://github.com/pingcap/tidb/issues/30271)
     - `ENUM`型の列で`JOIN`を実行した際に発生する可能性のある誤った結果を修正します [#27831](https://github.com/pingcap/tidb/issues/27831)
-    - `ENUM`データ型で`CASE WHEN`関数を使用した際に発生panicを修正しました [#29357](https://github.com/pingcap/tidb/issues/29357)
+    - `ENUM`データ型で`CASE WHEN`式を使用した際に発生するpanicを修正しました [#29357](https://github.com/pingcap/tidb/issues/29357)
     - ベクトル化された式における`microsecond`関数の誤った結果を修正 [#29244](https://github.com/pingcap/tidb/issues/29244)
     - ウィンドウ関数がエラーを報告する代わりにTiDBをpanicにする問題を修正しました [#30326](https://github.com/pingcap/tidb/issues/30326)
     - マージ結合オペレーターが特定の場合に誤った結果を返す問題を修正しました [#33042](https://github.com/pingcap/tidb/issues/33042)

--- a/releases/release-6.3.0.md
+++ b/releases/release-6.3.0.md
@@ -363,7 +363,7 @@ TiDBバージョン: 6.3.0-DMR
     - UPDATE 文が場合によっては誤って投影を削除し、 `Can't find column` エラーが発生する問題を修正しました。 [#37568](https://github.com/pingcap/tidb/issues/37568) @[AilinKid](https://github.com/AilinKid)
     - 結合したテーブルの再配置操作が誤って外部結合条件をプッシュダウンする問題を修正 [#37238](https://github.com/pingcap/tidb/issues/37238) @[AilinKid](https://github.com/AilinKid)
     - 一部のパターンで `IN` と `NOT IN` サブクエリが `Can't find column` エラーを報告する問題を修正しました。 [#37032](https://github.com/pingcap/tidb/issues/37032) @[AilinKid](https://github.com/AilinKid)
-    - `Can't find column`ステートメントに共通テーブル式 (CTE) が含まれている場合に`UPDATE`が報告される問題を修正 [#35758](https://github.com/pingcap/tidb/issues/35758) @[AilinKid](https://github.com/AilinKid)
+    - `UPDATE`ステートメントに共通テーブル式 (CTE) が含まれている場合に`Can't find column`が報告される問題を修正 [#35758](https://github.com/pingcap/tidb/issues/35758) @[AilinKid](https://github.com/AilinKid)
     - 間違った`PromQL`を修正 [#35856](https://github.com/pingcap/tidb/issues/35856) @[Defined2014](https://github.com/Defined2014)
 
 - TiKV

--- a/releases/release-6.4.0.md
+++ b/releases/release-6.4.0.md
@@ -393,7 +393,7 @@ TiDBバージョン: 6.4.0-DMR
 
     - 新しいインデックスを作成した後に発生する可能性のあるインデックスの不整合の問題を修正します [#38165](https://github.com/pingcap/tidb/issues/38165) @[tangenta](https://github.com/tangenta)
     - `INFORMATION_SCHEMA.TIKV_REGION_STATUS`テーブルの権限の問題を修正しました [#38407](https://github.com/pingcap/tidb/issues/38407) @[CbcWestwolf](https://github.com/CbcWestwolf)
-    - `grantor`テーブルに`mysql.tables_priv`フィールドが欠落している問題を修正します [#38293](https://github.com/pingcap/tidb/issues/38293) @[CbcWestwolf](https://github.com/CbcWestwolf)
+    - `mysql.tables_priv`テーブルに`grantor`フィールドが欠落している問題を修正します [#38293](https://github.com/pingcap/tidb/issues/38293) @[CbcWestwolf](https://github.com/CbcWestwolf)
     - 共通テーブル式の結合結果が間違っている可能性がある問題を修正 [#38170](https://github.com/pingcap/tidb/issues/38170) @[wjhuang2016](https://github.com/wjhuang2016)
     - 共通テーブル式の和集合の結果が間違っている可能性がある問題を修正 [#37928](https://github.com/pingcap/tidb/issues/37928) @[YangKeao](https://github.com/YangKeao)
     - **トランザクション領域番号**監視パネルの情報が正しくない問題を修正 [#38139](https://github.com/pingcap/tidb/issues/38139) @[jackysp](https://github.com/jackysp)
@@ -435,7 +435,7 @@ TiDBバージョン: 6.4.0-DMR
 
     - TiCDC
 
-        - `sasl-password`の結果で`changefeed query`がマスクされない問題を修正 [#7182](https://github.com/pingcap/tiflow/issues/7182) @[dveeden](https://github.com/dveeden)
+        - `changefeed query`の結果で`sasl-password`がマスクされない問題を修正 [#7182](https://github.com/pingcap/tiflow/issues/7182) @[dveeden](https://github.com/dveeden)
         - etcdトランザクションで操作が多すぎるとTiCDCが利用できなくなる可能性がある問題を修正 [#7131](https://github.com/pingcap/tiflow/issues/7131) @[asddongmen](https://github.com/asddongmen)
         - リドゥログが正しく削除されない可能性がある問題を修正 [#6413](https://github.com/pingcap/tiflow/issues/6413) @[asddongmen](https://github.com/asddongmen)
         - Kafka Sink V2 でワイドテーブルを複製するときのパフォーマンスの低下を修正 [#7344](https://github.com/pingcap/tiflow/issues/7344) @[Rustin170506](https://github.com/Rustin170506)
@@ -452,7 +452,7 @@ TiDBバージョン: 6.4.0-DMR
         - チェックポイントの更新時に大きなトランザクションが発生する可能性がある問題を修正しました [#5010](https://github.com/pingcap/tiflow/issues/5010) @[lance6716](https://github.com/lance6716)
         - フルタスクモードで、タスクが同期段階に入ってすぐに失敗した場合、DMがアップストリームのテーブルスキーマ情報を失う可能性がある問題を修正します [#7159](https://github.com/pingcap/tiflow/issues/7159) @[lance6716](https://github.com/lance6716)
         - 整合性チェックが有効になっている場合にデッドロックが発生する可能性がある問題を修正 [#7241](https://github.com/pingcap/tiflow/issues/7241) @[buchuitoudegou](https://github.com/buchuitoudegou)
-        - タスクの事前チェックで`SELECT`テーブルに対する`INFORMATION_SCHEMA`権限が必要になる問題を修正します。 [#7317](https://github.com/pingcap/tiflow/issues/7317) @[lance6716](https://github.com/lance6716)
+        - タスクの事前チェックで`INFORMATION_SCHEMA`テーブルに対する`SELECT`権限が必要になる問題を修正します。 [#7317](https://github.com/pingcap/tiflow/issues/7317) @[lance6716](https://github.com/lance6716)
         - TLS設定が空の場合にエラーが発生する問題を修正しました [#7384](https://github.com/pingcap/tiflow/issues/7384) @[liumengya94](https://github.com/liumengya94)
 
     - TiDB Lightning

--- a/releases/release-7.3.0.md
+++ b/releases/release-7.3.0.md
@@ -247,7 +247,7 @@ TiDB バージョン: 7.3.0
     - `INFORMATION_SCHEMA.TIFLASH_REPLICA`テーブルの読み取り権限の問題を修正 [#7795](https://github.com/pingcap/tiflash/issues/7795) @[Lloyd-Pottiger](https://github.com/Lloyd-Pottiger)
     - パーティションテーブル名が間違っている場合にエラーが発生する問題を修正 [#44967](https://github.com/pingcap/tidb/issues/44967) @[River2000i](https://github.com/River2000i)
     - `tidb_enable_dist_task`が有効になっている場合にインデックス作成が停止する問題を修正 [#44440](https://github.com/pingcap/tidb/issues/44440) @[tangenta](https://github.com/tangenta)
-    - BR を使用して `duplicate entry` を含むテーブルを復元する際に発生する `AUTO_ID_CACHE=1` エラーを修正します。 [#44716](https://github.com/pingcap/tidb/issues/44716) @[tiancaiamao](https://github.com/tiancaiamao)
+    - BR を使用して `AUTO_ID_CACHE=1` を含むテーブルを復元する際に発生する `duplicate entry` エラーを修正します。 [#44716](https://github.com/pingcap/tidb/issues/44716) @[tiancaiamao](https://github.com/tiancaiamao)
     - `TRUNCATE TABLE`の実行に要した時間が`ADMIN SHOW DDL JOBS`に表示されるタスク実行時間と一致しない問題を修正しました。 [#44785](https://github.com/pingcap/tidb/issues/44785) @[tangenta](https://github.com/tangenta)
     - TiDBのアップグレード時にメタデータの読み取りに1つのDDLリースよりも時間がかかると、アップグレードが停止する問題を修正しました [#45176](https://github.com/pingcap/tidb/issues/45176) @[zimulala](https://github.com/zimulala)
     - `SELECT CAST(n AS CHAR)`ステートメント内の`n`が負の数の場合、クエリ結果が正しくない問題を修正しました [#44786](https://github.com/pingcap/tidb/issues/44786) @[xhebox](https://github.com/xhebox)

--- a/releases/release-7.5.0.md
+++ b/releases/release-7.5.0.md
@@ -190,8 +190,8 @@ v7.5.0 以降、次のコンテンツが`TiDB-community-toolkit`[バイナリパ
     - 非整数クラスター化インデックスでの分割テーブル操作を禁止 [#47350](https://github.com/pingcap/tidb/issues/47350) @[tangenta](https://github.com/tangenta)
     - タイムゾーン情報が間違っているタイムフィールドのエンコード問題を修正 [#46033](https://github.com/pingcap/tidb/issues/46033) @[tangenta](https://github.com/tangenta)
     - Sort オペレーターがスピル プロセス中に TiDB をクラッシュさせる可能性がある問題を修正 [#47538](https://github.com/pingcap/tidb/issues/47538) @[windtalker](https://github.com/windtalker)
-    - TiDB が`Can't find column`を使用したクエリに対して`GROUP_CONCAT`を返す問題を修正 [#41957](https://github.com/pingcap/tidb/issues/41957) @[AilinKid](https://github.com/AilinKid)
-    - `batch-client`の`client-go`のpanic問題を修正 [#47691](https://github.com/pingcap/tidb/issues/47691) @[crazycs520](https://github.com/crazycs520)
+    - TiDB が`GROUP_CONCAT`を使用したクエリに対して`Can't find column`を返す問題を修正 [#41957](https://github.com/pingcap/tidb/issues/41957) @[AilinKid](https://github.com/AilinKid)
+    - `client-go`の`batch-client`のpanic問題を修正 [#47691](https://github.com/pingcap/tidb/issues/47691) @[crazycs520](https://github.com/crazycs520)
     - `INDEX_LOOKUP_HASH_JOIN` のメモリ使用量推定の誤りを修正 [#47788](https://github.com/pingcap/tidb/issues/47788) @[SeaRise](https://github.com/SeaRise)
     - 長期間オフラインだったTiFlashノードの再参加によって生じる不均一なワークロードの問題を修正 [#35418](https://github.com/pingcap/tidb/issues/35418) @[windtalker](https://github.com/windtalker)
     - HashJoin オペレーターがプローブを実行する際にチャンクを再利用できない問題を修正します [#48082](https://github.com/pingcap/tidb/issues/48082) @[wshwsh12](https://github.com/wshwsh12)
@@ -202,7 +202,7 @@ v7.5.0 以降、次のコンテンツが`TiDB-community-toolkit`[バイナリパ
     - ウィンドウ関数によって導入されたソートを削減するために、オプティマイザが誤って IndexFullScan を選択する問題を修正しました [#46177](https://github.com/pingcap/tidb/issues/46177) @[qw4990](https://github.com/qw4990)
     - CTEの条件プッシュダウンにより、複数のCTE参照によって誤った結果が生じる問題を修正 [#47881](https://github.com/pingcap/tidb/issues/47881) @[winoros](https://github.com/winoros)
     - MySQLの圧縮プロトコルが大量のデータ（&gt;=16M）を処理できない問題を修正[#47152](https://github.com/pingcap/tidb/issues/47152) [#47157](https://github.com/pingcap/tidb/issues/47157) [#47161](https://github.com/pingcap/tidb/issues/47161) @[dveeden](https://github.com/dveeden)
-    - TiDBが`cgroup`で起動されたときに`systemd`のリソース制限を読み取らない問題を修正 [#47442](https://github.com/pingcap/tidb/issues/47442) @[hawkingrei](https://github.com/hawkingrei)
+    - TiDBが`systemd`で起動されたときに`cgroup`のリソース制限を読み取らない問題を修正 [#47442](https://github.com/pingcap/tidb/issues/47442) @[hawkingrei](https://github.com/hawkingrei)
 
 - TiKV
 

--- a/releases/release-7.6.0.md
+++ b/releases/release-7.6.0.md
@@ -329,7 +329,7 @@ v7.6.0 以降、 `TiDB-community-server`[バイナリパッケージ](/binary-pa
     - TiCDC
 
         - TiCDCによるオブジェクトストレージへのデータ複製パフォーマンスを並列処理の増加によって改善する [#10098](https://github.com/pingcap/tiflow/issues/10098) @[CharlesCheung96](https://github.com/CharlesCheung96)
-        - `content-compatible=true` [公式Canal出力のコンテンツ形式と互換性がある](/ticdc/ticdc-canal-json.md#compatibility-with-the-official-canal)`sink-uri`の@[3AceShowHand](https://github.com/3AceShowHand) [#10106](https://github.com/pingcap/tiflow/issues/10106)
+        - `sink-uri`設定で`content-compatible=true`を設定することで、TiCDC の Canal-JSON コンテンツ形式を[公式Canal出力のコンテンツ形式と互換性がある](/ticdc/ticdc-canal-json.md#compatibility-with-the-official-canal)ようにすることをサポートします。 [#10106](https://github.com/pingcap/tiflow/issues/10106) @[3AceShowHand](https://github.com/3AceShowHand)
 
     - TiDB Data Migration (DM)
 
@@ -348,11 +348,11 @@ v7.6.0 以降、 `TiDB-community-server`[バイナリパッケージ](/binary-pa
     - DDL `jobID`が 0 に復元されたときに発生する TiDB ノードpanicの問題を修正 [#46296](https://github.com/pingcap/tidb/issues/46296) @[jiyfhust](https://github.com/jiyfhust)
     - 同じクエリプランでも異なる`PLAN_DIGEST`値が存在する場合がある問題を修正 [#47634](https://github.com/pingcap/tidb/issues/47634) @[King-Dylan](https://github.com/King-Dylan)
     - DUALテーブルを最初のサブノードとして`UNION ALL`を実行するとエラーが発生する可能性がある問題を修正しました [#48755](https://github.com/pingcap/tidb/issues/48755) @[winoros](https://github.com/winoros)
-    - 共通テーブル式（CTE）を含むクエリで、 `runtime error: index out of range [32] with length 32`小さな値に設定されている場合に`tidb_max_chunk_size`が報告される問題を修正 [#48808](https://github.com/pingcap/tidb/issues/48808) @[guo-shaoge](https://github.com/guo-shaoge)
+    - 共通テーブル式（CTE）を含むクエリで、 `tidb_max_chunk_size`が小さな値に設定されている場合に`runtime error: index out of range [32] with length 32`が報告される問題を修正 [#48808](https://github.com/pingcap/tidb/issues/48808) @[guo-shaoge](https://github.com/guo-shaoge)
     - `AUTO_ID_CACHE=1`使用時のゴルーチンリークの問題を修正 [#46324](https://github.com/pingcap/tidb/issues/46324) @[tiancaiamao](https://github.com/tiancaiamao)
     - MPP によって計算された`COUNT(INT)`の結果が正しくない可能性がある問題を修正 [#48643](https://github.com/pingcap/tidb/issues/48643) @[AilinKid](https://github.com/AilinKid)
-    - パーティション列のタイプが`ALTER TABLE ... LAST PARTITION`の場合に`DATETIME`の実行が失敗する問題を修正します [#48814](https://github.com/pingcap/tidb/issues/48814) @[crazycs520](https://github.com/crazycs520)
-    - `_`で`LIKE`ワイルドカードを使用すると、データに末尾の空白が含まれている場合にクエリ結果が正しくない可能性がある問題を修正します [#48983](https://github.com/pingcap/tidb/issues/48983) @[time-and-fate](https://github.com/time-and-fate)
+    - パーティション列のタイプが`DATETIME`の場合に`ALTER TABLE ... LAST PARTITION`の実行が失敗する問題を修正します [#48814](https://github.com/pingcap/tidb/issues/48814) @[crazycs520](https://github.com/crazycs520)
+    - `LIKE`で`_`ワイルドカードを使用すると、データに末尾の空白が含まれている場合にクエリ結果が正しくない可能性がある問題を修正します [#48983](https://github.com/pingcap/tidb/issues/48983) @[time-and-fate](https://github.com/time-and-fate)
     - `tidb_server_memory_limit` による長期メモリ負荷が原因で TiDB の CPU 使用率が高くなる問題を修正しました。 [#48741](https://github.com/pingcap/tidb/issues/48741) @[XuHuaiyu](https://github.com/XuHuaiyu)
     - `ENUM`型の列を結合キーとして使用した場合にクエリ結果が正しくない問題を修正 [#48991](https://github.com/pingcap/tidb/issues/48991) @[winoros](https://github.com/winoros)
     - メモリ制限を超えると、CTE を含むクエリが予期せずスタックする問題を修正 [#49096](https://github.com/pingcap/tidb/issues/49096) @[AilinKid](https://github.com/AilinKid)
@@ -386,7 +386,7 @@ v7.6.0 以降、 `TiDB-community-server`[バイナリパッケージ](/binary-pa
     - `CHECK`制約を持つDDL文が停止する問題を修正 [#47632](https://github.com/pingcap/tidb/issues/47632) @[jiyfhust](https://github.com/jiyfhust)
     - メモリ不足が原因でDDL文のインデックス追加が失敗する問題を修正 [#47862](https://github.com/pingcap/tidb/issues/47862) @[GMHDBJD](https://github.com/GMHDBJD)
     - `ADD INDEX`の実行中にクラスターをアップグレードすると、データがインデックスと不整合になる可能性がある問題を修正しました [#46306](https://github.com/pingcap/tidb/issues/46306) @[zimulala](https://github.com/zimulala)
-    - `ADMIN CHECK`システム変数を更新した後に`tidb_mem_quota_query`を実行すると`ERROR 8175`が返される問題を修正 [#49258](https://github.com/pingcap/tidb/issues/49258) @[tangenta](https://github.com/tangenta)
+    - `tidb_mem_quota_query`システム変数を更新した後に`ADMIN CHECK`を実行すると`ERROR 8175`が返される問題を修正 [#49258](https://github.com/pingcap/tidb/issues/49258) @[tangenta](https://github.com/tangenta)
     - `ALTER TABLE`外部キーで参照される列の型を変更した際に、 `DECIMAL`の精度変更がエラーとして報告されない問題を修正しました。 [#49836](https://github.com/pingcap/tidb/issues/49836) @[yoshikipom](https://github.com/yoshikipom)
     - `ALTER TABLE`外部キーで参照される列の型を変更する際に、 `INTEGER`の長さの変更が誤ってエラーとして報告される問題を修正しました。 [#47702](https://github.com/pingcap/tidb/issues/47702) @[yoshikipom](https://github.com/yoshikipom)
     - 一部のシナリオで式のインデックスが除数が0であることを検出しない問題を修正しました [#50053](https://github.com/pingcap/tidb/issues/50053) @[lcwangchao](https://github.com/lcwangchao)
@@ -411,7 +411,7 @@ v7.6.0 以降、 `TiDB-community-server`[バイナリパッケージ](/binary-pa
     - `GROUP_CONCAT(ORDER BY)`構文を含むクエリを実行するとエラーが返される可能性がある問題を修正 [#49986](https://github.com/pingcap/tidb/issues/49986) @[AilinKid](https://github.com/AilinKid)
     - `UPDATE` 、 `DELETE` 、および`INSERT`文が、 `SQL_MODE`が厳密でない場合に警告ではなくオーバーフローエラーを返す問題を修正します [#49137](https://github.com/pingcap/tidb/issues/49137) @[YangKeao](https://github.com/YangKeao)
     - テーブルに多値インデックスと非バイナリ型文字列で構成される複合インデックスがある場合にデータを挿入できない問題を修正 [#49680](https://github.com/pingcap/tidb/issues/49680) @[YangKeao](https://github.com/YangKeao)
-    - 多階層にネストされた`LIMIT`クエリ内の`UNION`無効になる可能性がある問題を修正 [#49874](https://github.com/pingcap/tidb/issues/49874) @[Defined2014](https://github.com/Defined2014)
+    - 多階層にネストされた`UNION`クエリ内の`LIMIT`が無効になる可能性がある問題を修正 [#49874](https://github.com/pingcap/tidb/issues/49874) @[Defined2014](https://github.com/Defined2014)
     - `BETWEEN ... AND ...`条件を使用してパーティションテーブルをクエリすると誤った結果が返される問題を修正 [#49842](https://github.com/pingcap/tidb/issues/49842) @[Defined2014](https://github.com/Defined2014)
     - `REPLACE INTO`文でヒントが使用できない問題を修正 [#34325](https://github.com/pingcap/tidb/issues/34325) @[YangKeao](https://github.com/YangKeao)
     - ハッシュパーティションテーブルのクエリ時に TiDB が間違ったパーティションを選択する可能性がある問題を修正 [#50044](https://github.com/pingcap/tidb/issues/50044) @[Defined2014](https://github.com/Defined2014)

--- a/releases/release-8.0.0.md
+++ b/releases/release-8.0.0.md
@@ -415,12 +415,12 @@ TiDB バージョン: 8.0.0
     - データ変更がないにもかかわらず`auto analyze`が複数回トリガーされる問題を修正 [#51775](https://github.com/pingcap/tidb/issues/51775) @[Rustin170506](https://github.com/Rustin170506)
     - `auto analyze`の同時実行設定が正しくない問題を修正 [#51749](https://github.com/pingcap/tidb/issues/51749) @[hawkingrei](https://github.com/hawkingrei)
     - 単一のSQL文を使用して複数のインデックスを追加した際に発生するインデックスの不整合の問題を修正 [#51746](https://github.com/pingcap/tidb/issues/51746) @[tangenta](https://github.com/tangenta)
-    - クエリで`Column ... in from clause is ambiguous`を使用する場合に発生する可能性がある`NATURAL JOIN`エラーを修正 [#32044](https://github.com/pingcap/tidb/issues/32044) @[AilinKid](https://github.com/AilinKid)
+    - クエリで`NATURAL JOIN`を使用する場合に発生する可能性がある`Column ... in from clause is ambiguous`エラーを修正 [#32044](https://github.com/pingcap/tidb/issues/32044) @[AilinKid](https://github.com/AilinKid)
     - TiDB が`group by`の定数値を誤って削除したことによる誤ったクエリ結果の問題を修正 [#38756](https://github.com/pingcap/tidb/issues/38756) @[Rustin170506](https://github.com/Rustin170506)
     - `LEADING`ヒントが`UNION ALL`ステートメントで有効にならない問題を修正 [#50067](https://github.com/pingcap/tidb/issues/50067) @[hawkingrei](https://github.com/hawkingrei)
     - `BIT`型の列が一部の関数の計算に関与している場合、デコードエラーによりクエリエラーが発生する可能性がある問題を修正しました。 [#49566](https://github.com/pingcap/tidb/issues/49566) [#50850](https://github.com/pingcap/tidb/issues/50850) [#50855](https://github.com/pingcap/tidb/issues/50855) @[jiyfhust](https://github.com/jiyfhust)
     - PDとの相互作用の問題により、 `tiup cluster upgrade/start`を使用してローリングアップグレードを実行するとTiDBがpanicする可能性がある問題を修正しました [#50152](https://github.com/pingcap/tidb/issues/50152) @[zimulala](https://github.com/zimulala)
-    - `UNIQUE`句を使用して`ORDER BY`インデックスルックアップを実行するとエラーが発生する可能性がある問題を修正 [#49920](https://github.com/pingcap/tidb/issues/49920) @[jackysp](https://github.com/jackysp)
+    - `ORDER BY`句を使用して`UNIQUE`インデックスルックアップを実行するとエラーが発生する可能性がある問題を修正 [#49920](https://github.com/pingcap/tidb/issues/49920) @[jackysp](https://github.com/jackysp)
     - TiDBが`ENUM`または`SET`型を定数伝播で処理する際に誤ったクエリ結果を返す問題を修正 [#49440](https://github.com/pingcap/tidb/issues/49440) @[winoros](https://github.com/winoros)
     - クエリに Apply オペレーターが含まれている場合に TiDB がpanicを起こし、 `fatal error: concurrent map writes`エラーが発生する問題を修正しました [#50347](https://github.com/pingcap/tidb/issues/50347) @[SeaRise](https://github.com/SeaRise)
     - 文字列型の変数に対する`SET_VAR`の制御が無効になる可能性がある問題を修正しました [#50507](https://github.com/pingcap/tidb/issues/50507) @[qw4990](https://github.com/qw4990)
@@ -440,13 +440,13 @@ TiDB バージョン: 8.0.0
     - `init-stats`プロセスが TiDB をpanic、 `load stats`プロセスを終了する可能性がある問題を修正しました [#51581](https://github.com/pingcap/tidb/issues/51581) @[hawkingrei](https://github.com/hawkingrei)
     - `IN()`述語に`NULL`が含まれている場合にクエリ結果が正しくない問題を修正 [#51560](https://github.com/pingcap/tidb/issues/51560) @[winoros](https://github.com/winoros)
     - DDLタスクが複数のテーブルに関係する場合、ブロックされたDDL文がMDLビューに表示されない問題を修正します [#47743](https://github.com/pingcap/tidb/issues/47743) @[wjhuang2016](https://github.com/wjhuang2016)
-    - テーブル上の`processed_rows`タスクの`ANALYZE`が、そのテーブルの総行数を超える可能性がある問題を修正しました [#50632](https://github.com/pingcap/tidb/issues/50632) @[hawkingrei](https://github.com/hawkingrei)
+    - テーブル上の`ANALYZE`タスクの`processed_rows`が、そのテーブルの総行数を超える可能性がある問題を修正しました [#50632](https://github.com/pingcap/tidb/issues/50632) @[hawkingrei](https://github.com/hawkingrei)
     - `HashJoin`オペレーターがディスクにスピルしない場合に発生する可能性のあるゴルーチンリークの問題を修正 [#50841](https://github.com/pingcap/tidb/issues/50841) @[wshwsh12](https://github.com/wshwsh12)
     - CTEクエリのメモリ使用量が制限を超えた場合に発生するゴルーチンリークの問題を修正 [#50337](https://github.com/pingcap/tidb/issues/50337) @[guo-shaoge](https://github.com/guo-shaoge)
     - 集計関数をグループ計算に使用した際に発生する可能性のある`Can't find column ...`エラーを修正 [#50926](https://github.com/pingcap/tidb/issues/50926) @[qw4990](https://github.com/qw4990)
     - `CREATE TABLE`文に特定のパーティションまたは制約が含まれている場合に、テーブル名の変更などの DDL 操作が停止する問題を修正しました [#50972](https://github.com/pingcap/tidb/issues/50972) @[lcwangchao](https://github.com/lcwangchao)
     - Grafana の監視メトリック`tidb_statistics_auto_analyze_total`が整数として表示されない問題を修正 [#51051](https://github.com/pingcap/tidb/issues/51051) @[hawkingrei](https://github.com/hawkingrei)
-    - `tidb_gogc_tuner_threshold`変数が変更された後、 `tidb_server_memory_limit`システム変数が適切に調整されない問題を修正 [#48180](https://github.com/pingcap/tidb/issues/48180) @[hawkingrei](https://github.com/hawkingrei)
+    - `tidb_server_memory_limit`変数が変更された後、 `tidb_gogc_tuner_threshold`システム変数が適切に調整されない問題を修正 [#48180](https://github.com/pingcap/tidb/issues/48180) @[hawkingrei](https://github.com/hawkingrei)
     - クエリに JOIN 操作が含まれる場合に`index out of range`エラーが発生する可能性がある問題を修正 [#42588](https://github.com/pingcap/tidb/issues/42588) @[AilinKid](https://github.com/AilinKid)
     - 列のデフォルト値が削除されている場合、列のデフォルト値を取得するとエラーが返される問題を修正します[#50043](https://github.com/pingcap/tidb/issues/50043) [#51324](https://github.com/pingcap/tidb/issues/51324) @[crazycs520](https://github.com/crazycs520)
     - TiFlash の遅延マテリアライゼーション処理で関連する列が処理されると、間違った結果が返される場合がある問題を修正[#49241](https://github.com/pingcap/tidb/issues/49241) [#51204](https://github.com/pingcap/tidb/issues/51204) @[Lloyd-Pottiger](https://github.com/Lloyd-Pottiger)
@@ -526,7 +526,7 @@ TiDB バージョン: 8.0.0
 
         - ストレージシンク使用時にストレージサービスによって生成されるファイルシーケンス番号が正しくインクリメントされない可能性がある問題を修正しました [#10352](https://github.com/pingcap/tiflow/issues/10352) @[CharlesCheung96](https://github.com/CharlesCheung96)
         - TiCDCが複数のチェンジフィードを同時に作成する際に`ErrChangeFeedAlreadyExists`エラーを返す問題を修正 [#10430](https://github.com/pingcap/tiflow/issues/10430) @[CharlesCheung96](https://github.com/CharlesCheung96)
-        - `add table partition`で`ignore-event`イベントをフィルタリングした後、TiCDC が関連パーティションの他のタイプの DML 変更を下流にレプリケートしない問題を修正します。 [#10524](https://github.com/pingcap/tiflow/issues/10524) @[CharlesCheung96](https://github.com/CharlesCheung96)
+        - `ignore-event`で`add table partition`イベントをフィルタリングした後、TiCDC が関連パーティションの他のタイプの DML 変更を下流にレプリケートしない問題を修正します。 [#10524](https://github.com/pingcap/tiflow/issues/10524) @[CharlesCheung96](https://github.com/CharlesCheung96)
         - アップストリームテーブルで`TRUNCATE PARTITION`が実行された後、changefeed がエラーを報告する問題を修正します [#10522](https://github.com/pingcap/tiflow/issues/10522) @[sdojjy](https://github.com/sdojjy)
         - 変更フィードを再開する際に`snapshot lost caused by GC`が時間内に報告されず、変更フィードの`checkpoint-ts`が TiDB の GC セーフポイントより小さい問題を修正します [#10463](https://github.com/pingcap/tiflow/issues/10463) @[sdojjy](https://github.com/sdojjy)
         - 単一行データのデータ整合性検証が有効になった後、タイムゾーンの不一致により TiCDC `TIMESTAMP`タイプのチェックサムを検証できない問題を修正 [#10573](https://github.com/pingcap/tiflow/issues/10573) @[3AceShowHand](https://github.com/3AceShowHand)
@@ -545,7 +545,7 @@ TiDB バージョン: 8.0.0
 
         - TiKVスペースのチェックによって発生するパフォーマンス低下の問題を修正 [#43636](https://github.com/pingcap/tidb/issues/43636) @[lance6716](https://github.com/lance6716)
         - TiDB Lightningがファイルスキャン中に無効なシンボリックリンクファイルに遭遇した際にエラーを報告する問題を修正しました [#49423](https://github.com/pingcap/tidb/issues/49423) @[lance6716](https://github.com/lance6716)
-        - `0`が`NO_ZERO_IN_DATE` に含まれていない場合に、 TiDB Lightning が`sql_mode`を含む日付値を正しく解析できない問題 [#50757](https://github.com/pingcap/tidb/issues/50757) @[GMHDBJD](https://github.com/GMHDBJD)
+        - `NO_ZERO_IN_DATE`が`sql_mode` に含まれていない場合に、 TiDB Lightning が`0`を含む日付値を正しく解析できない問題 [#50757](https://github.com/pingcap/tidb/issues/50757) @[GMHDBJD](https://github.com/GMHDBJD)
 
 ## 貢献者 {#contributors}
 

--- a/releases/release-8.2.0.md
+++ b/releases/release-8.2.0.md
@@ -267,7 +267,7 @@ TiDB バージョン: 8.2.0
     - `YEAR`型の列を範囲外の符号なし整数と比較すると誤った結果が生じる問題を修正しました [#50235](https://github.com/pingcap/tidb/issues/50235) @[qw4990](https://github.com/qw4990)
     - TiDBを再起動した後に、主キー列統計のヒストグラムとTopNが読み込まれない問題を修正しました [#37548](https://github.com/pingcap/tidb/issues/37548) @[hawkingrei](https://github.com/hawkingrei)
     - `final` AggMode と`non-final` AggMode が大規模並列処理 (MPP) で共存できない問題を修正します [#51362](https://github.com/pingcap/tidb/issues/51362) @[AilinKid](https://github.com/AilinKid)
-    - 述語が常に`SHOW ERRORS`である`true`ステートメントを実行すると TiDB がパニックを起こす問題を修正します [#46962](https://github.com/pingcap/tidb/issues/46962) @[elsa0520](https://github.com/elsa0520)
+    - 述語が常に`true`である`SHOW ERRORS`ステートメントを実行すると TiDB がパニックを起こす問題を修正します [#46962](https://github.com/pingcap/tidb/issues/46962) @[elsa0520](https://github.com/elsa0520)
     - ビューの使用が再帰的CTEで機能しない問題を修正 [#49721](https://github.com/pingcap/tidb/issues/49721) @[hawkingrei](https://github.com/hawkingrei)
     - TiDB が起動時に統計をロードするときに GC が原因でエラーを報告する可能性がある問題を修正 [#53592](https://github.com/pingcap/tidb/issues/53592) @[you06](https://github.com/you06)
     - `PREPARE` / `EXECUTE`文で`CONV`式に`?`引数が含まれている場合、複数回実行するとクエリ結果が正しくない可能性がある問題を修正します。 [#53505](https://github.com/pingcap/tidb/issues/53505) @[qw4990](https://github.com/qw4990)
@@ -275,7 +275,7 @@ TiDB バージョン: 8.2.0
     - TiDBが外部キーを持つテーブルを作成する際に、対応する統計メタデータ（ `stats_meta` ）を作成しない問題を修正 [#53652](https://github.com/pingcap/tidb/issues/53652) @[hawkingrei](https://github.com/hawkingrei)
     - クエリ内の特定のフィルタ条件によってプランナーモジュールが`invalid memory address or nil pointer dereference`エラーを報告する可能性がある問題を修正しました[#53582](https://github.com/pingcap/tidb/issues/53582) [#53580](https://github.com/pingcap/tidb/issues/53580) [#53594](https://github.com/pingcap/tidb/issues/53594) [#53603](https://github.com/pingcap/tidb/issues/53603) @[YangKeao](https://github.com/YangKeao)
     - `CREATE OR REPLACE VIEW`を同時に実行すると`table doesn't exist`エラーが発生する可能性がある問題を修正しました [#53673](https://github.com/pingcap/tidb/issues/53673) @[tangenta](https://github.com/tangenta)
-    - `STATE`フィールドの`INFORMATION_SCHEMA.TIDB_TRX`が定義されていないため、 `size`テーブルの`STATE`フィールドが空になる問題を修正しました。 [#53026](https://github.com/pingcap/tidb/issues/53026) @[cfzjywxk](https://github.com/cfzjywxk)
+    - `STATE`フィールドのうち`size`が定義されていないため、 `INFORMATION_SCHEMA.TIDB_TRX`テーブルの`STATE`フィールドが空になる問題を修正しました。 [#53026](https://github.com/pingcap/tidb/issues/53026) @[cfzjywxk](https://github.com/cfzjywxk)
     - `Distinct_count`が無効になっている場合、グローバル統計の`tidb_enable_async_merge_global_stats`情報が正しくない可能性がある問題を修正しました [#53752](https://github.com/pingcap/tidb/issues/53752) @[hawkingrei](https://github.com/hawkingrei)
     - オプティマイザヒント使用時の警告情報の誤りを修正 [#53767](https://github.com/pingcap/tidb/issues/53767) @[hawkingrei](https://github.com/hawkingrei)
     - 時間型を否定すると誤った値になる問題を修正 [#52262](https://github.com/pingcap/tidb/issues/52262) @[solotzg](https://github.com/solotzg)
@@ -295,7 +295,7 @@ TiDB バージョン: 8.2.0
     - `REFERENCED_TABLE_SCHEMA`テーブルの`INFORMATION_SCHEMA.KEY_COLUMN_USAGE`フィールドが正しくない問題を修正します [#52350](https://github.com/pingcap/tidb/issues/52350) @[wd0517](https://github.com/wd0517)
     - `AUTO_ID_CACHE=1`の場合に、単一のステートメントで複数の行を挿入すると`AUTO_INCREMENT`列が不連続になる問題を修正しました。 [#52465](https://github.com/pingcap/tidb/issues/52465) @[tiancaiamao](https://github.com/tiancaiamao)
     - 非推奨警告のフォーマットを修正 [#52515](https://github.com/pingcap/tidb/issues/52515) @[dveeden](https://github.com/dveeden)
-    - `TRACE`で`copr.buildCopTasks`コマンドが欠落している問題を修正 [#53085](https://github.com/pingcap/tidb/issues/53085) @[time-and-fate](https://github.com/time-and-fate)
+    - `copr.buildCopTasks`で`TRACE`コマンドが欠落している問題を修正 [#53085](https://github.com/pingcap/tidb/issues/53085) @[time-and-fate](https://github.com/time-and-fate)
     - `memory_quota`ヒントがサブクエリで機能しない可能性がある問題を修正しました [#53834](https://github.com/pingcap/tidb/issues/53834) @[qw4990](https://github.com/qw4990)
     - メタデータロックの不適切な使用により、特定の状況下でプランキャッシュを使用する際に異常なデータが書き込まれる可能性がある問題を修正しました [#53634](https://github.com/pingcap/tidb/issues/53634) @[zimulala](https://github.com/zimulala)
     - トランザクション内のステートメントがメモリ不足で強制終了された後、TiDB が同じトランザクション内の次のステートメントの実行を継続すると、 `Trying to start aggressive locking while it's already started`エラーが発生し、panicが発生する可能性がある問題を修正しました。 [#53540](https://github.com/pingcap/tidb/issues/53540) @[MyonKeminta](https://github.com/MyonKeminta)
@@ -310,7 +310,7 @@ TiDB バージョン: 8.2.0
     - 監視ダッシュボードで**gRPC リクエストソースの期間**メトリクスが正しく表示されない問題を修正 [#17133](https://github.com/tikv/tikv/issues/17133) @[King-Dylan](https://github.com/King-Dylan)
     - TiKVからTiDBに送信されるメッセージに対して`grpc-compression-type`を介してgRPCメッセージ圧縮方法を設定しても効果がない問題を修正しました [#17176](https://github.com/tikv/tikv/issues/17176) @[ekexium](https://github.com/ekexium)
     - tikv-ctl の`raft region`コマンドの出力にリージョンステータス情報が含まれていない問題を修正 [#17037](https://github.com/tikv/tikv/issues/17037) @[glorv](https://github.com/glorv)
-    - CDCとlog-backupが`check_leader`構成を使用して`advance-ts-interval` のタイムアウトを制限しないため、場合によってはTiKVが正常に再起動した際に`resolved_ts`のラグが大きくなりすぎる問題を修正しました。 [#17107](https://github.com/tikv/tikv/issues/17107) @[MyonKeminta](https://github.com/MyonKeminta)
+    - CDCとlog-backupが`advance-ts-interval`構成を使用して`check_leader` のタイムアウトを制限しないため、場合によってはTiKVが正常に再起動した際に`resolved_ts`のラグが大きくなりすぎる問題を修正しました。 [#17107](https://github.com/tikv/tikv/issues/17107) @[MyonKeminta](https://github.com/MyonKeminta)
 
 - PD
 

--- a/releases/release-8.3.0.md
+++ b/releases/release-8.3.0.md
@@ -236,7 +236,7 @@ TiDBバージョン：8.3.0
     - `((idx_col_1 > 1) or (idx_col_1 = 1 and idx_col_2 > 10)) and ((idx_col_1 < 10) or (idx_col_1 = 10 and idx_col_2 < 20))`のようなフィルター条件のより正確なインデックス アクセス範囲を構築します [#54337](https://github.com/pingcap/tidb/issues/54337) @[ghazalfamilyusa](https://github.com/ghazalfamilyusa)
     - インデックス順序を使用して、 `WHERE idx_col_1 IS NULL ORDER BY idx_col_2`のような SQL クエリの余分なソート操作を回避します [#54188](https://github.com/pingcap/tidb/issues/54188) @[ari-e](https://github.com/ari-e)
     - `mysql.analyze_jobs`システムテーブルに分析済みインデックスを表示します [#53567](https://github.com/pingcap/tidb/issues/53567) @[Rustin170506](https://github.com/Rustin170506)。
-    - `tidb_redact_log`ステートメントの出力に`EXPLAIN`設定を適用することをサポートし、ログ処理ロジックをさらに最適化します [#54565](https://github.com/pingcap/tidb/issues/54565) @[hawkingrei](https://github.com/hawkingrei)
+    - `EXPLAIN`ステートメントの出力に`tidb_redact_log`設定を適用することをサポートし、ログ処理ロジックをさらに最適化します [#54565](https://github.com/pingcap/tidb/issues/54565) @[hawkingrei](https://github.com/hawkingrei)
     - クエリ効率を向上させるため、多値インデックスに対して`Selection` `IndexRangeScan`オペレーターを生成するサポート [#54876](https://github.com/pingcap/tidb/issues/54876) @[time-and-fate](https://github.com/time-and-fate)
     - 設定された時間枠外で実行されている自動タスク`ANALYZE`の強制終了をサポート [#55283](https://github.com/pingcap/tidb/issues/55283) @[hawkingrei](https://github.com/hawkingrei)
     - 統計情報が完全に TopN で構成され、対応するテーブル統計情報の変更された行数がゼロでない場合、TopN に到達しない等価条件の推定結果を 0 から 1 に調整します。 [#47400](https://github.com/pingcap/tidb/issues/47400) @[terry1purcell](https://github.com/terry1purcell)
@@ -251,10 +251,10 @@ TiDBバージョン：8.3.0
 
 - PD
 
-    - `batch`を介して`evict-leader-scheduler`の`pd-ctl`構成を変更してリーダー退去プロセスを加速するサポート [#8265](https://github.com/tikv/pd/issues/8265) @[rleungx](https://github.com/rleungx)
+    - `pd-ctl`を介して`evict-leader-scheduler`の`batch`構成を変更してリーダー退去プロセスを加速するサポート [#8265](https://github.com/tikv/pd/issues/8265) @[rleungx](https://github.com/rleungx)
     - Grafana の**クラスタ &gt; Label 配信**パネルに`store_id`モニタリングメトリックを追加して、異なるラベルに対応するストア ID を表示します [#8337](https://github.com/tikv/pd/issues/8337) @[HuSharp](https://github.com/HuSharp)
     - 指定されたリソースグループが存在しない場合、デフォルトのリソースグループへのフォールバックをサポートする [#8388](https://github.com/tikv/pd/issues/8388) @[JmPotato](https://github.com/JmPotato)
-    - `approximate_kv_size`の`region`コマンドが出力するリージョン情報に`pd-ctl`フィールドを追加します。 [#8412](https://github.com/tikv/pd/issues/8412) @[zeminzhou](https://github.com/zeminzhou)
+    - `pd-ctl`の`region`コマンドが出力するリージョン情報に`approximate_kv_size`フィールドを追加します。 [#8412](https://github.com/tikv/pd/issues/8412) @[zeminzhou](https://github.com/zeminzhou)
     - PD APIを呼び出してTTL設定を削除したときに返されるメッセージを最適化します [#8450](https://github.com/tikv/pd/issues/8450) @[lhy1024](https://github.com/lhy1024)
     - 大規模クエリ読み取りリクエストのRU消費動作を最適化し、他のリクエストへの影響を軽減する [#8457](https://github.com/tikv/pd/issues/8457) @[nolouch](https://github.com/nolouch)
     - PDマイクロサービスの設定ミス時に返されるエラーメッセージを最適化する [#52912](https://github.com/pingcap/tidb/issues/52912) @[rleungx](https://github.com/rleungx)
@@ -289,7 +289,7 @@ TiDBバージョン：8.3.0
 
 - TiDB
 
-    - `Open`の`PipelinedWindow`メソッドのパラメータをリセットし、 `PipelinedWindow`を`Apply`の子ノードとして使用した際に、繰り返し開閉操作によって以前のパラメータ値が再利用されることで発生する予期しないエラーを修正します。 [#53600](https://github.com/pingcap/tidb/issues/53600) @[XuHuaiyu](https://github.com/XuHuaiyu)
+    - `PipelinedWindow`の`Open`メソッドのパラメータをリセットし、 `PipelinedWindow`を`Apply`の子ノードとして使用した際に、繰り返し開閉操作によって以前のパラメータ値が再利用されることで発生する予期しないエラーを修正します。 [#53600](https://github.com/pingcap/tidb/issues/53600) @[XuHuaiyu](https://github.com/XuHuaiyu)
     - `tidb_mem_quota_query`で設定された制限を超えるメモリ使用量のため、クエリ終了時に処理が停止する可能性がある問題を修正しました。 [#55042](https://github.com/pingcap/tidb/issues/55042) @[yibin87](https://github.com/yibin87)
     - HashAggオペレーターのディスクスピルによって並列計算中にクエリ結果が不正になる問題を修正しました [#55290](https://github.com/pingcap/tidb/issues/55290) @[xzhangxian1008](https://github.com/xzhangxian1008)
     - `JSON_TYPE` JSON 形式にキャストした際に`YEAR`が間違って表示される問題を修正 [#54494](https://github.com/pingcap/tidb/issues/54494) @[YangKeao](https://github.com/YangKeao)

--- a/releases/release-8.4.0.md
+++ b/releases/release-8.4.0.md
@@ -368,7 +368,7 @@ TiDB をアップグレードする前に、オペレーティングシステム
     - クエリに`(... AND ...) OR (... AND ...) ...`のようなフィルタ条件が含まれている場合、オプティマイザが行数推定に最適な複数列統計情報を使用しない問題を修正します [#54323](https://github.com/pingcap/tidb/issues/54323) @[time-and-fate](https://github.com/time-and-fate)
     - クエリに利用可能なインデックスマージ実行計画がある場合、 `read_from_storage`ヒントが有効にならない可能性がある問題を修正 [#56217](https://github.com/pingcap/tidb/issues/56217) @[AilinKid](https://github.com/AilinKid)
     - `IndexNestedLoopHashJoin` のデータ競合問題を修正 [#49692](https://github.com/pingcap/tidb/issues/49692) @[solotzg](https://github.com/solotzg)
-    - `SUB_PART`テーブル内の`INFORMATION_SCHEMA.STATISTICS`の値が`NULL`になっている問題を修正します [#55812](https://github.com/pingcap/tidb/issues/55812) @[Defined2014](https://github.com/Defined2014)
+    - `INFORMATION_SCHEMA.STATISTICS`テーブル内の`SUB_PART`の値が`NULL`になっている問題を修正します [#55812](https://github.com/pingcap/tidb/issues/55812) @[Defined2014](https://github.com/Defined2014)
     - DML文にネストされた生成列が含まれている場合にエラーが発生する問題を修正しました [#53967](https://github.com/pingcap/tidb/issues/53967) @[wjhuang2016](https://github.com/wjhuang2016)
     - 除算演算において最小表示長の整数型データを使用すると除算結果がオーバーフローする場合がある問題を修正 [#55837](https://github.com/pingcap/tidb/issues/55837) @[windtalker](https://github.com/windtalker)
     - TopN オペレーターに続くオペレーターがメモリ制限を超えた場合にフォールバックアクションをトリガーできない問題を修正しました [#56185](https://github.com/pingcap/tidb/issues/56185) @[xzhangxian1008](https://github.com/xzhangxian1008)

--- a/releases/release-8.5.0.md
+++ b/releases/release-8.5.0.md
@@ -229,7 +229,7 @@ TiDB をアップグレードする前に、オペレーティングシステム
     - v6.5からv7.5以降にアップグレードしたクラスターで、既存のTTLタスクが予期せず頻繁に実行される問題を修正します [#56539](https://github.com/pingcap/tidb/issues/56539) @[lcwangchao](https://github.com/lcwangchao)
     - `INSERT ... ON DUPLICATE KEY`ステートメントが`mysql_insert_id`と互換性がない問題を修正 [#55965](https://github.com/pingcap/tidb/issues/55965) @[tiancaiamao](https://github.com/tiancaiamao)
     - TiKVをストレージエンジンとして選択しない場合、TTLが失敗する可能性がある問題を修正 [#56402](https://github.com/pingcap/tidb/issues/56402) @[YangKeao](https://github.com/YangKeao)
-    - `AUTO_INCREMENT`ステートメントを使用してデータをインポートした後、 `IMPORT INTO`フィールドが正しく設定されない問題を修正します [#56476](https://github.com/pingcap/tidb/issues/56476) @[D3Hunter](https://github.com/D3Hunter)
+    - `IMPORT INTO`ステートメントを使用してデータをインポートした後、 `AUTO_INCREMENT`フィールドが正しく設定されない問題を修正します [#56476](https://github.com/pingcap/tidb/issues/56476) @[D3Hunter](https://github.com/D3Hunter)
     - TiDBが`ADD INDEX`を実行する際にインデックス長の制限をチェックしない問題を修正しました。 [#56930](https://github.com/pingcap/tidb/issues/56930) @[fzzf678](https://github.com/fzzf678)
     - `RECOVER TABLE BY JOB JOB_ID;`を実行すると TiDB がpanicを起こす可能性がある問題を修正しました [#55113](https://github.com/pingcap/tidb/issues/55113) @[crazycs520](https://github.com/crazycs520)
     - 古い読み取りが読み取り操作のタイムスタンプを厳密に検証しないため、TSOと実際の物理時間の間にオフセットが存在する場合にトランザクションの一貫性に影響を与える可能性がわずかにある問題を修正しました [#56809](https://github.com/pingcap/tidb/issues/56809) @[MyonKeminta](https://github.com/MyonKeminta)

--- a/releases/release-8.5.1.md
+++ b/releases/release-8.5.1.md
@@ -77,7 +77,7 @@ CentOS Linux 7はサポート終了（EOL）を迎えたため、今後のTiDB�
     - TTLが特定の場合に大量の警告ログを生成する可能性がある問題を修正 [#58305](https://github.com/pingcap/tidb/issues/58305) @[lcwangchao](https://github.com/lcwangchao)
     - `tidb_ttl_delete_rate_limit`を変更する際に一部の TTL ジョブがハングアップする問題を修正しました [#58484](https://github.com/pingcap/tidb/issues/58484) @[lcwangchao](https://github.com/lcwangchao)
     - `REORGANIZE PARTITION`のデータバックフィル中に同時更新がロールバックされる可能性がある問題を修正 [#58226](https://github.com/pingcap/tidb/issues/58226) @[mjonss](https://github.com/mjonss)
-    - `cluster_slow_query table`をクエリする際に`ORDER BY`を使用すると、結果が順不同になる可能性がある問題を修正しました [#51723](https://github.com/pingcap/tidb/issues/51723) @[Defined2014](https://github.com/Defined2014)
+    - `cluster_slow_query`テーブルをクエリする際に`ORDER BY`を使用すると、結果が順不同になる可能性がある問題を修正しました [#51723](https://github.com/pingcap/tidb/issues/51723) @[Defined2014](https://github.com/Defined2014)
 
 - TiKV
 

--- a/releases/release-8.5.1.md
+++ b/releases/release-8.5.1.md
@@ -77,7 +77,7 @@ CentOS Linux 7はサポート終了（EOL）を迎えたため、今後のTiDB�
     - TTLが特定の場合に大量の警告ログを生成する可能性がある問題を修正 [#58305](https://github.com/pingcap/tidb/issues/58305) @[lcwangchao](https://github.com/lcwangchao)
     - `tidb_ttl_delete_rate_limit`を変更する際に一部の TTL ジョブがハングアップする問題を修正しました [#58484](https://github.com/pingcap/tidb/issues/58484) @[lcwangchao](https://github.com/lcwangchao)
     - `REORGANIZE PARTITION`のデータバックフィル中に同時更新がロールバックされる可能性がある問題を修正 [#58226](https://github.com/pingcap/tidb/issues/58226) @[mjonss](https://github.com/mjonss)
-    - `ORDER BY`をクエリする際に`cluster_slow_query table`を使用すると、結果が順不同になる可能性がある問題を修正しました [#51723](https://github.com/pingcap/tidb/issues/51723) @[Defined2014](https://github.com/Defined2014)
+    - `cluster_slow_query table`をクエリする際に`ORDER BY`を使用すると、結果が順不同になる可能性がある問題を修正しました [#51723](https://github.com/pingcap/tidb/issues/51723) @[Defined2014](https://github.com/Defined2014)
 
 - TiKV
 

--- a/releases/release-8.5.2.md
+++ b/releases/release-8.5.2.md
@@ -101,7 +101,7 @@ TiDBバージョン：8.5.2
 - TiFlash
 
     - ソート中にデータが流出してTiFlashがクラッシュする可能性がある問題を修正 [#9999](https://github.com/pingcap/tiflash/issues/9999) @[windtalker](https://github.com/windtalker)
-    - TiFlashが`Exception: Block schema mismatch`を含むSQL文を実行する際に`GROUP BY ... WITH ROLLUP`エラーを返す可能性がある問題を修正しました。 [#10110](https://github.com/pingcap/tiflash/issues/10110) @[gengliqi](https://github.com/gengliqi)
+    - TiFlashが`GROUP BY ... WITH ROLLUP`を含むSQL文を実行する際に`Exception: Block schema mismatch`エラーを返す可能性がある問題を修正しました。 [#10110](https://github.com/pingcap/tiflash/issues/10110) @[gengliqi](https://github.com/gengliqi)
     - 分散ストレージとコンピューティングアーキテクチャで、 TiFlashコンピューティングノードがリージョンピアを追加するターゲットノードとして誤って選択される可能性がある問題を修正 [#9750](https://github.com/pingcap/tiflash/issues/9750) @[JaySon-Huang](https://github.com/JaySon-Huang)
     - 特定の状況でTiFlash が予期せず終了した場合に、エラースタック トレースの出力に失敗することがある問題を修正 [#9902](https://github.com/pingcap/tiflash/issues/9902) @[JaySon-Huang](https://github.com/JaySon-Huang)
     - 大量のデータをインポートした後にTiFlash が高いメモリ使用量を維持する可能性がある問題を修正 [#9812](https://github.com/pingcap/tiflash/issues/9812) @[CalvinNeo](https://github.com/CalvinNeo)
@@ -122,7 +122,7 @@ TiDBバージョン：8.5.2
     - Backup & Restore (BR)
 
         - データ復元中に SST ファイルのダウンロードを繰り返すと、極端な場合に TiKV がpanicを引き起こす可能性がある問題を修正 [#18335](https://github.com/tikv/tikv/issues/18335) @[3pointer](https://github.com/3pointer)
-        - `status`を使用してログバックアップタスクをクエリした際に、結果に`br log status --json`フィールドが欠落する問題を修正 [#57959](https://github.com/pingcap/tidb/issues/57959) @[Leavrth](https://github.com/Leavrth)
+        - `br log status --json`を使用してログバックアップタスクをクエリした際に、結果に`status`フィールドが欠落する問題を修正 [#57959](https://github.com/pingcap/tidb/issues/57959) @[Leavrth](https://github.com/Leavrth)
         - TiKVへのリクエスト送信時に`rpcClient is idle`エラーが発生し、 BRの復元に失敗する問題を修正します。 [#58845](https://github.com/pingcap/tidb/issues/58845) @[Tristan1900](https://github.com/Tristan1900)
         - PDにアクセスできないために致命的なエラーが発生した場合にログバックアップが正常に終了しない問題を修正 [#18087](https://github.com/tikv/tikv/issues/18087) @[YuJuncen](https://github.com/YuJuncen)
         - PITR が 3072 バイトを超えるインデックスの復元に失敗する問題を修正 [#58430](https://github.com/pingcap/tidb/issues/58430) @[YuJuncen](https://github.com/YuJuncen)
@@ -139,7 +139,7 @@ TiDBバージョン：8.5.2
 
     - TiDB Data Migration (DM)
 
-        - TLSと`start-task`の両方が設定されている場合、 `shard-mode`の事前チェックが失敗する問題を修正 [#11842](https://github.com/pingcap/tiflow/issues/11842) @[sunxiaoguang](https://github.com/sunxiaoguang)
+        - TLSと`shard-mode`の両方が設定されている場合、 `start-task`の事前チェックが失敗する問題を修正 [#11842](https://github.com/pingcap/tiflow/issues/11842) @[sunxiaoguang](https://github.com/sunxiaoguang)
 
     - TiDB Lightning
 

--- a/tidb-cloud/get-started-with-cli.md
+++ b/tidb-cloud/get-started-with-cli.md
@@ -89,7 +89,7 @@ MySQL コマンドライン クライアントがインストールされてい�
 
 > **Note:**
 >
-> TiUPを使用する場合は、 `tiup cloud`の代わりに`ticloud` } を使用できます。
+> TiUPを使用する場合は、`ticloud`の代わりに`tiup cloud`を使用できます。
 
 [TiDB Cloud Starter](/tidb-cloud/select-cluster-tier.md#starter) 、 TiDB Cloudを始めるための最適な方法です。このセクションでは、 TiDB Cloud CLIを使用してTiDB Cloud Starterインスタンスを作成する方法を学びます。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Corpus-wide sweep for a recurring defect class: a sentence contains two backtick-quoted identifiers (config items, table/column names, SQL keywords, error strings) whose relative positions got swapped in the Japanese translation, reversing which term modifies which (e.g. "the DELETE privilege on user" becoming "the user privilege on DELETE").

Fixed 42 occurrences across 17 files:
- `tidb-cloud/get-started-with-cli.md`: reversed recommendation to use `ticloud` instead of `tiup cloud` (should be the other way around per EN), plus a stray MT-artifact brace
- 41 occurrences across 16 `releases/*.md` files (release-5.1.0.md through release-8.5.2.md)

Each fix was verified against the corresponding EN source in `release-8.5`, including cross-checking sibling release files that backport the same PR/issue (several already had the correct order, confirming these were isolated translation slips rather than systemic).

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected Japanese wording throughout TiDB 5.1–8.5.2 release notes, including descriptions of features, bug fixes, commands, settings, errors, and compatibility behavior.
  * Corrected TiDB Cloud CLI Quick Start instructions for TiUP usage, including the proper `tiup cloud` command and removal of an extraneous character.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->