### PR TITLE
dm-faq: fix table_parttern_ typo to table_pattern_

### DIFF
--- a/dm/dm-faq.md
+++ b/dm/dm-faq.md
@@ -146,7 +146,7 @@ You need to check the error message and log files to further analyze this error.
 Check the configuration items `block-allow-list` and `table-route`:
 
 - You need to configure the names of upstream databases and tables under `block-allow-list`. You can add "~" before `do-tables` to use regular expressions to match names.
-- `table-route` uses wildcard characters instead of regular expressions to match table names. For example, `table_parttern_[0-63]` only matches 7 tables, from `table_parttern_0` to `table_pattern_6`.
+- `table-route` uses wildcard characters instead of regular expressions to match table names. For example, `table_pattern_[0-63]` only matches 7 tables, from `table_pattern_0` to `table_pattern_6`.
 
 ## Why does the `replicate lag` monitor metric show no data when DM is not replicating from upstream?
 


### PR DESCRIPTION
## What is changed, added or deleted? (Required)

Fixes a typo in the example table name: `table_parttern_` should be `table_pattern_`, consistent with the rest of the sentence which already uses `table_pattern_6`.

## Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v8.5 (LTS)

## Related PR or Tracking Issue (Required for bug fixes)

N/A

## Do your changes match any of the following descriptions? (Required)

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after being deployed online

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the `table-route` wildcard example to consistently use the `table_pattern_` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->