### PR TITLE
docs: fix YAML syntax in Japanese TiUP clean page

### DIFF
--- a/tiup/tiup-command-clean.md
+++ b/tiup/tiup-command-clean.md
@@ -1,6 +1,6 @@
 ---
 title: tiup clean
-summary: "tiup clean"コマンドは、コンポーネント操作中に生成されたデータを消去します。構文は"tiup clean [name] [flags]"で、すべての操作記録を消去するには"--all"オプションを使用します。
+summary: この「tiup clean」コマンドは、コンポーネント操作中に生成されたデータを消去します。構文は「tiup clean [name] [flags]」で、すべての操作記録を消去するには「--all」オプションを使用します。
 ---
 
 # tiup clean {#tiup-clean}


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix the invalid YAML front matter in the Japanese `tiup clean` page by making the summary start with Japanese text and using Japanese quotation marks. This prevents the website build from treating the leading ASCII double quote as a YAML string delimiter.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/blob/release-8.5/tiup/tiup-command-clean.md
- Other reference link(s): https://github.com/pingcap/website-docs/actions/runs/34193136236

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quotation mark formatting in the `tiup clean` command documentation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->