### PR TITLE
ci: include TiDB Cloud Lake in zh translation workflow

### DIFF
--- a/.github/workflows/translation-zh.yaml
+++ b/.github/workflows/translation-zh.yaml
@@ -37,8 +37,8 @@ env:
   SOURCE_BRANCH: release-8.5
   TERMS_BRANCH: master
   CN_CLOUD_BRANCH: i18n-zh-release-8.5
-  CLOUD_TOC_FILES: TOC-tidb-cloud.md,TOC-tidb-cloud-starter.md,TOC-tidb-cloud-essential.md,TOC-tidb-cloud-premium.md,TOC-tidb-cloud-releases.md
-  CLOUD_INDEX_FILES: tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md
+  CLOUD_TOC_FILES: TOC-tidb-cloud.md,TOC-tidb-cloud-starter.md,TOC-tidb-cloud-essential.md,TOC-tidb-cloud-premium.md,TOC-tidb-cloud-releases.md,TOC-tidb-cloud-lake.md
+  CLOUD_INDEX_FILES: tidb-cloud/dedicated/_index.md,tidb-cloud/essential/_index.md,tidb-cloud/premium/_index.md,tidb-cloud/releases/_index.md,tidb-cloud/starter/_index.md,tidb-cloud-lake/_index.md
   AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
   # Manual all-updated runs use the same global cursor behavior as scheduled runs.
@@ -169,6 +169,7 @@ jobs:
           BASE_REF: ${{ steps.commits.outputs.base_ref }}
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           DOCS_SOURCE_PATH: ${{ github.workspace }}/docs-source
+          DOCS_TARGET_PATH: ${{ github.workspace }}/docs
           CLOUD_TOC_FILES: ${{ env.CLOUD_TOC_FILES }}
           CLOUD_INDEX_FILES: ${{ env.CLOUD_INDEX_FILES }}
         run: |
@@ -191,6 +192,7 @@ jobs:
           SOURCE_HEAD_REF: ${{ steps.commits.outputs.head_ref }}
           SOURCE_FOLDER: ""
           SOURCE_FILES: ${{ steps.source_files.outputs.files }}
+          SOURCE_FULL_FILES: ${{ steps.source_files.outputs.full_files }}
           SOURCE_FILES_TRANSLATION_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.translation_scope == 'Translate only specified files' && inputs.source_files_translation_mode || 'incremental' }}
           SOURCE_LANGUAGE: English
           TARGET_LANGUAGE: Chinese


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

- Include `TOC-tidb-cloud-lake.md` and `tidb-cloud-lake/_index.md` in the Cloud English-to-Chinese translation scope.
- Pass the target docs checkout to the source-file resolver so it can identify newly introduced TOCs.
- Pass the resolved full-translation file list to the commit-sync translator, allowing files newly entering the translation scope to be bootstrapped from their latest source versions.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Related code change PR links (if applicable): https://github.com/qiancai/ai-markdown-translator/pull/1
- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated translation workflows to include Cloud Lake table-of-contents and index documentation.
  * Improved source-file resolution for targeted documentation paths.
  * Ensured resolved file paths are synchronized correctly during translation commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->