### PR TITLE
best-practices: clarify scheduler pool underutilization wording

### DIFF
--- a/best-practices/three-nodes-hybrid-deployment.md
+++ b/best-practices/three-nodes-hybrid-deployment.md
@@ -72,7 +72,7 @@ In this test, the value of this parameter is set to `2`. Observe the **gRPC poll
 
 When TiKV detects that the CPU core number of the machine is greater than or equal to `16`, this parameter value defaults to `8`. When the CPU core number is smaller than `16`, the parameter value defaults to `4`. This parameter is used when TiKV converts complex transaction requests to simple key-value reads or writes, but the scheduler thread pool does not perform any writes.
 
-Ideally, the usage rate of the scheduler thread pool is kept between 50% and 75%. Similar to the gRPC thread pool, the `storage.scheduler-worker-pool-size` parameter defaults to a larger value during the hybrid deployment, which makes resource usage insufficient. In this test, the value of this parameter is set to `2`, which is in line with the best practices, a conclusion drawn by observing the corresponding metrics in the **Scheduler worker CPU** panel.
+Ideally, the usage rate of the scheduler thread pool is kept between 50% and 75%. Similar to the gRPC thread pool, the `storage.scheduler-worker-pool-size` parameter defaults to a larger value during the hybrid deployment, which results in a lower resource utilization rate. In this test, the value of this parameter is set to `2`, which is in line with the best practices, a conclusion drawn by observing the corresponding metrics in the **Scheduler worker CPU** panel.
 
 ![Scheduler Worker CPU](/media/best-practices/three-nodes-scheduler-pool-usage.png)
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Rewords "which makes resource usage insufficient" to "which results in a lower resource utilization rate" for clarity. The original phrasing is ambiguous and can be misread as "there aren't enough resources" (a shortage), when the intended meaning — confirmed against the Chinese source ("资源利用不充分", literally "resource utilization is insufficient") — is that an oversized thread pool leads to a lower utilization rate (wasted capacity), the opposite concern from a resource shortage.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Related code change PR links (if applicable):
- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the explanation of resource utilization associated with the default scheduler worker pool size in three-node hybrid deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->