### PR TITLE
i18n(ja): restore literal English error messages in DM precheck troubleshooting

### DIFF
--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -62,13 +62,13 @@ TiDB Cloudクラスターでエラーが発生した場合は、ドキュメン�
 
 このセクションでは、移行中に発生する可能性のある問題とその解決策について説明します。これらのエラーメッセージは、**Migration Job Details**ページに表示されます。
 
-### エラーメッセージ：「移行に必要なバイナリログがソースデータベースに存在しません。移行が成功するためには、バイナリログファイルが十分な期間保持されていることを確認してください。」 {#error-message-the-required-binary-log-for-migration-no-longer-exists-on-the-source-database-please-make-sure-binary-log-files-are-kept-for-long-enough-time-for-migration-to-succeed}
+### エラーメッセージ：「The required binary log for migration no longer exists on the source database. Please make sure binary log files are kept for long enough time for migration to succeed.」 {#error-message-the-required-binary-log-for-migration-no-longer-exists-on-the-source-database-please-make-sure-binary-log-files-are-kept-for-long-enough-time-for-migration-to-succeed}
 
 このエラーは、移行対象のバイナリログが既にクリーンアップされており、新しいタスクを作成することによってのみ復元できることを意味します。
 
 増分移行に必要なバイナリログが存在することを確認してください。バイナリログの保存期間を延長するために、 `expire_logs_days`を設定することをお勧めします。移行ジョブでバイナリログのクリーンアップが必要な場合は、 `purge binary log`を使用してバイナリログをクリーンアップしないでください。
 
-### エラーメッセージ：「指定されたパラメータを使用してソースデータベースに接続できませんでした。ソースデータベースが稼働しており、指定されたパラメータを使用して接続できることを確認してください。」 {#error-message-failed-to-connect-to-the-source-database-using-given-parameters-please-make-sure-the-source-database-is-up-and-can-be-connected-using-the-given-parameters}
+### エラーメッセージ：「Failed to connect to the source database using given parameters. Please make sure the source database is up and can be connected using the given parameters.」 {#error-message-failed-to-connect-to-the-source-database-using-given-parameters-please-make-sure-the-source-database-is-up-and-can-be-connected-using-the-given-parameters}
 
 このエラーは、ソースデータベースへの接続に失敗したことを意味します。ソースデータベースが起動しており、指定されたパラメータを使用して接続できるかどうかを確認してください。ソースデータベースが利用可能であることを確認したら、 **Restart**をクリックしてタスクの復旧を試みてください。
 
@@ -76,25 +76,25 @@ TiDB Cloudクラスターでエラーが発生した場合は、ドキュメン�
 
 このエラーは、ダウンストリームの TiDB クラスタへの接続に失敗したことを意味します。ダウンストリームの TiDB クラスタが正常な状態（ `Available`および`Modifying`を含む）であり、ジョブで指定されたユーザー名とパスワードで接続できるかどうかを確認してください。ダウンストリームの TiDB クラスタが利用可能であることを確認したら、 **Restart**をクリックしてタスクを再開してみてください。
 
-### エラーメッセージ：「指定されたユーザー名とパスワードを使用してTiDBクラスタに接続できませんでした。TiDBクラスタが起動しており、指定されたユーザー名とパスワードで接続できることを確認してください。」 {#error-message-failed-to-connect-to-the-tidb-cluster-using-the-given-user-and-password-please-make-sure-tidb-cluster-is-up-and-can-be-connected-to-using-the-given-user-and-password}
+### エラーメッセージ：「Failed to connect to the TiDB cluster using the given user and password. Please make sure TiDB Cluster is up and can be connected to using the given user and password.」 {#error-message-failed-to-connect-to-the-tidb-cluster-using-the-given-user-and-password-please-make-sure-tidb-cluster-is-up-and-can-be-connected-to-using-the-given-user-and-password}
 
 TiDB クラスターへの接続に失敗しました。TiDB クラスターが正常な状態（ `Available`および`Modifying`を含む）であるかどうかを確認することをお勧めします。ジョブで指定されたユーザー名とパスワードを使用して接続できます。TiDB クラスターが利用可能であることを確認したら、 **Restart**をクリックしてタスクを再開してみてください。
 
-### エラーメッセージ：「TiDBクラスタのストレージが不足しています。TiKVのノードストレージを増やしてください。」 {#error-message-tidb-cluster-storage-is-not-enough-please-increase-the-node-storage-of-tikv}
+### エラーメッセージ：「TiDB cluster storage is not enough. Please increase the node storage of TiKV.」 {#error-message-tidb-cluster-storage-is-not-enough-please-increase-the-node-storage-of-tikv}
 
 TiDB クラスターのストレージが不足しています。 [TiKVノードのストレージを増やす](/tidb-cloud/scale-tidb-cluster.md#change-storage)から、 **Restart**をクリックしてタスクを再開することをお勧めします。
 
-### エラーメッセージ：「ソースデータベースへの接続に失敗しました。データベースが利用可能か、または最大接続数に達していないかを確認してください。」 {#error-message-failed-to-connect-to-the-source-database-please-check-whether-the-database-is-available-or-the-maximum-connections-have-been-reached}
+### エラーメッセージ：「Failed to connect to the source database. Please check whether the database is available or the maximum connections have been reached.」 {#error-message-failed-to-connect-to-the-source-database-please-check-whether-the-database-is-available-or-the-maximum-connections-have-been-reached}
 
 ソースデータベースへの接続に失敗しました。ソースデータベースが起動しているか、データベース接続数が上限に達していないか、ジョブで指定されたパラメータを使用して接続できるかを確認してください。ソースデータベースが利用可能であることを確認したら、 **Restart**をクリックしてジョブを再開してください。
 
-### エラーメッセージ：「エラー 1273: 新しい照合順序が有効になっている場合、サポートされていない照合順序です: 'utf8mb4_0900_ai_ci'」 {#error-message-error-1273-unsupported-collation-when-new-collation-is-enabled-utf8mb4-0900-ai-ci}
+### エラーメッセージ：「Error 1273: Unsupported collation when new collation is enabled: 'utf8mb4_0900_ai_ci'」 {#error-message-error-1273-unsupported-collation-when-new-collation-is-enabled-utf8mb4-0900-ai-ci}
 
 ダウンストリームのTiDBクラスタでスキーマを作成できませんでした。このエラーは、アップストリームのMySQLで使用されている照合順序がTiDBクラスタでサポートされていないことを意味します。
 
 この問題を解決するには、 [サポートされている照合順序](/character-set-and-collation.md#character-sets-and-collations-supported-by-tidb)に基づいて TiDB クラスターにスキーマを作成し、 **Restart**をクリックしてタスクを再開します。
 
-### エラーメッセージ：「LOCK TABLES ... アクセスが拒否されました」 {#error-message-lock-tables-access-denied}
+### エラーメッセージ：「LOCK TABLES ... Access denied」 {#error-message-lock-tables-access-denied}
 
 ソースデータベースユーザーに`LOCK TABLES`権限がないため、データの完全なエクスポートが失敗します。このエラーは通常、マネージド MySQL サービス (Amazon RDS、 Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL、Google Cloud SQL など) から移行する場合に発生します。これらのサービスでは、クラウドプロバイダーによって`FLUSH TABLES WITH READ LOCK` (FTWRL) が許可されていません。このシナリオでは、DM はデフォルトの`consistency=auto`モードを使用し、完全なエクスポート中にデータの一貫性を確保するために`LOCK TABLES`にフォールバックします。この操作には`LOCK TABLES`権限が必要です。
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -82,7 +82,7 @@ TiDB クラスターへの接続に失敗しました。TiDB クラスターが�
 
 ### エラーメッセージ："TiDB cluster storage is not enough. Please increase the node storage of TiKV." {#error-message-tidb-cluster-storage-is-not-enough-please-increase-the-node-storage-of-tikv}
 
-TiDB クラスターのストレージが不足しています。 [TiKVノードのストレージを増やす](/tidb-cloud/scale-tidb-cluster.md#change-storage)から、 **Restart**をクリックしてタスクを再開することをお勧めします。
+TiDB クラスターのストレージが不足しています。 [TiKVノードのストレージを増やして](/tidb-cloud/scale-tidb-cluster.md#change-storage)から、 **Restart**をクリックしてタスクを再開することをお勧めします。
 
 ### エラーメッセージ："Failed to connect to the source database. Please check whether the database is available or the maximum connections have been reached." {#error-message-failed-to-connect-to-the-source-database-please-check-whether-the-database-is-available-or-the-maximum-connections-have-been-reached}
 

--- a/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
+++ b/tidb-cloud/tidb-cloud-dm-precheck-and-troubleshooting.md
@@ -62,13 +62,13 @@ TiDB Cloudクラスターでエラーが発生した場合は、ドキュメン�
 
 このセクションでは、移行中に発生する可能性のある問題とその解決策について説明します。これらのエラーメッセージは、**Migration Job Details**ページに表示されます。
 
-### エラーメッセージ：「The required binary log for migration no longer exists on the source database. Please make sure binary log files are kept for long enough time for migration to succeed.」 {#error-message-the-required-binary-log-for-migration-no-longer-exists-on-the-source-database-please-make-sure-binary-log-files-are-kept-for-long-enough-time-for-migration-to-succeed}
+### エラーメッセージ："The required binary log for migration no longer exists on the source database. Please make sure binary log files are kept for long enough time for migration to succeed." {#error-message-the-required-binary-log-for-migration-no-longer-exists-on-the-source-database-please-make-sure-binary-log-files-are-kept-for-long-enough-time-for-migration-to-succeed}
 
 このエラーは、移行対象のバイナリログが既にクリーンアップされており、新しいタスクを作成することによってのみ復元できることを意味します。
 
 増分移行に必要なバイナリログが存在することを確認してください。バイナリログの保存期間を延長するために、 `expire_logs_days`を設定することをお勧めします。移行ジョブでバイナリログのクリーンアップが必要な場合は、 `purge binary log`を使用してバイナリログをクリーンアップしないでください。
 
-### エラーメッセージ：「Failed to connect to the source database using given parameters. Please make sure the source database is up and can be connected using the given parameters.」 {#error-message-failed-to-connect-to-the-source-database-using-given-parameters-please-make-sure-the-source-database-is-up-and-can-be-connected-using-the-given-parameters}
+### エラーメッセージ："Failed to connect to the source database using given parameters. Please make sure the source database is up and can be connected using the given parameters." {#error-message-failed-to-connect-to-the-source-database-using-given-parameters-please-make-sure-the-source-database-is-up-and-can-be-connected-using-the-given-parameters}
 
 このエラーは、ソースデータベースへの接続に失敗したことを意味します。ソースデータベースが起動しており、指定されたパラメータを使用して接続できるかどうかを確認してください。ソースデータベースが利用可能であることを確認したら、 **Restart**をクリックしてタスクの復旧を試みてください。
 
@@ -76,25 +76,25 @@ TiDB Cloudクラスターでエラーが発生した場合は、ドキュメン�
 
 このエラーは、ダウンストリームの TiDB クラスタへの接続に失敗したことを意味します。ダウンストリームの TiDB クラスタが正常な状態（ `Available`および`Modifying`を含む）であり、ジョブで指定されたユーザー名とパスワードで接続できるかどうかを確認してください。ダウンストリームの TiDB クラスタが利用可能であることを確認したら、 **Restart**をクリックしてタスクを再開してみてください。
 
-### エラーメッセージ：「Failed to connect to the TiDB cluster using the given user and password. Please make sure TiDB Cluster is up and can be connected to using the given user and password.」 {#error-message-failed-to-connect-to-the-tidb-cluster-using-the-given-user-and-password-please-make-sure-tidb-cluster-is-up-and-can-be-connected-to-using-the-given-user-and-password}
+### エラーメッセージ："Failed to connect to the TiDB cluster using the given user and password. Please make sure TiDB Cluster is up and can be connected to using the given user and password." {#error-message-failed-to-connect-to-the-tidb-cluster-using-the-given-user-and-password-please-make-sure-tidb-cluster-is-up-and-can-be-connected-to-using-the-given-user-and-password}
 
 TiDB クラスターへの接続に失敗しました。TiDB クラスターが正常な状態（ `Available`および`Modifying`を含む）であるかどうかを確認することをお勧めします。ジョブで指定されたユーザー名とパスワードを使用して接続できます。TiDB クラスターが利用可能であることを確認したら、 **Restart**をクリックしてタスクを再開してみてください。
 
-### エラーメッセージ：「TiDB cluster storage is not enough. Please increase the node storage of TiKV.」 {#error-message-tidb-cluster-storage-is-not-enough-please-increase-the-node-storage-of-tikv}
+### エラーメッセージ："TiDB cluster storage is not enough. Please increase the node storage of TiKV." {#error-message-tidb-cluster-storage-is-not-enough-please-increase-the-node-storage-of-tikv}
 
 TiDB クラスターのストレージが不足しています。 [TiKVノードのストレージを増やす](/tidb-cloud/scale-tidb-cluster.md#change-storage)から、 **Restart**をクリックしてタスクを再開することをお勧めします。
 
-### エラーメッセージ：「Failed to connect to the source database. Please check whether the database is available or the maximum connections have been reached.」 {#error-message-failed-to-connect-to-the-source-database-please-check-whether-the-database-is-available-or-the-maximum-connections-have-been-reached}
+### エラーメッセージ："Failed to connect to the source database. Please check whether the database is available or the maximum connections have been reached." {#error-message-failed-to-connect-to-the-source-database-please-check-whether-the-database-is-available-or-the-maximum-connections-have-been-reached}
 
 ソースデータベースへの接続に失敗しました。ソースデータベースが起動しているか、データベース接続数が上限に達していないか、ジョブで指定されたパラメータを使用して接続できるかを確認してください。ソースデータベースが利用可能であることを確認したら、 **Restart**をクリックしてジョブを再開してください。
 
-### エラーメッセージ：「Error 1273: Unsupported collation when new collation is enabled: 'utf8mb4_0900_ai_ci'」 {#error-message-error-1273-unsupported-collation-when-new-collation-is-enabled-utf8mb4-0900-ai-ci}
+### エラーメッセージ："Error 1273: Unsupported collation when new collation is enabled: 'utf8mb4_0900_ai_ci'" {#error-message-error-1273-unsupported-collation-when-new-collation-is-enabled-utf8mb4-0900-ai-ci}
 
 ダウンストリームのTiDBクラスタでスキーマを作成できませんでした。このエラーは、アップストリームのMySQLで使用されている照合順序がTiDBクラスタでサポートされていないことを意味します。
 
 この問題を解決するには、 [サポートされている照合順序](/character-set-and-collation.md#character-sets-and-collations-supported-by-tidb)に基づいて TiDB クラスターにスキーマを作成し、 **Restart**をクリックしてタスクを再開します。
 
-### エラーメッセージ：「LOCK TABLES ... Access denied」 {#error-message-lock-tables-access-denied}
+### エラーメッセージ："LOCK TABLES ... Access denied" {#error-message-lock-tables-access-denied}
 
 ソースデータベースユーザーに`LOCK TABLES`権限がないため、データの完全なエクスポートが失敗します。このエラーは通常、マネージド MySQL サービス (Amazon RDS、 Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL、Google Cloud SQL など) から移行する場合に発生します。これらのサービスでは、クラウドプロバイダーによって`FLUSH TABLES WITH READ LOCK` (FTWRL) が許可されていません。このシナリオでは、DM はデフォルトの`consistency=auto`モードを使用し、完全なエクスポート中にデータの一貫性を確保するために`LOCK TABLES`にフォールバックします。この操作には`LOCK TABLES`権限が必要です。
 


### PR DESCRIPTION
### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

### What is changed, added or deleted? (Required)

Seven heading-level error messages in this troubleshooting doc are quoted-string literals in the EN source (actual DM/TiDB Cloud error text a user would see verbatim on screen), but were translated into Japanese prose instead of kept as literal English. This defeats the doc's purpose as a troubleshooting reference organized by "find the exact message you saw" — a reader can't match a Japanese paraphrase against the English text actually shown by the product.

The file's other, non-quoted "Error message: ..." headings are plain descriptive section labels (not literal on-screen text) and were correctly left translated — only the 7 quoted ones needed restoring.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] i18n-ja-release-8.5 (TiDB Japanese documentation for TiDB 8.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated seven migration error section headings to display the original English error messages.
  - Preserved existing section links and explanatory content.
  - Refined wording in the TiDB cluster storage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->