### PR TITLE
i18n(ja): restore literal S3 API action names

### DIFF
--- a/tidb-cloud/migrate-from-op-tidb.md
+++ b/tidb-cloud/migrate-from-op-tidb.md
@@ -210,7 +210,7 @@ TiDB Self-ManagedクラスターからAmazon S3にデータをエクスポート
 
     - s3:GetObject
     - s3:GetObjectVersion
-    - s3:リストバケット
+    - s3:ListBucket
     - s3:GetBucketLocation
 
     S3バケットがサーバー側暗号化（SSE-KMS）を使用している場合は、KMS権限も追加する必要があります。

--- a/tiflash/tiflash-disaggregated-and-s3.md
+++ b/tiflash/tiflash-disaggregated-and-s3.md
@@ -48,13 +48,13 @@ TiFlashの分散型ストレージおよびコンピューティングアーキ�
 
     TiFlash はデータにアクセスするために以下の S3 API を使用する必要があります。TiDB クラスター内のTiFlashノードにこれらの API に対する必要な権限が付与されていることを確認してください。
 
-    - オブジェクトを配置する
+    - PutObject
     - GetObject
-    - オブジェクトのコピー
-    - オブジェクトの削除
-    - リストオブジェクトV2
-    - オブジェクトタグ付けの取得
-    - PutBucketライフサイクル
+    - CopyObject
+    - DeleteObject
+    - ListObjectsV2
+    - GetObjectTagging
+    - PutBucketLifecycle
 
 2. TiDBクラスターに、ストレージとコンピューティングを組み合わせたアーキテクチャを使用してデプロイされたTiFlashノードがないことを確認してください。もしある場合は、すべてのテーブルのTiFlashレプリカ数を`0`に設定し、すべてのTiFlashノードを削除してください。例：
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The English source lists literal AWS S3 API action names (e.g. `PutObject`, `s3:ListBucket`) as identifiers, not descriptive prose. Several of these had been translated word-by-word into Japanese instead of being kept as literal identifiers, which is incorrect since they are not natural-language phrases but exact API/IAM action names that must match AWS's own naming for the reader to look them up or use them in an IAM policy.

Found by searching the whole corpus for the same defect pattern after fixing one instance flagged during an unrelated review:

- `tiflash/tiflash-disaggregated-and-s3.md`: a bullet list of S3 APIs TiFlash needs permission for had 6 of its 7 entries mistranslated — `PutObject`→"オブジェクトを配置する", `CopyObject`→"オブジェクトのコピー", `DeleteObject`→"オブジェクトの削除", `ListObjectsV2`→"リストオブジェクトV2" (also word-order scrambled), `GetObjectTagging`→"オブジェクトタグ付けの取得", `PutBucketLifecycle`→"PutBucketライフサイクル" (partially translated). Only `GetObject` in the same list was already correct.
- `tidb-cloud/migrate-from-op-tidb.md`: `s3:ListBucket` was rendered `s3:リストバケット` in a required-IAM-permissions list, while the sibling page `tidb-cloud/premium/migrate-from-op-tidb-premium.md` already correctly keeps this and the other 3 permissions in the same list as literal English/`s3:` identifiers.

Searched the rest of the corpus (all files mentioning S3 IAM/API permissions, including `br/*`, `tidb-cloud/configure-external-storage-access.md`, `tidb-cloud/dedicated-external-storage.md`, `tidb-cloud/troubleshoot-import-access-denied-error.md`, `tidb-cloud/premium/import-from-s3-premium.md`) — no further instances of this defect found; all other S3 API/action name mentions are already correctly kept as literal identifiers.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch