### PR TITLE
i18n(ja): fix function/argument name swaps

### DIFF
--- a/ai/integrations/vector-search-auto-embedding-cohere.md
+++ b/ai/integrations/vector-search-auto-embedding-cohere.md
@@ -110,7 +110,7 @@ LIMIT 2;
 
 ## オプション（TiDB Cloudホスティング） {#options-tidb-cloud-hosted}
 
-**Embed v3**モデルと**Multilingual Embed v3**モデルの両方で、以下のオプションがサポートされています。これらのオプションは、 `additional_json_options`関数の`EMBED_TEXT()`パラメータを介して指定できます。
+**Embed v3**モデルと**Multilingual Embed v3**モデルの両方で、以下のオプションがサポートされています。これらのオプションは、 `EMBED_TEXT()`関数の`additional_json_options`パラメータを介して指定できます。
 
 - `input_type` (必須): 埋め込みの目的を示す特別なトークンを先頭に追加します。同じタスクの埋め込みを生成する場合は、常に同じ入力タイプを使用する必要があります。そうしないと、埋め込みが異なる意味空間にマッピングされ、互換性がなくなります。唯一の例外はセマンティック検索で、ドキュメントは`search_document`で埋め込まれ、クエリは`search_query`で埋め込まれます。
 
@@ -299,7 +299,7 @@ LIMIT 2;
 
 ## オプション（BYOK） {#options-byok}
 
-[Cohereの埋め込みオプション](https://docs.cohere.com/v2/reference/embed)は`additional_json_options`関数の`EMBED_TEXT()`パラメータを介してサポートされます。
+[Cohereの埋め込みオプション](https://docs.cohere.com/v2/reference/embed)は`EMBED_TEXT()`関数の`additional_json_options`パラメータを介してサポートされます。
 
 **例：検索操作と挿入操作で異なる`input_type`を指定する**
 

--- a/ai/integrations/vector-search-auto-embedding-gemini.md
+++ b/ai/integrations/vector-search-auto-embedding-gemini.md
@@ -247,7 +247,7 @@ embedding: list[float] = EmbeddingFunction(
 
 ## オプション {#options}
 
-すべての[Geminiオプション](https://ai.google.dev/gemini-api/docs/embeddings)`EMBED_TEXT()`関数の`additional_json_options`パラメータを介してサポートされます。
+すべての[Geminiオプション](https://ai.google.dev/gemini-api/docs/embeddings)は`EMBED_TEXT()`関数の`additional_json_options`パラメータを介してサポートされます。
 
 **例：タスクの種類を指定して品質を向上させる**
 

--- a/ai/integrations/vector-search-auto-embedding-gemini.md
+++ b/ai/integrations/vector-search-auto-embedding-gemini.md
@@ -247,7 +247,7 @@ embedding: list[float] = EmbeddingFunction(
 
 ## オプション {#options}
 
-すべての[Geminiオプション](https://ai.google.dev/gemini-api/docs/embeddings)`additional_json_options`関数の`EMBED_TEXT()`パラメータを介してサポートされます。
+すべての[Geminiオプション](https://ai.google.dev/gemini-api/docs/embeddings)`EMBED_TEXT()`関数の`additional_json_options`パラメータを介してサポートされます。
 
 **例：タスクの種類を指定して品質を向上させる**
 

--- a/ai/integrations/vector-search-auto-embedding-jina-ai.md
+++ b/ai/integrations/vector-search-auto-embedding-jina-ai.md
@@ -225,7 +225,7 @@ LIMIT 2;
 
 ## オプション {#options}
 
-すべての[Jina AIのオプション](https://jina.ai/embeddings/)は`additional_json_options`関数の`EMBED_TEXT()`パラメータを通じてサポートされます。
+すべての[Jina AIのオプション](https://jina.ai/embeddings/)は`EMBED_TEXT()`関数の`additional_json_options`パラメータを通じてサポートされます。
 
 **例：パフォーマンス向上のため「下流タスク」を指定してください**
 

--- a/ai/integrations/vector-search-auto-embedding-openai.md
+++ b/ai/integrations/vector-search-auto-embedding-openai.md
@@ -271,7 +271,7 @@ SET @@GLOBAL.TIDB_EXP_EMBED_OPENAI_API_BASE = '';
 
 ## オプション {#options}
 
-すべての[OpenAIの埋め込みオプション](https://platform.openai.com/docs/api-reference/embeddings/create)は`additional_json_options`関数の`EMBED_TEXT()`パラメータを通じてサポートされます。
+すべての[OpenAIの埋め込みオプション](https://platform.openai.com/docs/api-reference/embeddings/create)は`EMBED_TEXT()`関数の`additional_json_options`パラメータを通じてサポートされます。
 
 **例：text-embedding-3-large に別の次元を使用する**
 

--- a/releases/release-8.0.0.md
+++ b/releases/release-8.0.0.md
@@ -376,7 +376,7 @@ TiDB バージョン: 8.0.0
 
 - TiFlash
 
-    - `json_path`関数の`JSON_EXTRACT()`引数に非定数値を使用することをサポートする [#8510](https://github.com/pingcap/tiflash/issues/8510) @[SeaRise](https://github.com/SeaRise)
+    - `JSON_EXTRACT()`関数の`json_path`引数に非定数値を使用することをサポートする [#8510](https://github.com/pingcap/tiflash/issues/8510) @[SeaRise](https://github.com/SeaRise)
     - `JSON_LENGTH(json, path)` 機能をサポートします [#8711](https://github.com/pingcap/tiflash/issues/8711) @[SeaRise](https://github.com/SeaRise)
 
 - ツール


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Follow-up to #23704 (which fixed cases where 機能 was wrongly used for a genuine function): this checks the reverse direction — cases where 関数 was used for something that is not actually a callable function.

Both confirmed defects turned out to be a function/argument role swap (not just a wrong word choice):

- `ai/integrations/vector-search-auto-embedding-{cohere,gemini,jina-ai,openai}.md` (5 occurrences): EN says "the `additional_json_options` parameter of the `EMBED_TEXT()` function", but JA had the roles reversed (`` `additional_json_options`関数の`EMBED_TEXT()`パラメータ ``, making `additional_json_options` the function and `EMBED_TEXT()` the parameter).
- `releases/release-8.0.0.md`: EN says "the `json_path` argument in the `JSON_EXTRACT()` function", but JA had `` `json_path`関数の`JSON_EXTRACT()`引数 `` (backwards).

123 total candidates matching the pattern (a lowercase backtick-quoted identifier immediately followed by 関数, without parentheses) were checked against the EN source; the other 121 were confirmed to be genuine SQL/Go function names correctly labeled 関数 and were left untouched.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Japanese documentation for Cohere, Gemini, Jina AI, and OpenAI embedding options, clarifying that `additional_json_options` is a parameter of `EMBED_TEXT()`.
  - Clarified the Japanese TiDB 8.0.0 release notes to accurately describe the `JSON_EXTRACT()` function and its `json_path` argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->