### PR TITLE
ttl: document index scans for TTL jobs

### DIFF
--- a/system-variable-reference.md
+++ b/system-variable-reference.md
@@ -4136,6 +4136,13 @@ Referenced in:
 - [TiDB 7.1.6 Release Notes](/releases/release-7.1.6.md)
 - [TiDB 6.5.0 Release Notes](/releases/release-6.5.0.md)
 
+### tidb_ttl_enable_index_scan
+
+Referenced in:
+
+- [Periodically Delete Expired Data Using TTL (Time to Live)](/time-to-live.md)
+- [System Variables](/system-variables.md#tidb_ttl_enable_index_scan)
+
 ### tidb_ttl_job_enable
 
 Referenced in:

--- a/system-variables.md
+++ b/system-variables.md
@@ -6725,6 +6725,19 @@ For details, see [Identify Slow Queries](/identify-slow-queries.md).
 - Range: `[1, 256]`
 - This variable is used to set the maximum concurrency of TTL jobs on each TiDB node. For more information, refer to [Time to Live](/time-to-live.md).
 
+### tidb_ttl_enable_index_scan
+
+> **Note:**
+>
+> This variable is read-only for [{{{ .starter }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#starter) and [{{{ .essential }}}](https://docs.pingcap.com/tidbcloud/select-cluster-tier#essential) instances.
+
+- Scope: GLOBAL
+- Persists to cluster: Yes
+- Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
+- Default value: `ON`
+- Type: Boolean
+- This variable controls whether newly created TTL jobs can use an eligible secondary index or nonclustered primary index that starts with the TTL column. When this variable is set to `OFF`, new TTL jobs scan in table-key order. Changing this variable does not change the scan path of running TTL tasks. For index eligibility and rolling-upgrade behavior, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
+
 ### tidb_ttl_job_enable <span class="version-mark">New in v6.5.0</span>
 
 > **Note:**

--- a/system-variables.md
+++ b/system-variables.md
@@ -6736,7 +6736,7 @@ For details, see [Identify Slow Queries](/identify-slow-queries.md).
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
 - Default value: `ON`
 - Type: Boolean
-- This variable controls whether TTL jobs can use an eligible secondary index or non-clustered primary key that starts with the TTL column. When this variable is set to `OFF`, TTL jobs scan in table-key order. For index eligibility, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
+- This variable controls whether TTL jobs can use an eligible secondary index or non-clustered primary key index that starts with the TTL column. When this variable is set to `OFF`, TTL jobs scan in table-key order. For index eligibility, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
 
 ### tidb_ttl_job_enable <span class="version-mark">New in v6.5.0</span>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -6736,7 +6736,7 @@ For details, see [Identify Slow Queries](/identify-slow-queries.md).
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
 - Default value: `ON`
 - Type: Boolean
-- This variable controls whether newly created TTL jobs can use an eligible secondary index or nonclustered primary index that starts with the TTL column. When this variable is set to `OFF`, new TTL jobs scan in table-key order. Changing this variable does not change the scan path of running TTL tasks. For index eligibility and rolling-upgrade behavior, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
+- This variable controls whether TTL jobs can use an eligible secondary index or nonclustered primary index that starts with the TTL column. When this variable is set to `OFF`, TTL jobs scan in table-key order. For index eligibility, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
 
 ### tidb_ttl_job_enable <span class="version-mark">New in v6.5.0</span>
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -6736,7 +6736,7 @@ For details, see [Identify Slow Queries](/identify-slow-queries.md).
 - Applies to hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value): No
 - Default value: `ON`
 - Type: Boolean
-- This variable controls whether TTL jobs can use an eligible secondary index or nonclustered primary index that starts with the TTL column. When this variable is set to `OFF`, TTL jobs scan in table-key order. For index eligibility, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
+- This variable controls whether TTL jobs can use an eligible secondary index or non-clustered primary key that starts with the TTL column. When this variable is set to `OFF`, TTL jobs scan in table-key order. For index eligibility, see [Scan expired rows using an index](/time-to-live.md#scan-expired-rows-using-an-index).
 
 ### tidb_ttl_job_enable <span class="version-mark">New in v6.5.0</span>
 

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -142,14 +142,14 @@ TiDB also limits the number of concurrent TTL tasks at the cluster level. You ca
 
 ### Scan expired rows using an index
 
-By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. This avoids scanning unexpired index entries.
+To use an index scan, the TTL column must be the first column of the index. This allows TiDB to scan the index range that can contain expired rows without scanning unexpired index entries.
 
-This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variables.md#tidb_ttl_enable_index_scan) global variable, which is enabled by default. When this variable is disabled or no eligible index is available, TiDB falls back to scanning in table-key order and prevents the optimizer from selecting a secondary index for that scan.
+By default, TiDB automatically selects an eligible index for this scan. This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variables.md#tidb_ttl_enable_index_scan) global variable, which is enabled by default. When this variable is disabled or no eligible index is available, TiDB falls back to scanning in table-key order and prevents the optimizer from selecting a secondary index for that scan. For a table with a clustered primary key, the table-key scan uses that primary key.
 
-An eligible index must meet the following requirements:
+In addition to starting with the TTL column, an eligible index must meet the following requirements:
 
-- It is a secondary index or a non-clustered primary key. TiDB does not use a clustered primary key, partial index, global index, multi-valued index, vector search index, full-text index, or invisible index for this scan.
-- Its first column is the TTL column, and each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
+- It is a visible secondary index or a non-clustered primary key index. It is not a partial index, global index, multi-valued index, vector search index, or full-text index.
+- Each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
 - For a unique index that contains multiple columns, all columns except the TTL column are `NOT NULL`.
 - A non-unique index meets the following requirements:
     - It includes either all primary key columns or none of them. It cannot include only some columns of a composite primary key.
@@ -224,7 +224,7 @@ In addition, TiDB provides three tables to obtain more information about TTL job
 
     The columns `{last, current}_job_{start_time, finish_time, ttl_expire}` describe respectively the start time, finish time, and expiration time used by the TTL job of the last or current execution. The `last_job_summary` column describes the execution status of the last TTL task, including the total number of rows, the number of successful rows, and the number of failed rows.
 
-+ The `mysql.tidb_ttl_task` table contains information about the ongoing TTL subtasks. A TTL job is split into many subtasks, and this table records the subtasks that are currently being executed. The `scan_index_id` column indicates the scan path selected when the job was created. A non-`NULL` value is the ID of the selected index, and `NULL` means that the task scans in table-key order.
++ The `mysql.tidb_ttl_task` table contains information about the ongoing TTL subtasks. A TTL job is split into subtasks, and this table records the subtasks that are currently being executed. The `scan_index_id` column indicates the scan path selected when the job was created. A non-`NULL` value is the ID of the selected index, and `NULL` means that the task scans in table-key order.
 + The `mysql.tidb_ttl_job_history` table contains information about the TTL jobs that have been executed. The record of TTL job history is kept for 90 days.
 
     ```sql

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -142,27 +142,19 @@ TiDB also limits the number of concurrent TTL tasks at the cluster level. You ca
 
 ### Scan expired rows using an index
 
-By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. Compared with scanning in table-key order, scanning in TTL-column order avoids repeatedly scanning unexpired index entries. TiDB splits the job according to the TiKV Regions of the selected index, and Regions that are entirely after the expiration-time boundary do not participate in the job.
+By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. This avoids scanning unexpired index entries. TiDB splits the job by the Regions of the selected index and does not create tasks for Regions entirely after the expiration-time boundary.
 
 This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variables.md#tidb_ttl_enable_index_scan) global variable, which is enabled by default. When this variable is disabled or no eligible index is available, TiDB falls back to scanning in table-key order and prevents the optimizer from selecting a secondary index for that scan.
 
-An index must meet all of the following requirements to be used by a TTL job:
+An eligible index must meet the following requirements:
 
-- It is a public, visible, local secondary index or nonclustered primary index. Clustered primary indexes, global indexes, multi-valued indexes, columnar indexes, and conditional indexes are not eligible.
-- Its first column is the TTL column, and every indexed column stores the full value of a visible table column. Prefix indexes and indexes on hidden expression columns are not eligible.
-- It provides a stable, unique pagination order. For a unique composite index, every indexed column other than the TTL column must be `NOT NULL`. For a non-unique index, the declared index columns must contain either the entire table key or none of it. If they contain none of the table key, TiDB appends the implicit table key to the pagination order when that physical order is supported.
-- The final pagination columns do not contain `SET`, `FLOAT`, or `DOUBLE` columns.
+- It is a visible secondary index or nonclustered primary index, and its first column is the TTL column.
+- Each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
+- In a unique composite index, all columns except the TTL column are `NOT NULL`.
+- For a non-unique index, TiDB must be able to append the table row identifier to the scan order. Including all primary key columns in the index ensures this requirement; including only some columns of a composite primary key is not supported.
+- The columns used to identify a row do not use the `SET`, `FLOAT`, or `DOUBLE` data type.
 
-Here, the table key is the clustered primary key, or `_tidb_rowid` for a table without a clustered primary key. A non-unique index that contains only part of a composite table key is not eligible. An unsigned integer clustered primary key and a common handle with a prefix primary-key column cannot be used as an implicit suffix, but the index can still be eligible if it explicitly contains the complete table key.
-
-If multiple indexes are eligible, TiDB prefers a single-column index on the TTL column, then an index that explicitly contains the complete table key, and then the index with the shortest pagination tuple. If pagination tuples have the same length, TiDB prefers the index that requires reading fewer columns.
-
-> **Note:**
->
-> - During a rolling upgrade, if a table would use an index scan but the TiDB server builds in the cluster do not match, TiDB does not create a new TTL job for that table. The scheduler retries after the TiDB server builds become consistent. To keep creating jobs using table-key scans during the upgrade, temporarily disable `tidb_ttl_enable_index_scan`.
-> - If TiDB cannot obtain or compare server information, it creates the job using a table-key scan instead.
-> - If the selected index is dropped after a TTL job is created, the affected task reports an error. A later TTL job can select another eligible index or fall back to a table-key scan.
-> - Each scan page is a separate SQL statement. If an indexed value changes during a scan, the current job might skip the row or observe it again. Before deletion, TiDB checks the expiration condition again, so a row that is no longer expired is not deleted. An expired row skipped by the current job remains eligible for a later TTL job.
+TTL jobs do not use clustered primary indexes, partial indexes, global indexes, multi-valued indexes, columnar indexes, or invisible indexes.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:
 

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -142,19 +142,17 @@ TiDB also limits the number of concurrent TTL tasks at the cluster level. You ca
 
 ### Scan expired rows using an index
 
-By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. This avoids scanning unexpired index entries. TiDB splits the job by the Regions of the selected index and does not create tasks for Regions entirely after the expiration-time boundary.
+By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. This avoids scanning unexpired index entries.
 
 This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variables.md#tidb_ttl_enable_index_scan) global variable, which is enabled by default. When this variable is disabled or no eligible index is available, TiDB falls back to scanning in table-key order and prevents the optimizer from selecting a secondary index for that scan.
 
 An eligible index must meet the following requirements:
 
-- It is a visible secondary index or nonclustered primary index, and its first column is the TTL column.
-- Each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
+- It is a visible secondary index or nonclustered primary index, rather than a partial, global, multi-valued, or columnar index.
+- Its first column is the TTL column, and each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
 - In a unique composite index, all columns except the TTL column are `NOT NULL`.
-- For a non-unique index, TiDB must be able to append the table row identifier to the scan order. Including all primary key columns in the index ensures this requirement; including only some columns of a composite primary key is not supported.
+- A non-unique index includes either all primary key columns or none of them.
 - The columns used to identify a row do not use the `SET`, `FLOAT`, or `DOUBLE` data type.
-
-TTL jobs do not use clustered primary indexes, partial indexes, global indexes, multi-valued indexes, columnar indexes, or invisible indexes.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:
 

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -152,7 +152,7 @@ An eligible index must meet the following requirements:
 - Its first column is the TTL column, and each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
 - In a unique composite index, all columns except the TTL column are `NOT NULL`.
 - A non-unique index includes either all primary key columns or none of them.
-- The columns used to identify a row do not use the `SET`, `FLOAT`, or `DOUBLE` data type.
+- Index columns cannot use the `SET`, `FLOAT`, or `DOUBLE` data type. For a non-unique index that does not include primary key columns, the primary key columns cannot use these data types either.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:
 

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -148,10 +148,14 @@ This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variab
 
 An eligible index must meet the following requirements:
 
-- It is a visible secondary index or nonclustered primary index, rather than a partial, global, multi-valued, or columnar index.
+- It is a secondary index or a non-clustered primary key. TiDB does not use a clustered primary key, partial index, global index, multi-valued index, vector search index, full-text index, or invisible index for this scan.
 - Its first column is the TTL column, and each index column indexes the full column value. Prefix indexes and expression indexes are not supported.
-- In a unique composite index, all columns except the TTL column are `NOT NULL`.
-- A non-unique index includes either all primary key columns or none of them.
+- For a unique index that contains multiple columns, all columns except the TTL column are `NOT NULL`.
+- A non-unique index meets the following requirements:
+    - It includes either all primary key columns or none of them. It cannot include only some columns of a composite primary key.
+    - If the table has a clustered primary key consisting of a single unsigned integer column, the index includes that primary key column.
+    - If any column of the clustered primary key is defined with a prefix length, the index includes all primary key columns.
+    - If the [new collation framework](/character-set-and-collation.md#new-framework-for-collations) is enabled, for a table created by an earlier TiDB version whose clustered primary key contains non-binary string columns, include all primary key columns to avoid compatibility restrictions.
 - Index columns cannot use the `SET`, `FLOAT`, or `DOUBLE` data type. For a non-unique index that does not include primary key columns, the primary key columns cannot use these data types either.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -155,7 +155,6 @@ An eligible index must meet the following requirements:
     - It includes either all primary key columns or none of them. It cannot include only some columns of a composite primary key.
     - If the table has a clustered primary key consisting of a single unsigned integer column, the index includes that primary key column.
     - If any column of the clustered primary key is defined with a prefix length, the index includes all primary key columns.
-    - For a table created by an earlier TiDB version whose clustered primary key contains non-binary string columns, the index includes all primary key columns.
 - Index columns cannot use the `SET`, `FLOAT`, or `DOUBLE` data type. For a non-unique index that does not include primary key columns, the primary key columns cannot use these data types either.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -155,7 +155,7 @@ An eligible index must meet the following requirements:
     - It includes either all primary key columns or none of them. It cannot include only some columns of a composite primary key.
     - If the table has a clustered primary key consisting of a single unsigned integer column, the index includes that primary key column.
     - If any column of the clustered primary key is defined with a prefix length, the index includes all primary key columns.
-    - If the [new collation framework](/character-set-and-collation.md#new-framework-for-collations) is enabled, for a table created by an earlier TiDB version whose clustered primary key contains non-binary string columns, include all primary key columns to avoid compatibility restrictions.
+    - For a table created by an earlier TiDB version whose clustered primary key contains non-binary string columns, the index includes all primary key columns.
 - Index columns cannot use the `SET`, `FLOAT`, or `DOUBLE` data type. For a non-unique index that does not include primary key columns, the primary key columns cannot use these data types either.
 
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:

--- a/time-to-live.md
+++ b/time-to-live.md
@@ -140,6 +140,30 @@ When executing a TTL job, TiDB splits the table into tasks, with the Region as t
 
 TiDB also limits the number of concurrent TTL tasks at the cluster level. You can adjust this concurrency by setting the system variable [`tidb_ttl_running_tasks`](/system-variables.md#tidb_ttl_running_tasks-new-in-v700).
 
+### Scan expired rows using an index
+
+By default, TiDB uses an eligible index that starts with the TTL column to scan expired rows. Compared with scanning in table-key order, scanning in TTL-column order avoids repeatedly scanning unexpired index entries. TiDB splits the job according to the TiKV Regions of the selected index, and Regions that are entirely after the expiration-time boundary do not participate in the job.
+
+This behavior is controlled by the [`tidb_ttl_enable_index_scan`](/system-variables.md#tidb_ttl_enable_index_scan) global variable, which is enabled by default. When this variable is disabled or no eligible index is available, TiDB falls back to scanning in table-key order and prevents the optimizer from selecting a secondary index for that scan.
+
+An index must meet all of the following requirements to be used by a TTL job:
+
+- It is a public, visible, local secondary index or nonclustered primary index. Clustered primary indexes, global indexes, multi-valued indexes, columnar indexes, and conditional indexes are not eligible.
+- Its first column is the TTL column, and every indexed column stores the full value of a visible table column. Prefix indexes and indexes on hidden expression columns are not eligible.
+- It provides a stable, unique pagination order. For a unique composite index, every indexed column other than the TTL column must be `NOT NULL`. For a non-unique index, the declared index columns must contain either the entire table key or none of it. If they contain none of the table key, TiDB appends the implicit table key to the pagination order when that physical order is supported.
+- The final pagination columns do not contain `SET`, `FLOAT`, or `DOUBLE` columns.
+
+Here, the table key is the clustered primary key, or `_tidb_rowid` for a table without a clustered primary key. A non-unique index that contains only part of a composite table key is not eligible. An unsigned integer clustered primary key and a common handle with a prefix primary-key column cannot be used as an implicit suffix, but the index can still be eligible if it explicitly contains the complete table key.
+
+If multiple indexes are eligible, TiDB prefers a single-column index on the TTL column, then an index that explicitly contains the complete table key, and then the index with the shortest pagination tuple. If pagination tuples have the same length, TiDB prefers the index that requires reading fewer columns.
+
+> **Note:**
+>
+> - During a rolling upgrade, if a table would use an index scan but the TiDB server builds in the cluster do not match, TiDB does not create a new TTL job for that table. The scheduler retries after the TiDB server builds become consistent. To keep creating jobs using table-key scans during the upgrade, temporarily disable `tidb_ttl_enable_index_scan`.
+> - If TiDB cannot obtain or compare server information, it creates the job using a table-key scan instead.
+> - If the selected index is dropped after a TTL job is created, the affected task reports an error. A later TTL job can select another eligible index or fall back to a table-key scan.
+> - Each scan page is a separate SQL statement. If an indexed value changes during a scan, the current job might skip the row or observe it again. Before deletion, TiDB checks the expiration condition again, so a row that is no longer expired is not deleted. An expired row skipped by the current job remains eligible for a later TTL job.
+
 To disable the execution of TTL jobs, in addition to setting the `TTL_ENABLE='OFF'` table option, you can also disable the execution of TTL jobs in the entire cluster by setting the [`tidb_ttl_job_enable`](/system-variables.md#tidb_ttl_job_enable-new-in-v650) global variable:
 
 ```sql
@@ -207,7 +231,7 @@ In addition, TiDB provides three tables to obtain more information about TTL job
 
     The columns `{last, current}_job_{start_time, finish_time, ttl_expire}` describe respectively the start time, finish time, and expiration time used by the TTL job of the last or current execution. The `last_job_summary` column describes the execution status of the last TTL task, including the total number of rows, the number of successful rows, and the number of failed rows.
 
-+ The `mysql.tidb_ttl_task` table contains information about the ongoing TTL subtasks. A TTL job is split into many subtasks, and this table records the subtasks that are currently being executed.
++ The `mysql.tidb_ttl_task` table contains information about the ongoing TTL subtasks. A TTL job is split into many subtasks, and this table records the subtasks that are currently being executed. The `scan_index_id` column indicates the scan path selected when the job was created. A non-`NULL` value is the ID of the selected index, and `NULL` means that the task scans in table-key order.
 + The `mysql.tidb_ttl_job_history` table contains information about the TTL jobs that have been executed. The record of TTL job history is kept for 90 days.
 
     ```sql


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Document TTL index scans, including the system variable, eligible index requirements, fallback behavior, and task metadata.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Related code change PR links (if applicable): https://github.com/pingcap/tidb/pull/68397
- This PR is translated from: N/A
- Other reference link(s): N/A

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added `tidb_ttl_enable_index_scan` to the system variable reference.
  - Documented its global scope, cluster persistence, default `ON` value, behavior, and TiDB Cloud availability.
  - Added guidance on using eligible indexes to scan expired rows, including fallback behavior and index requirements.
  - Documented the `scan_index_id` field in the TTL task table to clarify the selected scan path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->