### PR TITLE
i18n(ja): fix dropped particles and unclosed parenthesis found by CodeRabbit

### DIFF
--- a/develop/dev-guide-sample-application-golang-gorm.md
+++ b/develop/dev-guide-sample-application-golang-gorm.md
@@ -81,7 +81,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -126,7 +126,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -160,7 +160,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -184,7 +184,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-golang-gorm.md
+++ b/develop/dev-guide-sample-application-golang-gorm.md
@@ -81,7 +81,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -126,7 +126,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -160,7 +160,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -184,7 +184,7 @@ cd tidb-golang-gorm-quickstart
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-golang-sql-driver.md
+++ b/develop/dev-guide-sample-application-golang-sql-driver.md
@@ -81,7 +81,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -126,7 +126,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -160,7 +160,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -184,7 +184,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-golang-sql-driver.md
+++ b/develop/dev-guide-sample-application-golang-sql-driver.md
@@ -81,7 +81,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -126,7 +126,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -160,7 +160,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -184,7 +184,7 @@ cd tidb-golang-sql-driver-quickstart
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-hibernate.md
+++ b/develop/dev-guide-sample-application-java-hibernate.md
@@ -82,7 +82,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-hibernate.md
+++ b/develop/dev-guide-sample-application-java-hibernate.md
@@ -82,7 +82,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-hibernate-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-jdbc.md
+++ b/develop/dev-guide-sample-application-java-jdbc.md
@@ -83,7 +83,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -129,7 +129,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -164,7 +164,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -188,7 +188,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-jdbc.md
+++ b/develop/dev-guide-sample-application-java-jdbc.md
@@ -83,7 +83,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -129,7 +129,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -164,7 +164,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -188,7 +188,7 @@ cd tidb-java-jdbc-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-mybatis.md
+++ b/develop/dev-guide-sample-application-java-mybatis.md
@@ -82,7 +82,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-mybatis.md
+++ b/develop/dev-guide-sample-application-java-mybatis.md
@@ -82,7 +82,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-mybatis-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-spring-boot.md
+++ b/develop/dev-guide-sample-application-java-spring-boot.md
@@ -8,7 +8,7 @@ aliases: ['/ja/tidbcloud/dev-guide-sample-application-spring-boot','/ja/tidb/dev
 
 [Spring](https://spring.io/)は Java用の人気のあるオープンソースコンテナフレームワークです。TiDBはMySQL互換データベースで、このドキュメントでは Spring の使用方法として[Spring Boot](https://spring.io/projects/spring-boot)を使用します。
 
-このチュートリアルでは、TiDBを[Spring Data JPA](https://spring.io/projects/spring-data-jpa)およびJPAプロバイダとしての[Hibernate](https://hibernate.org/orm/)と組み合わせて使用し、以下のタスクを実行する方法を学びます。
+このチュートリアルでは、TiDBを[Spring Data JPA](https://spring.io/projects/spring-data-jpa)およびJPAプロバイダとしての[Hibernate](https://hibernate.org/orm/)と組み合わせて使用​​し、以下のタスクを実行する方法を学びます。
 
 - 環境をセットアップしてください。
 - HibernateとSpring Data JPAを使用してTiDBに接続します。
@@ -82,7 +82,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続文字列`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-java-spring-boot.md
+++ b/develop/dev-guide-sample-application-java-spring-boot.md
@@ -82,7 +82,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-6. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -127,7 +127,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-8. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -161,7 +161,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-5. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -185,7 +185,7 @@ cd tidb-java-springboot-jpa-quickstart
     cp env.sh.example env.sh
     ```
 
-2. 対応する接続​​文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`env.sh`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```shell
     export TIDB_HOST='{host}'

--- a/develop/dev-guide-sample-application-nextjs.md
+++ b/develop/dev-guide-sample-application-nextjs.md
@@ -100,7 +100,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{gateway-region}.aws.tidbcloud.com'
@@ -150,7 +150,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -181,7 +181,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-nextjs.md
+++ b/develop/dev-guide-sample-application-nextjs.md
@@ -100,7 +100,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{gateway-region}.aws.tidbcloud.com'
@@ -150,7 +150,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -181,7 +181,7 @@ npm install
     Copy-Item ".env.example" -Destination ".env"
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```bash
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-django.md
+++ b/develop/dev-guide-sample-application-python-django.md
@@ -99,7 +99,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -144,7 +144,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -177,7 +177,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -201,7 +201,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-django.md
+++ b/develop/dev-guide-sample-application-python-django.md
@@ -99,7 +99,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -144,7 +144,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -177,7 +177,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -201,7 +201,7 @@ mysqlclient でインストールの問題が発生した場合は、 [mysqlclie
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-mysql-connector.md
+++ b/develop/dev-guide-sample-application-python-mysql-connector.md
@@ -89,7 +89,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -132,7 +132,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -165,7 +165,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -189,7 +189,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-mysql-connector.md
+++ b/develop/dev-guide-sample-application-python-mysql-connector.md
@@ -89,7 +89,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -132,7 +132,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -165,7 +165,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -189,7 +189,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-mysqlclient.md
+++ b/develop/dev-guide-sample-application-python-mysqlclient.md
@@ -91,7 +91,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{gateway-region}.aws.tidbcloud.com'
@@ -136,7 +136,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -170,7 +170,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}.clusters.tidb-cloud.com'
@@ -194,7 +194,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-mysqlclient.md
+++ b/develop/dev-guide-sample-application-python-mysqlclient.md
@@ -91,7 +91,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{gateway-region}.aws.tidbcloud.com'
@@ -136,7 +136,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -170,7 +170,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}.clusters.tidb-cloud.com'
@@ -194,7 +194,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-peewee.md
+++ b/develop/dev-guide-sample-application-python-peewee.md
@@ -93,7 +93,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -136,7 +136,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -169,7 +169,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -193,7 +193,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-peewee.md
+++ b/develop/dev-guide-sample-application-python-peewee.md
@@ -93,7 +93,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -136,7 +136,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -169,7 +169,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -193,7 +193,7 @@ peeweeは、複数のデータベースを扱うORMライブラリです。デ�
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-pymysql.md
+++ b/develop/dev-guide-sample-application-python-pymysql.md
@@ -89,7 +89,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -132,7 +132,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -165,7 +165,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -189,7 +189,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-pymysql.md
+++ b/develop/dev-guide-sample-application-python-pymysql.md
@@ -89,7 +89,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -132,7 +132,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -165,7 +165,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -189,7 +189,7 @@ pip install -r requirements.txt
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-sqlalchemy.md
+++ b/develop/dev-guide-sample-application-python-sqlalchemy.md
@@ -99,7 +99,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -142,7 +142,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -175,7 +175,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -199,7 +199,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-sample-application-python-sqlalchemy.md
+++ b/develop/dev-guide-sample-application-python-sqlalchemy.md
@@ -99,7 +99,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com
@@ -142,7 +142,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-8. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+8. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -175,7 +175,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-5. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+5. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{host}'  # e.g. tidb.xxxx.clusters.tidb-cloud.com
@@ -199,7 +199,7 @@ SQLAlchemyは、複数のデータベースを扱うORMライブラリです。�
     cp .env.example .env
     ```
 
-2. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+2. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{tidb_server_host}'

--- a/develop/dev-guide-wordpress.md
+++ b/develop/dev-guide-wordpress.md
@@ -74,7 +74,7 @@ TiDB Cloud StarterへのWordPressデータベース接続を設定します。
     cp .env.example .env
     ```
 
-6. 対応する接続文字列`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{HOST}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com

--- a/develop/dev-guide-wordpress.md
+++ b/develop/dev-guide-wordpress.md
@@ -74,7 +74,7 @@ TiDB Cloud StarterへのWordPressデータベース接続を設定します。
     cp .env.example .env
     ```
 
-6. 対応する接続​​文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
+6. 対応する接続文字列を`.env`ファイルにコピー＆ペーストしてください。例は以下のとおりです。
 
     ```dotenv
     TIDB_HOST='{HOST}'  # e.g. gateway01.ap-northeast-1.prod.aws.tidbcloud.com

--- a/tidb-cloud/tidbx-instance-move-faq.md
+++ b/tidb-cloud/tidbx-instance-move-faq.md
@@ -140,4 +140,4 @@ TiDB Cloud API を使用してインスタンスを管理する場合は、 [TiD
 
 ## どこで助けを得られますか？ {#where-can-i-get-help}
 
-自動化、統合、またはData Serviceの設定が元のプロジェクトIDに依存しているかどうか不明な場合は、移行を開始する前に、 TiDB Cloudサポート（ [support@pingcap.com](mailto:support@pingcap.com)にお問い合わせください。
+自動化、統合、またはData Serviceの設定が元のプロジェクトIDに依存しているかどうか不明な場合は、移行を開始する前に、 TiDB Cloudサポート（ [support@pi​​ngcap.com](mailto:support@pingcap.com)）にお問い合わせください。

--- a/tidb-cloud/tidbx-instance-move-faq.md
+++ b/tidb-cloud/tidbx-instance-move-faq.md
@@ -140,4 +140,4 @@ TiDB Cloud API を使用してインスタンスを管理する場合は、 [TiD
 
 ## どこで助けを得られますか？ {#where-can-i-get-help}
 
-自動化、統合、またはData Serviceの設定が元のプロジェクトIDに依存しているかどうか不明な場合は、移行を開始する前に、 TiDB Cloudサポート（ [support@pi​​ngcap.com](mailto:support@pingcap.com)）にお問い合わせください。
+自動化、統合、またはData Serviceの設定が元のプロジェクトIDに依存しているかどうか不明な場合は、移行を開始する前に、 TiDB Cloudサポート（ [support@pingcap.com](mailto:support@pingcap.com)）にお問い合わせください。

--- a/tiproxy/tiproxy-configuration.md
+++ b/tiproxy/tiproxy-configuration.md
@@ -147,7 +147,7 @@ server_configs:
     ha.interface: "eth0"
 ```
 
-TiProxy v1.3.1以降、複数の仮想IPアドレスの設定がサポートされます。コンピューティングレイヤーのリソースを分離する必要がある場合は、複数の仮想IPアドレスを設定し、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)組み合わせて使用できます。設定例については、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)を参照してください。
+TiProxy v1.3.1以降、複数の仮想IPアドレスの設定がサポートされます。コンピューティングレイヤーのリソースを分離する必要がある場合は、複数の仮想IPアドレスを設定し、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)と組み合わせて使用​​できます。設定例については、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)を参照してください。
 
 > **Note:**
 >

--- a/tiproxy/tiproxy-configuration.md
+++ b/tiproxy/tiproxy-configuration.md
@@ -147,7 +147,7 @@ server_configs:
     ha.interface: "eth0"
 ```
 
-TiProxy v1.3.1以降、複数の仮想IPアドレスの設定がサポートされます。コンピューティングレイヤーのリソースを分離する必要がある場合は、複数の仮想IPアドレスを設定し、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)と組み合わせて使用​​できます。設定例については、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)を参照してください。
+TiProxy v1.3.1以降、複数の仮想IPアドレスの設定がサポートされます。コンピューティングレイヤーのリソースを分離する必要がある場合は、複数の仮想IPアドレスを設定し、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)と組み合わせて使用できます。設定例については、 [ラベルベースの負荷分散](/tiproxy/tiproxy-load-balance.md#label-based-load-balancing)を参照してください。
 
 > **Note:**
 >


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fixes 3 defect classes found by CodeRabbit on PR #23778 (zero-width-space removal) that were unrelated to that PR's scope, split here to keep that diff focused:

1. Missing を particle before the `.env`/`env.sh` destination file name in the "copy and paste the corresponding connection string" step instruction, shared across 14 `develop/dev-guide-sample-application-*.md` pages + `develop/dev-guide-wordpress.md` (48 sites total -- CodeRabbit flagged only 1 site, a corpus grep for the identical shared template sentence found the same defect repeated across all sibling guide pages using this instruction).
2. `tidb-cloud/tidbx-instance-move-faq.md`: unclosed parenthesis around a support-contact mailto link.
3. `tiproxy/tiproxy-configuration.md`: missing と particle before 組み合わせて使用できます.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): pingcap/docs#23778 (where these were found via CodeRabbit review)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Japanese grammar and removed invisible-character typos in connection setup instructions across multiple language and framework guides.
  - Clarified directions for copying connection strings into `.env` and `env.sh` files.
  - Fixed Japanese wording in the WordPress and TiProxy configuration guides.
  - Corrected malformed Markdown syntax in the TiDBX instance move FAQ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
