### PR TITLE
release notes: include security dependency fixes in AI output

### DIFF
--- a/scripts/release-notes-ai-generator/prompts/release-note.md
+++ b/scripts/release-notes-ai-generator/prompts/release-note.md
@@ -19,7 +19,7 @@ Write a release note when the change is visible to TiDB users or operators, incl
 - Meaningful performance improvements observable in common operations.
 - Behavior changes that affect upgrade paths, tooling integration, or operational workflows.
 - Default value changes for system variables or configuration parameters.
-- Security fixes that address known or reported vulnerabilities in dependencies shipped with TiDB components, even when only dependency manifests or lockfiles change and functional behavior remains unchanged.
+- Security fixes that address known or reported vulnerabilities affecting dependencies used by TiDB components shipped to users, even when only dependency manifests or lockfiles change and functional behavior remains unchanged.
 
 Return a no-release-note verdict for internal-only changes, including:
 
@@ -31,7 +31,7 @@ Return a no-release-note verdict for internal-only changes, including:
 
 If a PR is mostly internal but the outcome is user-visible, describe the outcome and omit implementation details. If the only user-facing effect is indirect or speculative, lean toward `not_needed`.
 
-Do not classify a security dependency update as internal-only solely because it changes only dependency manifests or lockfiles. Return `not_needed` only when the affected dependencies are used exclusively by tests, development or build tooling, or other code not shipped with the product.
+Do not classify a security dependency update as internal-only solely because it changes only dependency manifests or lockfiles. Return `not_needed` if the dependency is used only by tests, development or build tooling, or other unshipped code, or if the vulnerability does not affect the shipped component.
 
 First, use all available context to decide whether the change needs a release note. If it does, classify it as follows:
 

--- a/scripts/release-notes-ai-generator/prompts/release-note.md
+++ b/scripts/release-notes-ai-generator/prompts/release-note.md
@@ -19,6 +19,7 @@ Write a release note when the change is visible to TiDB users or operators, incl
 - Meaningful performance improvements observable in common operations.
 - Behavior changes that affect upgrade paths, tooling integration, or operational workflows.
 - Default value changes for system variables or configuration parameters.
+- Security fixes that address known or reported vulnerabilities in dependencies shipped with TiDB components, even when only dependency manifests or lockfiles change and functional behavior remains unchanged.
 
 Return a no-release-note verdict for internal-only changes, including:
 
@@ -29,6 +30,8 @@ Return a no-release-note verdict for internal-only changes, including:
 - Code comments or source-code-only documentation changes.
 
 If a PR is mostly internal but the outcome is user-visible, describe the outcome and omit implementation details. If the only user-facing effect is indirect or speculative, lean toward `not_needed`.
+
+Do not classify a security dependency update as internal-only solely because it changes only dependency manifests or lockfiles. Return `not_needed` only when the affected dependencies are used exclusively by tests, development or build tooling, or other code not shipped with the product.
 
 First, use all available context to decide whether the change needs a release note. If it does, classify it as follows:
 

--- a/scripts/release-notes-ai-generator/prompts/release-note.md
+++ b/scripts/release-notes-ai-generator/prompts/release-note.md
@@ -31,7 +31,7 @@ Return a no-release-note verdict for internal-only changes, including:
 
 If a PR is mostly internal but the outcome is user-visible, describe the outcome and omit implementation details. If the only user-facing effect is indirect or speculative, lean toward `not_needed`.
 
-Do not classify a security dependency update as internal-only solely because it changes only dependency manifests or lockfiles. Return `not_needed` if the dependency is used only by tests, development or build tooling, or other unshipped code, or if the vulnerability does not affect the shipped component.
+Do not classify a security dependency update as internal-only solely because it changes only dependency manifests or lockfiles. Return `not_needed` if the dependency is used only by tests or other unshipped code, or if the vulnerability does not affect the shipped component.
 
 First, use all available context to decide whether the change needs a release note. If it does, classify it as follows:
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the AI release-note classification prompt to treat known or reported vulnerability fixes in dependencies shipped with TiDB components as release-note-worthy, even when only dependency manifests or lockfiles change.

Keep dependency updates used exclusively by tests, development or build tooling, or other unshipped code eligible for the not-needed verdict.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/docs/pull/23710
  - https://github.com/pingcap/docs-cn/pull/21913

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated release-note guidance to require notes for security fixes addressing known or reported vulnerabilities in dependencies shipped with product components, including manifest- or lockfile-only changes.
  - Clarified that these updates are not internal-only when they affect shipped components.
  - Specified that dependency changes affecting only tests, unshipped code, development or build tooling, or components unaffected by the vulnerability may remain internal-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->