### PR TITLE
i18n(ja): add missing execution qualifier to plan cache proper noun

### DIFF
--- a/TOC-tidb-cloud-premium.md
+++ b/TOC-tidb-cloud-premium.md
@@ -105,8 +105,8 @@
           - [クエリの最適化](/agg-distinct-optimization.md)
           - [コストモデル](/cost-model.md)
           - [ランタイムフィルタ](/runtime-filter.md)
-        - [プリペアドプランキャッシュ](/sql-prepared-plan-cache.md)
-        - [非プリペアドプランキャッシュ](/sql-non-prepared-plan-cache.md)
+        - [プリペアド実行プランキャッシュ](/sql-prepared-plan-cache.md)
+        - [非プリペアド実行プランキャッシュ](/sql-non-prepared-plan-cache.md)
       - 実行計画の制御
         - [概要](/control-execution-plan.md)
         - [オプティマイザのヒント](/optimizer-hints.md)

--- a/TOC-tidb-cloud-starter.md
+++ b/TOC-tidb-cloud-starter.md
@@ -99,8 +99,8 @@
           - [クエリの最適化](/agg-distinct-optimization.md)
           - [コストモデル](/cost-model.md)
           - [ランタイムフィルタ](/runtime-filter.md)
-        - [プリペアドプランキャッシュ](/sql-prepared-plan-cache.md)
-        - [非プリペアドプランキャッシュ](/sql-non-prepared-plan-cache.md)
+        - [プリペアド実行プランキャッシュ](/sql-prepared-plan-cache.md)
+        - [非プリペアド実行プランキャッシュ](/sql-non-prepared-plan-cache.md)
       - 実行計画の制御
         - [概要](/control-execution-plan.md)
         - [オプティマイザのヒント](/optimizer-hints.md)

--- a/TOC-tidb-cloud.md
+++ b/TOC-tidb-cloud.md
@@ -118,8 +118,8 @@
           - [クエリの最適化](/agg-distinct-optimization.md)
           - [コストモデル](/cost-model.md)
           - [ランタイムフィルタ](/runtime-filter.md)
-        - [プリペアドプランキャッシュ](/sql-prepared-plan-cache.md)
-        - [非プリペアドプランキャッシュ](/sql-non-prepared-plan-cache.md)
+        - [プリペアド実行プランキャッシュ](/sql-prepared-plan-cache.md)
+        - [非プリペアド実行プランキャッシュ](/sql-non-prepared-plan-cache.md)
       - 実行計画の制御
         - [概要](/control-execution-plan.md)
         - [オプティマイザのヒント](/optimizer-hints.md)

--- a/benchmark/benchmark-tidb-using-sysbench.md
+++ b/benchmark/benchmark-tidb-using-sysbench.md
@@ -19,7 +19,7 @@ server_configs:
     log.level: "error"
 ```
 
-また、 [`tidb_enable_prepared_plan_cache`](/system-variables.md#tidb_enable_prepared_plan_cache-new-in-v610)が有効になっていることを確認し、 `--db-ps-mode=auto`を使用して sysbench がプリペアドステートメントを使用できるようにすることをお勧めします。SQL プランキャッシュの機能と監視方法については、 [SQL プリペアドプランキャッシュ](/sql-prepared-plan-cache.md)のドキュメントを参照してください。
+また、 [`tidb_enable_prepared_plan_cache`](/system-variables.md#tidb_enable_prepared_plan_cache-new-in-v610)が有効になっていることを確認し、 `--db-ps-mode=auto`を使用して sysbench がプリペアドステートメントを使用できるようにすることをお勧めします。SQL プランキャッシュの機能と監視方法については、 [SQL プリペアド実行プランキャッシュ](/sql-prepared-plan-cache.md)のドキュメントを参照してください。
 
 > **Note:**
 >

--- a/sql-non-prepared-plan-cache.md
+++ b/sql-non-prepared-plan-cache.md
@@ -1,9 +1,9 @@
 ---
 title: SQL Non-Prepared Execution Plan Cache
-summary: TiDB の SQL 非プリペアドプランキャッシュの原理、使用法、および例について学習します。
+summary: TiDB の SQL 非プリペアド実行プランキャッシュの原理、使用法、および例について学習します。
 ---
 
-# SQL Non-Prepared Execution Plan Cache {#sql-non-prepared-execution-plan-cache}
+# SQL 非プリペアド実行プランキャッシュ {#sql-non-prepared-execution-plan-cache}
 
 TiDBは、 [ステートメント`Prepare` / `Execute`](/sql-prepared-plan-cache.md)と同様に、一部の`PREPARE`以外のステートメントに対して実行計画のキャッシュをサポートしています。この機能により、これらのステートメントは最適化フェーズをスキップし、パフォーマンスを向上させることができます。
 

--- a/sql-prepared-plan-cache.md
+++ b/sql-prepared-plan-cache.md
@@ -1,9 +1,9 @@
 ---
 title: SQL Prepared Execution Plan Cache
-summary: TiDB の SQL プリペアドプランキャッシュについて学習します。
+summary: TiDB の SQL プリペアド実行プランキャッシュについて学習します。
 ---
 
-# SQL プリペアドプランキャッシュ {#sql-prepared-execution-plan-cache}
+# SQL プリペアド実行プランキャッシュ {#sql-prepared-execution-plan-cache}
 
 TiDBは、 `Prepare`と`Execute`クエリの実行計画のキャッシュをサポートしています。これには、以下の2つの形式のプリペアドステートメントが含まれます。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

EN consistently names this feature "SQL (Non-)Prepared Execution Plan Cache" everywhere it appears as a proper noun (page titles, TOC entries, formal doc links). The JA page titles themselves (`sql-prepared-plan-cache.md`, `sql-non-prepared-plan-cache.md`) and 3 of 5 TOC files (`TOC-tidb-cloud.md`, `TOC-tidb-cloud-premium.md`, `TOC-tidb-cloud-starter.md`) dropped the "execution" qualifier (プリペアドプランキャッシュ), while `TOC.md`, `TOC-tidb-cloud-essential.md`, and `system-variable-reference.md` already included it (プリペアド実行プランキャッシュ). Also translates `sql-non-prepared-plan-cache.md`'s H1, which was left as literal English.

Generic lowercase "prepared plan cache" mentions elsewhere in the corpus are intentionally untouched — EN itself uses that shorter, casual form in many places (verified line-by-line against `release-8.5`), and JA correctly mirrors it there. Only sites where EN uses the capitalized proper-noun form were changed.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): follow-up from #23807

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Japanese documentation titles, summaries, and table-of-contents entries to consistently use terminology for prepared and non-prepared execution plan caches.
  - Updated the related benchmark documentation link text to match the revised terminology.
  - Link destinations and technical content remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->