### PR TITLE
i18n(ja): translate sentences left untranslated in English

### DIFF
--- a/releases/release-6.1.0.md
+++ b/releases/release-6.1.0.md
@@ -148,12 +148,12 @@ TiDB バージョン: 6.1.0
     以前のバージョンのTiDBでは、設定項目を変更した後、変更を有効にするにはクラスタを再起動する必要がありました。これにより、オンラインサービスが中断される可能性がありました。この問題に対処するため、TiDB v6.1.0では動的設定機能が導入され、クラスタを再起動せずにパラメータ変更を検証できるようになりました。具体的な最適化は以下の通りです。
 
     - TiDBの一部の設定項目をシステム変数に変換し、動的に変更・保存できるようにします。変換後は元の設定項目は非推奨となることに注意してください。変換後の設定項目の詳細なリストについては、 [コンフィグレーションファイルのパラメータ](#configuration-file-parameters)を参照してください。
-    - Support configuring some TiKV parameters online. For a detailed list of the parameters, see [その他](#others).
+    - 一部のTiKVパラメータのオンライン設定をサポートします。パラメータの詳細なリストについては、 [その他](#others)を参照してください。
     - TiFlash設定項目`max_threads`をシステム変数`tidb_max_tiflash_threads`に変換し、構成を動的に変更して永続化できるようにします。変換後も元の設定項目は保持されることに注意してください。
 
     以前のバージョンからアップグレードされた v6.1.0 クラスター (オンライン アップグレードとオフライン アップグレードを含む) については、次の点に注意してください。
 
-    - If the configuration items specified in the configuration file before the upgrade already exist, TiDB will automatically update the values of the configured items to those of the corresponding system variables during the upgrade process. In this way, after the upgrade, the system behavior is not affected by parameter optimization.
+    - アップグレード前に設定ファイルに指定された設定項目が既に存在する場合、TiDBはアップグレードプロセス中に、設定された項目の値を対応するシステム変数の値に自動的に更新します。これにより、パラメータの最適化により、アップグレード後もシステムの動作は変わりません。
     - 上記の自動更新はアップグレード中に1回のみ実行されます。アップグレード後は、廃止された設定項目は無効になります。
 
     この機能により、システムを再起動したりサービスを中断したりすることなく、パラメータを動的に変更し、検証して永続化することができます。これにより、日々のメンテナンスが容易になります。

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -195,7 +195,7 @@ Here is an example for Header:
 
 TiDB Self-Managed ユーザーの認証方法として`tidb_auth_token`を設定して使用するには、次の手順を実行します。
 
-1. Configure [`auth-token-jwks`](/tidb-configuration-file.md#auth-token-jwks-new-in-v640) and [`auth-token-refresh-interval`](/tidb-configuration-file.md#auth-token-refresh-interval-new-in-v640) in the TiDB configuration file.
+1. TiDB設定ファイルで[`auth-token-jwks`](/tidb-configuration-file.md#auth-token-jwks-new-in-v640)と[`auth-token-refresh-interval`](/tidb-configuration-file.md#auth-token-refresh-interval-new-in-v640)を設定します。
 
     たとえば、次のコマンドを使用して JWKS の例を取得できます。
 

--- a/ticdc/ticdc-open-api.md
+++ b/ticdc/ticdc-open-api.md
@@ -127,7 +127,7 @@ curl -X GET http://127.0.0.1:8300/api/v1/health
 
 `mounter_worker_num` : マウンタのスレッド番号。マウンタはTiKVから出力されたデータをデコードするために使用されます。デフォルト値は`16`です。
 
-The configuration parameters of sink are as follows:
+シンクの設定パラメータは以下のとおりです。
 
 ```json
 {


### PR DESCRIPTION
### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

### What is changed, added or deleted? (Required)

Three prose sentences/bullets were left in raw English amid otherwise fully translated Japanese text:

- `releases/release-6.1.0.md`: two bullets under the dynamic-config feature description and the upgrade-compatibility notes. The second one reuses the wording already translated for the same content appearing elsewhere in this same release note (lines 315-318), for consistency.
- `security-compatibility-with-mysql.md`: one numbered setup step for configuring `tidb_auth_token`.
- `ticdc/ticdc-open-api.md`: one lead-in sentence before the `sink_config` JSON example.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
