### PR TITLE
docs: fix 'allows to collect' grammar in Continuous Profiling

### DIFF
--- a/dashboard/continuous-profiling.md
+++ b/dashboard/continuous-profiling.md
@@ -19,7 +19,7 @@ Continuous Profiling is an enhanced feature of [Manual Profiling](/dashboard/das
 
 - Manual Profiling only collects performance data for a short period of time (for example, 30 seconds) at the moment you initiate the profiling, while Continuous Profiling collects data continuously when it is enabled.
 - Manual Profiling can only be used to analyze current occurring problems, while Continuous Profiling can be used to analyze both the current and historical problems.
-- Manual Profiling allows to collect specific performance data for specific instances, while Continuous Profiling collects all performance data for all instances.
+- Manual Profiling allows you to collect specific performance data for specific instances, while Continuous Profiling collects all performance data for all instances.
 - Continuous Profiling stores more performance data, therefore it takes up more disk space.
 
 ## Supported performance data


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Fix non-idiomatic grammar in the Continuous Profiling comparison list: "allows to collect" → "allows you to collect".

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- Related code change PR links (if applicable): N/A
- This PR is translated from: N/A
- Other reference link(s): N/A

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the grammar and clarity of the “Compare with Manual Profiling” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->