### PR TITLE
docs: add code PR field to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ https://github.com/pingcap/docs/tree/master/resources/doc-templates
 
 - [ ] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.
 
-### What is changed, added or deleted? (Required)
+### What is changed, added, or deleted? (Required)
 
 <!--Tell us what you did and why.-->
 
@@ -33,8 +33,9 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 
 ### What is the related PR or file link(s)?
 
-<!--Reference link(s) will help reviewers review your PR quickly.-->
+<!--Reference links help reviewers review your PR quickly. If this documentation update is related to a code change, link the corresponding code PR below.-->
 
+- Related code change PR(s) (if applicable):
 - This PR is translated from:
 - Other reference link(s):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 
 <!--Reference links help reviewers review your PR quickly. If this documentation update is related to a code change, link the corresponding code PR below.-->
 
-- Related code change PR(s) (if applicable):
+- Related code change pull requests (if applicable):
 - This PR is translated from:
 - Other reference link(s):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 
 <!--Reference links help reviewers review your PR quickly. If this documentation update is related to a code change, link the corresponding code PR below.-->
 
-- Related code change pull requests (if applicable):
+- Related code change PR links (if applicable):
 - This PR is translated from:
 - Other reference link(s):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@ For details, see [tips for choosing the affected versions](https://github.com/pi
 
 ### What is the related PR or file link(s)?
 
-<!--Reference links help reviewers review your PR quickly. If this documentation update is related to a code change, link the corresponding code PR below.-->
+<!--Reference links help reviewers review your PR quickly. If this documentation update is related to code changes, link the corresponding code PRs below.-->
 
 - Related code change PR links (if applicable):
 - This PR is translated from:


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Add a dedicated field for related code change PRs to the pull request template. The new guidance asks contributors to provide the corresponding code PR when a documentation update is related to a code change, helping reviewers verify that documented behavior matches the implementation.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Related code change PR(s) (if applicable):
- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs-cn/pull/21916

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request template wording and punctuation to make change descriptions clearer.
  - Clarified when documentation updates should reference related code changes.
  - Added a dedicated bullet for linking related code change pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->